### PR TITLE
Thread notifications with mark all read option

### DIFF
--- a/src/main/db/notifications.ts
+++ b/src/main/db/notifications.ts
@@ -288,6 +288,17 @@ export function markThreadRead(threadId: string): void {
     .run(threadId)
 }
 
+/** Marks multiple threads as read in one transaction. */
+export function markThreadsReadMany(threadIds: string[]): void {
+  if (threadIds.length === 0) return
+  
+  const db = getDb()
+  const placeholders = threadIds.map(() => '?').join(',')
+  db.prepare(
+    `UPDATE notification_threads SET unread = 0, last_read_at = datetime('now') WHERE id IN (${placeholders})`
+  ).run(...threadIds)
+}
+
 /** Removes a thread from local storage (called after unsubscribe). */
 export function deleteThread(threadId: string): void {
   getDb()

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -14,6 +14,7 @@ import {
   getUnreadCounts,
   assignThread,
   markThreadRead,
+  markThreadsReadMany,
   deleteThread,
   listRepoRules,
   createRepoRule,
@@ -118,6 +119,13 @@ app.whenReady().then(async () => {
   ipcMain.handle('notifications:mark-read', (_event, threadId: string) => {
     markThreadRead(threadId)
     // Emit update event so unread badges refresh immediately
+    BrowserWindow.getAllWindows().forEach((win) => {
+      win.webContents.send('notifications:updated')
+    })
+  })
+  ipcMain.handle('notifications:mark-read-many', (_event, threadIds: string[]) => {
+    markThreadsReadMany(threadIds)
+    // Emit a single update event after bulk operation
     BrowserWindow.getAllWindows().forEach((win) => {
       win.webContents.send('notifications:updated')
     })

--- a/src/renderer/src/components/ThreadedNotificationList.module.css
+++ b/src/renderer/src/components/ThreadedNotificationList.module.css
@@ -1,0 +1,274 @@
+/* ── Root ── */
+.root {
+  display: flex;
+  flex-direction: column;
+}
+
+/* ── Empty state ── */
+.empty {
+  padding: 40px 0;
+  text-align: center;
+  font-size: 13px;
+  color: var(--text-3);
+}
+
+/* ── Repo group ── */
+.repoGroup {
+  margin-bottom: 4px;
+}
+
+.repoGroup:last-child {
+  margin-bottom: 0;
+}
+
+.repoHeader {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 14px 0 6px;
+}
+
+.repoLabel {
+  flex-shrink: 0;
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--text-2);
+  letter-spacing: 0.01em;
+}
+
+.repoDivider {
+  flex: 1;
+  height: 1px;
+  background: var(--border);
+}
+
+/* ── Type group ── */
+.typeGroup {
+  padding-left: 12px;
+  margin-bottom: 2px;
+}
+
+.typeGroup:last-child {
+  margin-bottom: 0;
+}
+
+.typeHeader {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 0 3px;
+}
+
+.typeLabel {
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--text-3);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.typeCount {
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--text-3);
+  background: var(--bg-2);
+  border-radius: 10px;
+  padding: 0 5px;
+  min-width: 16px;
+  text-align: center;
+  line-height: 16px;
+}
+
+/* ── Thread row ── */
+.threadRow {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 7px 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.threadRow:last-child {
+  border-bottom: none;
+}
+
+.threadDot {
+  flex-shrink: 0;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--border-2);
+}
+
+.threadDot[data-unread='true'] {
+  background: var(--orange);
+}
+
+.threadBody {
+  flex: 1;
+  min-width: 0;
+}
+
+.threadTitle {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.threadName {
+  font-size: 13px;
+  font-weight: 400;
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.threadName[data-unread='true'] {
+  font-weight: 500;
+}
+
+.threadNameLink {
+  background: none;
+  border: none;
+  padding: 0;
+  font-family: var(--font);
+  cursor: pointer;
+  text-align: left;
+}
+
+.threadNameLink:hover {
+  text-decoration: underline;
+}
+
+/* ── State chips ── */
+.stateChip {
+  flex-shrink: 0;
+  font-size: 10px;
+  font-weight: 600;
+  border-radius: 4px;
+  padding: 1px 5px;
+  text-transform: lowercase;
+}
+
+.stateMerged {
+  background: rgba(130, 80, 255, 0.1);
+  color: var(--purple, #a78bfa);
+}
+
+.stateClosed {
+  background: rgba(220, 60, 60, 0.1);
+  color: var(--red, #f87171);
+}
+
+/* ── Type chips (used externally if needed) ── */
+.typeChip {
+  flex-shrink: 0;
+  font-size: 11px;
+  font-weight: 600;
+  border-radius: 4px;
+  padding: 1px 6px;
+}
+
+.typePR {
+  background: rgba(82, 130, 255, 0.1);
+  color: var(--blue-mid);
+}
+
+.typeIssue {
+  background: rgba(212, 82, 29, 0.1);
+  color: var(--orange);
+}
+
+.typeRelease {
+  background: rgba(50, 180, 100, 0.1);
+  color: var(--green);
+}
+
+.typeOther {
+  background: var(--bg-2);
+  color: var(--text-3);
+}
+
+/* ── Thread actions ── */
+.threadActions {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+/* Icon group — fades in on row hover */
+.threadIconGroup {
+  display: flex;
+  align-items: center;
+  gap: 1px;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition: opacity 100ms, visibility 0ms linear 100ms;
+}
+
+.threadRow:hover .threadIconGroup,
+.threadRow:focus-within .threadIconGroup {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transition: opacity 100ms, visibility 0ms linear 0ms;
+}
+
+.iconBtn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  border: none;
+  border-radius: 5px;
+  background: transparent;
+  color: var(--text-3);
+  cursor: pointer;
+  transition: background 80ms, color 80ms;
+  flex-shrink: 0;
+}
+
+.iconBtn:hover {
+  background: var(--bg-2);
+  color: var(--text);
+}
+
+.iconBtn:disabled {
+  opacity: 0.3;
+  cursor: default;
+  pointer-events: none;
+}
+
+/* ── Assign controls ── */
+.assignBtn {
+  padding: 3px 10px;
+  border-radius: 5px;
+  border: 1px solid var(--border-2);
+  background: transparent;
+  color: var(--blue);
+  font-family: var(--font);
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 80ms;
+}
+
+.assignBtn:hover {
+  background: rgba(82, 130, 255, 0.06);
+}
+
+.projectSelect {
+  font-family: var(--font);
+  font-size: 13px;
+  border: 1px solid var(--border-2);
+  border-radius: 5px;
+  padding: 3px 6px;
+  background: var(--bg);
+  color: var(--text);
+  cursor: pointer;
+}

--- a/src/renderer/src/components/ThreadedNotificationList.module.css
+++ b/src/renderer/src/components/ThreadedNotificationList.module.css
@@ -96,7 +96,7 @@
   display: flex;
   align-items: center;
   gap: 10px;
-  padding: 7px 0;
+  padding: 7px 0 7px 24px;
   border-bottom: 1px solid var(--border);
 }
 

--- a/src/renderer/src/components/ThreadedNotificationList.module.css
+++ b/src/renderer/src/components/ThreadedNotificationList.module.css
@@ -24,8 +24,14 @@
 .repoHeader {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 8px;
   padding: 14px 0 6px;
+}
+
+.repoHeader:hover .markAllBtn,
+.repoHeader:focus-within .markAllBtn {
+  opacity: 1;
+  pointer-events: auto;
 }
 
 .repoLabel {
@@ -59,8 +65,14 @@
   padding: 5px 0 3px;
 }
 
+.typeHeader:hover .markAllBtn,
+.typeHeader:focus-within .markAllBtn {
+  opacity: 1;
+  pointer-events: auto;
+}
+
 .typeLabel {
-  font-size: 11px;
+  font-size: 14px;
   font-weight: 500;
   color: var(--text-3);
   text-transform: uppercase;
@@ -140,6 +152,59 @@
 
 .threadNameLink:hover {
   text-decoration: underline;
+}
+
+/* ── Collapse button ── */
+.collapseBtn {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--text-3);
+  cursor: pointer;
+  padding: 0;
+  transition: background 80ms, color 80ms;
+}
+
+.collapseBtn:hover {
+  background: var(--bg-2);
+  color: var(--text-2);
+}
+
+.chevronExpanded {
+  transition: transform 150ms ease;
+  transform: rotate(0deg);
+}
+
+.chevronCollapsed {
+  transition: transform 150ms ease;
+  transform: rotate(-90deg);
+}
+
+/* ── Mark all read button ── */
+.markAllBtn {
+  flex-shrink: 0;
+  border: none;
+  background: transparent;
+  color: var(--blue);
+  font-family: var(--font);
+  font-size: 11px;
+  font-weight: 500;
+  cursor: pointer;
+  padding: 2px 6px;
+  border-radius: 4px;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 100ms, background 80ms;
+}
+
+.markAllBtn:hover {
+  background: rgba(82, 130, 255, 0.08);
 }
 
 /* ── State chips ── */

--- a/src/renderer/src/components/ThreadedNotificationList.test.tsx
+++ b/src/renderer/src/components/ThreadedNotificationList.test.tsx
@@ -1,0 +1,329 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { ThreadedNotificationList } from './ThreadedNotificationList'
+import type { NotificationThread } from '@shared/ipc-channels'
+
+beforeEach(() => {
+  ;(window as unknown as Record<string, unknown>).electron = {
+    ipc: { invoke: vi.fn() },
+    openExternal: vi.fn(),
+    onNotificationsUpdated: vi.fn(() => vi.fn()),
+  }
+})
+
+const mockThreads: NotificationThread[] = [
+  {
+    id: '1',
+    projectId: null,
+    repoOwner: 'owner',
+    repoName: 'repo-one',
+    title: 'PR #1',
+    type: 'PullRequest',
+    reason: 'author',
+    unread: true,
+    updatedAt: '2024-01-01T00:00:00Z',
+    lastReadAt: null,
+    apiUrl: 'https://api.github.com/notifications/threads/1',
+    subjectUrl: 'https://api.github.com/repos/owner/repo-one/pulls/1',
+    subjectState: 'open',
+    htmlUrl: 'https://github.com/owner/repo-one/pull/1',
+  },
+  {
+    id: '2',
+    projectId: null,
+    repoOwner: 'owner',
+    repoName: 'repo-one',
+    title: 'Issue #2',
+    type: 'Issue',
+    reason: 'mention',
+    unread: false,
+    updatedAt: '2024-01-02T00:00:00Z',
+    lastReadAt: '2024-01-02T01:00:00Z',
+    apiUrl: 'https://api.github.com/notifications/threads/2',
+    subjectUrl: 'https://api.github.com/repos/owner/repo-one/issues/2',
+    subjectState: 'open',
+    htmlUrl: 'https://github.com/owner/repo-one/issues/2',
+  },
+  {
+    id: '3',
+    projectId: null,
+    repoOwner: 'other',
+    repoName: 'repo-two',
+    title: 'PR #3',
+    type: 'PullRequest',
+    reason: 'review_requested',
+    unread: true,
+    updatedAt: '2024-01-03T00:00:00Z',
+    lastReadAt: null,
+    apiUrl: 'https://api.github.com/notifications/threads/3',
+    subjectUrl: 'https://api.github.com/repos/other/repo-two/pulls/3',
+    subjectState: 'open',
+    htmlUrl: 'https://github.com/other/repo-two/pull/3',
+  },
+]
+
+describe('ThreadedNotificationList', () => {
+  const onMarkRead = vi.fn()
+  const onMarkReadMany = vi.fn()
+  const onUnsubscribe = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('grouping', () => {
+    it('groups threads by repo and type', () => {
+      render(
+        <ThreadedNotificationList
+          threads={mockThreads}
+          onMarkRead={onMarkRead}
+          onUnsubscribe={onUnsubscribe}
+        />
+      )
+
+      // Should show two repo groups
+      expect(screen.getByText('owner/repo-one')).toBeInTheDocument()
+      expect(screen.getByText('other/repo-two')).toBeInTheDocument()
+
+      // Should show type labels within each repo (note: multiple repos may have same type)
+      expect(screen.getAllByText('Pull Requests').length).toBeGreaterThanOrEqual(1)
+      expect(screen.getByText('Issues')).toBeInTheDocument()
+    })
+
+    it('shows counts per type group', () => {
+      render(
+        <ThreadedNotificationList
+          threads={mockThreads}
+          onMarkRead={onMarkRead}
+          onUnsubscribe={onUnsubscribe}
+        />
+      )
+
+      // owner/repo-one has 1 PR and 1 Issue
+      const counts = screen.getAllByText('1')
+      expect(counts.length).toBeGreaterThanOrEqual(2)
+    })
+  })
+
+  describe('collapse/expand', () => {
+    it('collapses and expands repo groups', async () => {
+      render(
+        <ThreadedNotificationList
+          threads={mockThreads}
+          onMarkRead={onMarkRead}
+          onUnsubscribe={onUnsubscribe}
+        />
+      )
+
+      // Initially, threads should be visible
+      expect(screen.getByText('PR #1')).toBeInTheDocument()
+
+      // Find the collapse button for owner/repo-one
+      const collapseBtn = screen.getByLabelText('Collapse owner/repo-one')
+      fireEvent.click(collapseBtn)
+
+      // Threads should be hidden
+      await waitFor(() => {
+        expect(screen.queryByText('PR #1')).not.toBeInTheDocument()
+      })
+
+      // Button label should change
+      expect(screen.getByLabelText('Expand owner/repo-one')).toBeInTheDocument()
+
+      // Expand again
+      fireEvent.click(screen.getByLabelText('Expand owner/repo-one'))
+      await waitFor(() => {
+        expect(screen.getByText('PR #1')).toBeInTheDocument()
+      })
+    })
+
+    it('collapses and expands type groups', async () => {
+      render(
+        <ThreadedNotificationList
+          threads={mockThreads}
+          onMarkRead={onMarkRead}
+          onUnsubscribe={onUnsubscribe}
+        />
+      )
+
+      // Initially, threads should be visible
+      expect(screen.getByText('PR #1')).toBeInTheDocument()
+
+      // Find the collapse button for Pull Requests in owner/repo-one
+      const collapseBtn = screen.getByLabelText('Collapse owner/repo-one Pull Requests')
+      fireEvent.click(collapseBtn)
+
+      // PR #1 should be hidden, but Issue #2 should still be visible
+      await waitFor(() => {
+        expect(screen.queryByText('PR #1')).not.toBeInTheDocument()
+      })
+      expect(screen.getByText('Issue #2')).toBeInTheDocument()
+
+      // Expand again
+      fireEvent.click(screen.getByLabelText('Expand owner/repo-one Pull Requests'))
+      await waitFor(() => {
+        expect(screen.getByText('PR #1')).toBeInTheDocument()
+      })
+    })
+
+    it('sets aria-expanded correctly on repo collapse buttons', () => {
+      render(
+        <ThreadedNotificationList
+          threads={mockThreads}
+          onMarkRead={onMarkRead}
+          onUnsubscribe={onUnsubscribe}
+        />
+      )
+
+      const collapseBtn = screen.getByLabelText('Collapse owner/repo-one')
+      expect(collapseBtn).toHaveAttribute('aria-expanded', 'true')
+
+      fireEvent.click(collapseBtn)
+      expect(screen.getByLabelText('Expand owner/repo-one')).toHaveAttribute('aria-expanded', 'false')
+    })
+
+    it('sets aria-expanded correctly on type collapse buttons', () => {
+      render(
+        <ThreadedNotificationList
+          threads={mockThreads}
+          onMarkRead={onMarkRead}
+          onUnsubscribe={onUnsubscribe}
+        />
+      )
+
+      const collapseBtn = screen.getByLabelText('Collapse owner/repo-one Pull Requests')
+      expect(collapseBtn).toHaveAttribute('aria-expanded', 'true')
+
+      fireEvent.click(collapseBtn)
+      expect(screen.getByLabelText('Expand owner/repo-one Pull Requests')).toHaveAttribute('aria-expanded', 'false')
+    })
+  })
+
+  describe('mark all read', () => {
+    it('uses bulk API when onMarkReadMany is provided', async () => {
+      render(
+        <ThreadedNotificationList
+          threads={mockThreads}
+          onMarkRead={onMarkRead}
+          onMarkReadMany={onMarkReadMany}
+          onUnsubscribe={onUnsubscribe}
+        />
+      )
+
+      // Click "Mark all read" for owner/repo-one
+      const markAllBtns = screen.getAllByText('Mark all read')
+      const repoMarkAll = markAllBtns[0] // First button is for the repo group
+      fireEvent.click(repoMarkAll)
+
+      await waitFor(() => {
+        expect(onMarkReadMany).toHaveBeenCalledWith(['1']) // Only unread thread in owner/repo-one
+      })
+      expect(onMarkRead).not.toHaveBeenCalled()
+    })
+
+    it('falls back to individual calls when onMarkReadMany is not provided', async () => {
+      render(
+        <ThreadedNotificationList
+          threads={mockThreads}
+          onMarkRead={onMarkRead}
+          onUnsubscribe={onUnsubscribe}
+        />
+      )
+
+      const markAllBtns = screen.getAllByText('Mark all read')
+      const repoMarkAll = markAllBtns[0]
+      fireEvent.click(repoMarkAll)
+
+      await waitFor(() => {
+        expect(onMarkRead).toHaveBeenCalledWith('1')
+      })
+      expect(onMarkReadMany).not.toHaveBeenCalled()
+    })
+
+    it('only calls onMarkRead for unread threads', async () => {
+      render(
+        <ThreadedNotificationList
+          threads={mockThreads}
+          onMarkRead={onMarkRead}
+          onMarkReadMany={onMarkReadMany}
+          onUnsubscribe={onUnsubscribe}
+        />
+      )
+
+      // Click "Mark all read" for owner/repo-one (has 1 unread, 1 already read)
+      const markAllBtns = screen.getAllByText('Mark all read')
+      fireEvent.click(markAllBtns[0])
+
+      await waitFor(() => {
+        expect(onMarkReadMany).toHaveBeenCalledWith(['1']) // Only thread '1' is unread
+      })
+    })
+
+    it('disables button while mark all is in flight', async () => {
+      onMarkReadMany.mockImplementation(() => new Promise(resolve => setTimeout(resolve, 100)))
+
+      render(
+        <ThreadedNotificationList
+          threads={mockThreads}
+          onMarkRead={onMarkRead}
+          onMarkReadMany={onMarkReadMany}
+          onUnsubscribe={onUnsubscribe}
+        />
+      )
+
+      const markAllBtns = screen.getAllByText('Mark all read')
+      const repoMarkAll = markAllBtns[0]
+      fireEvent.click(repoMarkAll)
+
+      // Button should be disabled immediately
+      expect(repoMarkAll).toBeDisabled()
+
+      // Wait for completion
+      await waitFor(() => {
+        expect(repoMarkAll).not.toBeDisabled()
+      }, { timeout: 200 })
+    })
+
+    it('does not show "Mark all read" button when all threads are read', () => {
+      const allReadThreads = mockThreads.map(t => ({ ...t, unread: false }))
+      render(
+        <ThreadedNotificationList
+          threads={allReadThreads}
+          onMarkRead={onMarkRead}
+          onUnsubscribe={onUnsubscribe}
+        />
+      )
+
+      expect(screen.queryByText('Mark all read')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('empty state', () => {
+    it('shows empty message when no threads', () => {
+      render(
+        <ThreadedNotificationList
+          threads={[]}
+          onMarkRead={onMarkRead}
+          onUnsubscribe={onUnsubscribe}
+          emptyMessage="Nothing here"
+        />
+      )
+
+      expect(screen.getByText('Nothing here')).toBeInTheDocument()
+    })
+
+    it('uses default empty message', () => {
+      render(
+        <ThreadedNotificationList
+          threads={[]}
+          onMarkRead={onMarkRead}
+          onUnsubscribe={onUnsubscribe}
+        />
+      )
+
+      expect(screen.getByText('No notifications.')).toBeInTheDocument()
+    })
+  })
+})

--- a/src/renderer/src/components/ThreadedNotificationList.tsx
+++ b/src/renderer/src/components/ThreadedNotificationList.tsx
@@ -9,6 +9,7 @@ export interface ThreadedNotificationListProps {
   /** Provide projects to show the Assign button per thread. Omit for project-scoped views. */
   projects?: Project[]
   onMarkRead: (threadId: string) => Promise<void>
+  onMarkReadMany?: (threadIds: string[]) => Promise<void>
   onUnsubscribe: (threadId: string) => Promise<void>
   /** Called when a thread is assigned to a project. Requires `projects` to be set. */
   onAssign?: (threadId: string, projectId: number) => Promise<void>
@@ -51,6 +52,7 @@ export function ThreadedNotificationList({
   threads,
   projects,
   onMarkRead,
+  onMarkReadMany,
   onUnsubscribe,
   onAssign,
   emptyMessage = 'No notifications.',
@@ -58,6 +60,8 @@ export function ThreadedNotificationList({
   const [assigningId, setAssigningId] = useState<string | null>(null)
   const [collapsedRepos, setCollapsedRepos] = useState<Set<string>>(new Set())
   const [collapsedTypes, setCollapsedTypes] = useState<Set<string>>(new Set())
+  const [markingAllRepoKey, setMarkingAllRepoKey] = useState<string | null>(null)
+  const [markingAllTypeKey, setMarkingAllTypeKey] = useState<string | null>(null)
 
   if (threads.length === 0) {
     return <div className={styles.empty}>{emptyMessage}</div>
@@ -68,7 +72,11 @@ export function ThreadedNotificationList({
   const toggleRepo = (repoKey: string) => {
     setCollapsedRepos((prev) => {
       const next = new Set(prev)
-      next.has(repoKey) ? next.delete(repoKey) : next.add(repoKey)
+      if (next.has(repoKey)) {
+        next.delete(repoKey)
+      } else {
+        next.add(repoKey)
+      }
       return next
     })
   }
@@ -76,15 +84,25 @@ export function ThreadedNotificationList({
   const toggleType = (typeKey: string) => {
     setCollapsedTypes((prev) => {
       const next = new Set(prev)
-      next.has(typeKey) ? next.delete(typeKey) : next.add(typeKey)
+      if (next.has(typeKey)) {
+        next.delete(typeKey)
+      } else {
+        next.add(typeKey)
+      }
       return next
     })
   }
 
   const markAllRead = async (threadList: NotificationThread[]) => {
-    await Promise.allSettled(
-      threadList.filter((t) => t.unread).map((t) => onMarkRead(t.id))
-    )
+    const unreadThreads = threadList.filter((t) => t.unread)
+    if (unreadThreads.length === 0) return
+
+    // Use bulk API if available, otherwise fall back to individual calls
+    if (onMarkReadMany) {
+      await onMarkReadMany(unreadThreads.map((t) => t.id))
+    } else {
+      await Promise.allSettled(unreadThreads.map((t) => onMarkRead(t.id)))
+    }
   }
 
   return (
@@ -94,13 +112,17 @@ export function ThreadedNotificationList({
         const repoCollapsed = collapsedRepos.has(repoKey)
         const repoHasUnread = repoThreads.some((t) => t.unread)
 
+        const repoSectionId = `repo-section-${repoKey.replace(/[^a-zA-Z0-9_-]/g, '-')}`
+
         return (
-        <div key={repoKey} className={styles.repoGroup}>
+        <div key={repoKey} id={repoSectionId} className={styles.repoGroup}>
           <div className={styles.repoHeader}>
             <button
               className={styles.collapseBtn}
               onClick={() => toggleRepo(repoKey)}
-              aria-label={repoCollapsed ? 'Expand' : 'Collapse'}
+              aria-label={`${repoCollapsed ? 'Expand' : 'Collapse'} ${repoKey}`}
+              aria-expanded={!repoCollapsed}
+              aria-controls={repoSectionId}
             >
               <ChevronIcon collapsed={repoCollapsed} />
             </button>
@@ -109,7 +131,12 @@ export function ThreadedNotificationList({
             {repoHasUnread && (
               <button
                 className={styles.markAllBtn}
-                onClick={() => void markAllRead(repoThreads)}
+                onClick={async () => {
+                  setMarkingAllRepoKey(repoKey)
+                  await markAllRead(repoThreads)
+                  setMarkingAllRepoKey(null)
+                }}
+                disabled={markingAllRepoKey === repoKey}
                 title="Mark all as read"
               >
                 Mark all read
@@ -121,14 +148,17 @@ export function ThreadedNotificationList({
             const typeKey = `${repoKey}:${type}`
             const typeCollapsed = collapsedTypes.has(typeKey)
             const typeHasUnread = typeThreads.some((t) => t.unread)
+            const typeRegionId = `type-group-${repoKey}-${type}`.replace(/[^a-zA-Z0-9_-]/g, '-')
 
             return (
-            <div key={type} className={styles.typeGroup}>
+            <div key={type} id={typeRegionId} className={styles.typeGroup}>
               <div className={styles.typeHeader}>
                 <button
                   className={styles.collapseBtn}
                   onClick={() => toggleType(typeKey)}
-                  aria-label={typeCollapsed ? 'Expand' : 'Collapse'}
+                  aria-label={`${typeCollapsed ? 'Expand' : 'Collapse'} ${repoKey} ${typeLabel(type)}`}
+                  aria-expanded={!typeCollapsed}
+                  aria-controls={typeRegionId}
                 >
                   <ChevronIcon collapsed={typeCollapsed} />
                 </button>
@@ -137,7 +167,12 @@ export function ThreadedNotificationList({
                 {typeHasUnread && (
                   <button
                     className={styles.markAllBtn}
-                    onClick={() => void markAllRead(typeThreads)}
+                    onClick={async () => {
+                      setMarkingAllTypeKey(typeKey)
+                      await markAllRead(typeThreads)
+                      setMarkingAllTypeKey(null)
+                    }}
+                    disabled={markingAllTypeKey === typeKey}
                     title="Mark all as read"
                   >
                     Mark all read

--- a/src/renderer/src/components/ThreadedNotificationList.tsx
+++ b/src/renderer/src/components/ThreadedNotificationList.tsx
@@ -56,6 +56,8 @@ export function ThreadedNotificationList({
   emptyMessage = 'No notifications.',
 }: ThreadedNotificationListProps) {
   const [assigningId, setAssigningId] = useState<string | null>(null)
+  const [collapsedRepos, setCollapsedRepos] = useState<Set<string>>(new Set())
+  const [collapsedTypes, setCollapsedTypes] = useState<Set<string>>(new Set())
 
   if (threads.length === 0) {
     return <div className={styles.empty}>{emptyMessage}</div>
@@ -63,23 +65,87 @@ export function ThreadedNotificationList({
 
   const groups = groupThreads(threads)
 
+  const toggleRepo = (repoKey: string) => {
+    setCollapsedRepos((prev) => {
+      const next = new Set(prev)
+      next.has(repoKey) ? next.delete(repoKey) : next.add(repoKey)
+      return next
+    })
+  }
+
+  const toggleType = (typeKey: string) => {
+    setCollapsedTypes((prev) => {
+      const next = new Set(prev)
+      next.has(typeKey) ? next.delete(typeKey) : next.add(typeKey)
+      return next
+    })
+  }
+
+  const markAllRead = async (threadList: NotificationThread[]) => {
+    await Promise.allSettled(
+      threadList.filter((t) => t.unread).map((t) => onMarkRead(t.id))
+    )
+  }
+
   return (
     <div className={styles.root}>
-      {Array.from(groups.entries()).map(([repoKey, typeGroups]) => (
+      {Array.from(groups.entries()).map(([repoKey, typeGroups]) => {
+        const repoThreads = Array.from(typeGroups.values()).flat()
+        const repoCollapsed = collapsedRepos.has(repoKey)
+        const repoHasUnread = repoThreads.some((t) => t.unread)
+
+        return (
         <div key={repoKey} className={styles.repoGroup}>
           <div className={styles.repoHeader}>
+            <button
+              className={styles.collapseBtn}
+              onClick={() => toggleRepo(repoKey)}
+              aria-label={repoCollapsed ? 'Expand' : 'Collapse'}
+            >
+              <ChevronIcon collapsed={repoCollapsed} />
+            </button>
             <span className={styles.repoLabel}>{repoKey}</span>
             <div className={styles.repoDivider} />
+            {repoHasUnread && (
+              <button
+                className={styles.markAllBtn}
+                onClick={() => void markAllRead(repoThreads)}
+                title="Mark all as read"
+              >
+                Mark all read
+              </button>
+            )}
           </div>
 
-          {Array.from(typeGroups.entries()).map(([type, typeThreads]) => (
+          {!repoCollapsed && Array.from(typeGroups.entries()).map(([type, typeThreads]) => {
+            const typeKey = `${repoKey}:${type}`
+            const typeCollapsed = collapsedTypes.has(typeKey)
+            const typeHasUnread = typeThreads.some((t) => t.unread)
+
+            return (
             <div key={type} className={styles.typeGroup}>
               <div className={styles.typeHeader}>
+                <button
+                  className={styles.collapseBtn}
+                  onClick={() => toggleType(typeKey)}
+                  aria-label={typeCollapsed ? 'Expand' : 'Collapse'}
+                >
+                  <ChevronIcon collapsed={typeCollapsed} />
+                </button>
                 <span className={styles.typeLabel}>{typeLabel(type)}</span>
                 <span className={styles.typeCount}>{typeThreads.length}</span>
+                {typeHasUnread && (
+                  <button
+                    className={styles.markAllBtn}
+                    onClick={() => void markAllRead(typeThreads)}
+                    title="Mark all as read"
+                  >
+                    Mark all read
+                  </button>
+                )}
               </div>
 
-              {typeThreads.map((thread) => (
+              {!typeCollapsed && typeThreads.map((thread) => (
                 <div key={thread.id} className={styles.threadRow}>
                   <div className={styles.threadDot} data-unread={thread.unread} />
 
@@ -167,9 +233,11 @@ export function ThreadedNotificationList({
                 </div>
               ))}
             </div>
-          ))}
+            )
+          })}
         </div>
-      ))}
+        )
+      })}
     </div>
   )
 }
@@ -181,6 +249,21 @@ function StateChip({ state }: { state: SubjectState }) {
   if (state === 'merged') classes.push(styles.stateMerged)
   else if (state === 'closed') classes.push(styles.stateClosed)
   return <span className={classes.join(' ')}>{state}</span>
+}
+
+function ChevronIcon({ collapsed }: { collapsed: boolean }) {
+  return (
+    <svg
+      width="10"
+      height="10"
+      viewBox="0 0 10 10"
+      fill="none"
+      aria-hidden="true"
+      className={collapsed ? styles.chevronCollapsed : styles.chevronExpanded}
+    >
+      <path d="M2.5 3.5 5 6l2.5-2.5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  )
 }
 
 function ExternalLinkIcon() {

--- a/src/renderer/src/components/ThreadedNotificationList.tsx
+++ b/src/renderer/src/components/ThreadedNotificationList.tsx
@@ -1,0 +1,226 @@
+import { useState } from 'react'
+import type { NotificationThread, NotificationType, Project, SubjectState } from '@shared/ipc-channels'
+import styles from './ThreadedNotificationList.module.css'
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export interface ThreadedNotificationListProps {
+  threads: NotificationThread[]
+  /** Provide projects to show the Assign button per thread. Omit for project-scoped views. */
+  projects?: Project[]
+  onMarkRead: (threadId: string) => Promise<void>
+  onUnsubscribe: (threadId: string) => Promise<void>
+  /** Called when a thread is assigned to a project. Requires `projects` to be set. */
+  onAssign?: (threadId: string, projectId: number) => Promise<void>
+  emptyMessage?: string
+}
+
+// ── Grouping helpers ─────────────────────────────────────────────────────────
+
+type TypeGroup = Map<string, NotificationThread[]>
+type RepoGroups = Map<string, TypeGroup>
+
+function groupThreads(threads: NotificationThread[]): RepoGroups {
+  const byRepo: RepoGroups = new Map()
+  for (const t of threads) {
+    const repoKey = `${t.repoOwner}/${t.repoName}`
+    if (!byRepo.has(repoKey)) byRepo.set(repoKey, new Map())
+    const byType = byRepo.get(repoKey)!
+    const existing = byType.get(t.type) ?? []
+    existing.push(t)
+    byType.set(t.type, existing)
+  }
+  return byRepo
+}
+
+function typeLabel(type: string): string {
+  switch (type) {
+    case 'PullRequest': return 'Pull Requests'
+    case 'Issue': return 'Issues'
+    case 'Release': return 'Releases'
+    case 'Discussion': return 'Discussions'
+    case 'CheckSuite': return 'CI'
+    case 'Commit': return 'Commits'
+    default: return type
+  }
+}
+
+// ── Component ────────────────────────────────────────────────────────────────
+
+export function ThreadedNotificationList({
+  threads,
+  projects,
+  onMarkRead,
+  onUnsubscribe,
+  onAssign,
+  emptyMessage = 'No notifications.',
+}: ThreadedNotificationListProps) {
+  const [assigningId, setAssigningId] = useState<string | null>(null)
+
+  if (threads.length === 0) {
+    return <div className={styles.empty}>{emptyMessage}</div>
+  }
+
+  const groups = groupThreads(threads)
+
+  return (
+    <div className={styles.root}>
+      {Array.from(groups.entries()).map(([repoKey, typeGroups]) => (
+        <div key={repoKey} className={styles.repoGroup}>
+          <div className={styles.repoHeader}>
+            <span className={styles.repoLabel}>{repoKey}</span>
+            <div className={styles.repoDivider} />
+          </div>
+
+          {Array.from(typeGroups.entries()).map(([type, typeThreads]) => (
+            <div key={type} className={styles.typeGroup}>
+              <div className={styles.typeHeader}>
+                <span className={styles.typeLabel}>{typeLabel(type)}</span>
+                <span className={styles.typeCount}>{typeThreads.length}</span>
+              </div>
+
+              {typeThreads.map((thread) => (
+                <div key={thread.id} className={styles.threadRow}>
+                  <div className={styles.threadDot} data-unread={thread.unread} />
+
+                  <div className={styles.threadBody}>
+                    <div className={styles.threadTitle}>
+                      {thread.htmlUrl ? (
+                        <button
+                          className={`${styles.threadName} ${styles.threadNameLink}`}
+                          data-unread={thread.unread}
+                          onClick={() => window.electron.openExternal(thread.htmlUrl!)}
+                          title="Open in browser"
+                        >
+                          {thread.title}
+                        </button>
+                      ) : (
+                        <span className={styles.threadName} data-unread={thread.unread}>
+                          {thread.title}
+                        </span>
+                      )}
+                      {thread.subjectState && thread.subjectState !== 'open' && (
+                        <StateChip state={thread.subjectState} />
+                      )}
+                    </div>
+                  </div>
+
+                  <div className={styles.threadActions}>
+                    <div className={styles.threadIconGroup}>
+                      {thread.htmlUrl && (
+                        <button
+                          className={styles.iconBtn}
+                          title="Open in GitHub"
+                          aria-label="Open in GitHub"
+                          onClick={() => window.electron.openExternal(thread.htmlUrl!)}
+                        >
+                          <ExternalLinkIcon />
+                        </button>
+                      )}
+                      <button
+                        className={styles.iconBtn}
+                        title="Mark as read"
+                        aria-label="Mark as read"
+                        disabled={!thread.unread}
+                        onClick={() => void onMarkRead(thread.id)}
+                      >
+                        <MarkReadIcon />
+                      </button>
+                      <button
+                        className={styles.iconBtn}
+                        title="Unsubscribe"
+                        aria-label="Unsubscribe"
+                        onClick={() => void onUnsubscribe(thread.id)}
+                      >
+                        <UnsubscribeIcon />
+                      </button>
+                    </div>
+
+                    {projects && onAssign && (
+                      assigningId === thread.id ? (
+                        <select
+                          className={styles.projectSelect}
+                          autoFocus
+                          defaultValue=""
+                          onChange={(e) => {
+                            const val = e.target.value
+                            if (val) void onAssign(thread.id, parseInt(val, 10))
+                            setAssigningId(null)
+                          }}
+                          onBlur={() => setAssigningId(null)}
+                        >
+                          <option value="" disabled>Assign to…</option>
+                          {projects.map((p) => (
+                            <option key={p.id} value={p.id}>{p.name}</option>
+                          ))}
+                        </select>
+                      ) : (
+                        <button
+                          className={styles.assignBtn}
+                          onClick={() => setAssigningId(thread.id)}
+                        >
+                          Assign
+                        </button>
+                      )
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          ))}
+        </div>
+      ))}
+    </div>
+  )
+}
+
+// ── Sub-components ───────────────────────────────────────────────────────────
+
+function StateChip({ state }: { state: SubjectState }) {
+  const classes = [styles.stateChip]
+  if (state === 'merged') classes.push(styles.stateMerged)
+  else if (state === 'closed') classes.push(styles.stateClosed)
+  return <span className={classes.join(' ')}>{state}</span>
+}
+
+function ExternalLinkIcon() {
+  return (
+    <svg width="13" height="13" viewBox="0 0 13 13" fill="none" aria-hidden="true">
+      <path d="M5 2H2a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V8" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round"/>
+      <path d="M8 1.5H11.5V5M11.5 1.5 5.5 7.5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round"/>
+    </svg>
+  )
+}
+
+function MarkReadIcon() {
+  return (
+    <svg width="13" height="13" viewBox="0 0 13 13" fill="none" aria-hidden="true">
+      <path d="M2 6.5l3.5 3.5 5.5-5.5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round"/>
+    </svg>
+  )
+}
+
+function UnsubscribeIcon() {
+  return (
+    <svg width="13" height="13" viewBox="0 0 13 13" fill="none" aria-hidden="true">
+      <path d="M6.5 1v.5M5 11a1.5 1.5 0 0 0 3 0M3 9.5h7L9 8V5.5a2.5 2.5 0 0 0-5 0V8L3 9.5Z" stroke="currentColor" strokeWidth="1.25" strokeLinecap="round" strokeLinejoin="round"/>
+      <line x1="2" y1="2" x2="11" y2="11" stroke="currentColor" strokeWidth="1.25" strokeLinecap="round"/>
+    </svg>
+  )
+}
+
+// TypeChip is exported for use if callers need it (e.g. in flat list fallbacks)
+export function TypeChip({ type }: { type: NotificationType }) {
+  const classes = [styles.typeChip]
+  if (type === 'PullRequest') classes.push(styles.typePR)
+  else if (type === 'Issue') classes.push(styles.typeIssue)
+  else if (type === 'Release') classes.push(styles.typeRelease)
+  else classes.push(styles.typeOther)
+
+  const label =
+    type === 'PullRequest' ? 'PR'
+    : type === 'CheckSuite' ? 'CI'
+    : type
+
+  return <span className={classes.join(' ')}>{label}</span>
+}

--- a/src/renderer/src/pages/Inbox.tsx
+++ b/src/renderer/src/pages/Inbox.tsx
@@ -3,7 +3,6 @@ import { formatDistanceToNow, parseISO } from 'date-fns'
 import styles from './Inbox.module.css'
 import { ThreadedNotificationList } from '../components/ThreadedNotificationList'
 import type { NotificationThread, Project, RepoRuleSuggestion } from '@shared/ipc-channels'
-import { buildThreadUrl } from '@shared/thread-url'
 
 interface Props {
   onAssigned: () => void

--- a/src/renderer/src/pages/Inbox.tsx
+++ b/src/renderer/src/pages/Inbox.tsx
@@ -103,6 +103,15 @@ export function Inbox({ onAssigned }: Props) {
     }
   }
 
+  const handleMarkReadMany = async (threadIds: string[]) => {
+    try {
+      await window.electron.ipc.invoke('notifications:mark-read-many', threadIds)
+      setThreads((prev) => prev.map((t) => threadIds.includes(t.id) ? { ...t, unread: false } : t))
+    } catch (err) {
+      console.error('[Inbox] Mark read many failed:', err)
+    }
+  }
+
   const handleUnsubscribe = async (threadId: string) => {
     try {
       await window.electron.ipc.invoke('notifications:unsubscribe', threadId)
@@ -191,6 +200,7 @@ export function Inbox({ onAssigned }: Props) {
             threads={threads}
             projects={projects}
             onMarkRead={handleMarkRead}
+            onMarkReadMany={handleMarkReadMany}
             onUnsubscribe={handleUnsubscribe}
             onAssign={handleAssign}
           />

--- a/src/renderer/src/pages/Inbox.tsx
+++ b/src/renderer/src/pages/Inbox.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react'
 import { formatDistanceToNow, parseISO } from 'date-fns'
 import styles from './Inbox.module.css'
+import { ThreadedNotificationList } from '../components/ThreadedNotificationList'
 import type { NotificationThread, Project, RepoRuleSuggestion } from '@shared/ipc-channels'
 
 interface Props {
@@ -15,7 +16,6 @@ export function Inbox({ onAssigned }: Props) {
   const [syncError, setSyncError] = useState<string | null>(null)
   const [lastSyncTime, setLastSyncTime] = useState<string | null>(null)
   const [isAuthenticated, setIsAuthenticated] = useState<boolean | null>(null)
-  const [assigningId, setAssigningId] = useState<string | null>(null)
   const [suggestion, setSuggestion] = useState<(RepoRuleSuggestion & { threadId: string }) | null>(null)
 
   const load = useCallback(async () => {
@@ -73,7 +73,6 @@ export function Inbox({ onAssigned }: Props) {
     } catch (err) {
       console.error('[Inbox] Assign failed:', err)
     }
-    setAssigningId(null)
   }
 
   const handleAcceptRepoRule = async () => {
@@ -188,146 +187,15 @@ export function Inbox({ onAssigned }: Props) {
         )}
 
         {!isLoading && threads.length > 0 && (
-          <ul className={styles.list}>
-            {threads.map((thread) => (
-              <li key={thread.id} className={styles.threadRow}>
-                <div className={styles.threadDot} data-unread={thread.unread} />
-                <div className={styles.threadBody}>
-                  <div className={styles.threadTitle}>
-                    {thread.htmlUrl ? (
-                      <button
-                        className={`${styles.threadName} ${styles.threadNameLink}`}
-                        data-unread={thread.unread}
-                        onClick={() => window.electron.openExternal(thread.htmlUrl!)}
-                        title="Open in browser"
-                      >
-                        {thread.title}
-                      </button>
-                    ) : (
-                      <span className={styles.threadName} data-unread={thread.unread}>
-                        {thread.title}
-                      </span>
-                    )}
-                    <TypeChip type={thread.type} />
-                    {thread.subjectState && thread.subjectState !== 'open' && (
-                      <StateChip state={thread.subjectState} />
-                    )}
-                  </div>
-                  <div className={styles.threadMeta}>
-                    <span className={styles.threadRepo}>
-                      {thread.repoOwner}/{thread.repoName}
-                    </span>
-                  </div>
-                </div>
-
-                <div className={styles.threadActions}>
-                  <div className={styles.threadIconGroup}>
-                    {thread.htmlUrl && (
-                      <button
-                        className={styles.iconBtn}
-                        title="Open in GitHub"
-                        aria-label="Open in GitHub"
-                        onClick={() => window.electron.openExternal(thread.htmlUrl!)}
-                      >
-                        <ExternalLinkIcon />
-                      </button>
-                    )}
-                    <button
-                      className={styles.iconBtn}
-                      title="Mark as read"
-                      aria-label="Mark as read"
-                      disabled={!thread.unread}
-                      onClick={() => void handleMarkRead(thread.id)}
-                    >
-                      <MarkReadIcon />
-                    </button>
-                    <button
-                      className={styles.iconBtn}
-                      title="Unsubscribe"
-                      aria-label="Unsubscribe"
-                      onClick={() => void handleUnsubscribe(thread.id)}
-                    >
-                      <UnsubscribeIcon />
-                    </button>
-                  </div>
-                  {assigningId === thread.id ? (
-                    <select
-                      className={styles.projectSelect}
-                      autoFocus
-                      defaultValue=""
-                      onChange={(e) => {
-                        const val = e.target.value
-                        if (val) void handleAssign(thread.id, parseInt(val, 10))
-                      }}
-                      onBlur={() => setAssigningId(null)}
-                    >
-                      <option value="" disabled>Assign to…</option>
-                      {projects.map((p) => (
-                        <option key={p.id} value={p.id}>{p.name}</option>
-                      ))}
-                    </select>
-                  ) : (
-                    <button
-                      className={styles.assignBtn}
-                      onClick={() => setAssigningId(thread.id)}
-                    >
-                      Assign
-                    </button>
-                  )}
-                </div>
-              </li>
-            ))}
-          </ul>
+          <ThreadedNotificationList
+            threads={threads}
+            projects={projects}
+            onMarkRead={handleMarkRead}
+            onUnsubscribe={handleUnsubscribe}
+            onAssign={handleAssign}
+          />
         )}
       </div>
     </div>
   )
-}
-
-function ExternalLinkIcon() {
-  return (
-    <svg width="13" height="13" viewBox="0 0 13 13" fill="none" aria-hidden="true">
-      <path d="M5 2H2a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V8" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round"/>
-      <path d="M8 1.5H11.5V5M11.5 1.5 5.5 7.5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round"/>
-    </svg>
-  )
-}
-
-function MarkReadIcon() {
-  return (
-    <svg width="13" height="13" viewBox="0 0 13 13" fill="none" aria-hidden="true">
-      <path d="M2 6.5l3.5 3.5 5.5-5.5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round"/>
-    </svg>
-  )
-}
-
-function UnsubscribeIcon() {
-  return (
-    <svg width="13" height="13" viewBox="0 0 13 13" fill="none" aria-hidden="true">
-      <path d="M6.5 1v.5M5 11a1.5 1.5 0 0 0 3 0M3 9.5h7L9 8V5.5a2.5 2.5 0 0 0-5 0V8L3 9.5Z" stroke="currentColor" strokeWidth="1.25" strokeLinecap="round" strokeLinejoin="round"/>
-      <line x1="2" y1="2" x2="11" y2="11" stroke="currentColor" strokeWidth="1.25" strokeLinecap="round"/>
-    </svg>
-  )
-}
-
-function TypeChip({ type }: { type: string }) {
-  const classes = [styles.typeChip]
-  if (type === 'PullRequest') classes.push(styles.typePR)
-  else if (type === 'Issue') classes.push(styles.typeIssue)
-  else if (type === 'Release') classes.push(styles.typeRelease)
-  else classes.push(styles.typeOther)
-
-  const label =
-    type === 'PullRequest' ? 'PR'
-    : type === 'CheckSuite' ? 'CI'
-    : type
-
-  return <span className={classes.join(' ')}>{label}</span>
-}
-
-function StateChip({ state }: { state: string }) {
-  const classes = [styles.stateChip]
-  if (state === 'merged') classes.push(styles.stateMerged)
-  else if (state === 'closed') classes.push(styles.stateClosed)
-  return <span className={classes.join(' ')}>{state}</span>
 }

--- a/src/renderer/src/pages/ProjectDetail.tsx
+++ b/src/renderer/src/pages/ProjectDetail.tsx
@@ -1,7 +1,8 @@
 import { useState, useRef, useEffect, useCallback } from 'react'
 import styles from './ProjectDetail.module.css'
 import { useProjectDetail } from '../hooks/useProjectDetail'
-import type { NotificationThread, NotificationType, ProjectLink, SnoozeMode } from '@shared/ipc-channels'
+import { ThreadedNotificationList } from '../components/ThreadedNotificationList'
+import type { NotificationThread, ProjectLink, SnoozeMode } from '@shared/ipc-channels'
 
 type Tab = 'todos' | 'notes' | 'notifications'
 
@@ -529,146 +530,12 @@ interface NotificationsTabProps {
 }
 
 function NotificationsTab({ notifications, onMarkRead, onUnsubscribe }: NotificationsTabProps) {
-  if (notifications.length === 0) {
-    return (
-      <div className={styles.notificationsEmpty}>
-        <p>No notifications for this project.</p>
-      </div>
-    )
-  }
-
-  // Group by repo
-  const groups = new Map<string, NotificationThread[]>()
-  for (const n of notifications) {
-    const key = `${n.repoOwner}/${n.repoName}`
-    const existing = groups.get(key) ?? []
-    existing.push(n)
-    groups.set(key, existing)
-  }
-
   return (
-    <div className={styles.notificationsList}>
-      {Array.from(groups.entries()).map(([repoKey, threads]) => (
-        <div key={repoKey} className={styles.notificationGroup}>
-          <div className={styles.notificationGroupHeader}>
-            <span>{repoKey}</span>
-            <div className={styles.notificationGroupDivider} />
-          </div>
-          {threads.map((n) => (
-            <div key={n.id} className={styles.notificationRow}>
-              <div
-                className={styles.notificationDot}
-                data-unread={n.unread}
-              />
-              <div className={styles.notificationBody}>
-                <div className={styles.notificationTitle}>
-                  {n.htmlUrl ? (
-                    <button
-                      className={`${styles.notificationName} ${styles.notificationNameLink}`}
-                      data-unread={n.unread}
-                      onClick={() => window.electron.openExternal(n.htmlUrl!)}
-                      title="Open in browser"
-                    >
-                      {n.title}
-                    </button>
-                  ) : (
-                    <span className={styles.notificationName} data-unread={n.unread}>
-                      {n.title}
-                    </span>
-                  )}
-                  <NotificationTypeChip type={n.type} />
-                  {n.subjectState && n.subjectState !== 'open' && (
-                    <NotificationStateChip state={n.subjectState} />
-                  )}
-                </div>
-                <div className={styles.notificationMeta}>
-                  <span className={styles.notificationRepo}>
-                    {n.repoOwner}/{n.repoName}
-                  </span>
-                </div>
-              </div>
-              <div className={styles.notificationIconGroup}>
-                    {n.htmlUrl && (
-                      <button
-                        className={styles.notificationIconBtn}
-                        title="Open in GitHub"
-                        aria-label="Open in GitHub"
-                        onClick={() => window.electron.openExternal(n.htmlUrl!)}
-                      >
-                        <ExternalLinkIcon />
-                      </button>
-                    )}
-                    <button
-                      className={styles.notificationIconBtn}
-                      title="Mark as read"
-                      aria-label="Mark as read"
-                      disabled={!n.unread}
-                      onClick={() => void onMarkRead(n.id)}
-                    >
-                      <MarkReadIcon />
-                    </button>
-                    <button
-                      className={styles.notificationIconBtn}
-                      title="Unsubscribe"
-                      aria-label="Unsubscribe"
-                      onClick={() => void onUnsubscribe(n.id)}
-                    >
-                      <UnsubscribeIcon />
-                    </button>
-              </div>
-            </div>
-          ))}
-        </div>
-      ))}
-    </div>
+    <ThreadedNotificationList
+      threads={notifications}
+      onMarkRead={onMarkRead}
+      onUnsubscribe={onUnsubscribe}
+      emptyMessage="No notifications for this project."
+    />
   )
-}
-
-function ExternalLinkIcon() {
-  return (
-    <svg width="13" height="13" viewBox="0 0 13 13" fill="none" aria-hidden="true">
-      <path d="M5 2H2a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V8" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round"/>
-      <path d="M8 1.5H11.5V5M11.5 1.5 5.5 7.5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round"/>
-    </svg>
-  )
-}
-
-function MarkReadIcon() {
-  return (
-    <svg width="13" height="13" viewBox="0 0 13 13" fill="none" aria-hidden="true">
-      <path d="M2 6.5l3.5 3.5 5.5-5.5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round"/>
-    </svg>
-  )
-}
-
-function UnsubscribeIcon() {
-  return (
-    <svg width="13" height="13" viewBox="0 0 13 13" fill="none" aria-hidden="true">
-      <path d="M6.5 1v.5M5 11a1.5 1.5 0 0 0 3 0M3 9.5h7L9 8V5.5a2.5 2.5 0 0 0-5 0V8L3 9.5Z" stroke="currentColor" strokeWidth="1.25" strokeLinecap="round" strokeLinejoin="round"/>
-      <line x1="2" y1="2" x2="11" y2="11" stroke="currentColor" strokeWidth="1.25" strokeLinecap="round"/>
-    </svg>
-  )
-}
-
-function NotificationTypeChip({ type }: { type: NotificationType }) {
-  const chipClass =
-    type === 'PullRequest' ? styles.typeChipPR
-    : type === 'Issue' ? styles.typeChipIssue
-    : type === 'Release' ? styles.typeChipRelease
-    : styles.typeChipOther
-
-  const label =
-    type === 'PullRequest' ? 'PR'
-    : type === 'CheckSuite' ? 'CI'
-    : type
-
-  return <span className={`${styles.typeChip} ${chipClass}`}>{label}</span>
-}
-
-function NotificationStateChip({ state }: { state: string }) {
-  const stateClass =
-    state === 'merged' ? styles.stateChipMerged
-    : state === 'closed' ? styles.stateChipClosed
-    : styles.stateChipOpen
-  return <span className={`${styles.stateChip} ${stateClass}`}>{state}</span>
 }

--- a/src/renderer/src/pages/ProjectDetail.tsx
+++ b/src/renderer/src/pages/ProjectDetail.tsx
@@ -530,10 +530,20 @@ interface NotificationsTabProps {
 }
 
 function NotificationsTab({ notifications, onMarkRead, onUnsubscribe }: NotificationsTabProps) {
+  const handleMarkReadMany = async (threadIds: string[]) => {
+    try {
+      await window.electron.ipc.invoke('notifications:mark-read-many', threadIds)
+      // Parent will refresh via onNotificationsUpdated listener
+    } catch (err) {
+      console.error('[NotificationsTab] Mark read many failed:', err)
+    }
+  }
+
   return (
     <ThreadedNotificationList
       threads={notifications}
       onMarkRead={onMarkRead}
+      onMarkReadMany={handleMarkReadMany}
       onUnsubscribe={onUnsubscribe}
       emptyMessage="No notifications for this project."
     />

--- a/src/renderer/src/pages/ProjectDetail.tsx
+++ b/src/renderer/src/pages/ProjectDetail.tsx
@@ -2,8 +2,7 @@ import { useState, useRef, useEffect, useCallback } from 'react'
 import styles from './ProjectDetail.module.css'
 import { useProjectDetail } from '../hooks/useProjectDetail'
 import { ThreadedNotificationList } from '../components/ThreadedNotificationList'
-import type { NotificationThread, NotificationType, ProjectLink, SnoozeMode } from '@shared/ipc-channels'
-import { buildThreadUrl } from '@shared/thread-url'
+import type { NotificationThread, ProjectLink, SnoozeMode } from '@shared/ipc-channels'
 
 type Tab = 'todos' | 'notes' | 'notifications'
 

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -287,6 +287,12 @@ export type IpcChannels = {
     result: void
   }
 
+  /** Marks multiple notification threads as read in one transaction. No write-back to GitHub. */
+  'notifications:mark-read-many': {
+    args: [threadIds: string[]]
+    result: void
+  }
+
   /**
    * Unsubscribes from a GitHub notification thread via the API,
    * then removes the thread from local storage.


### PR DESCRIPTION
Resolves https://github.com/robert-crandall/gh-notifier/issues/52

Introduce threaded notifications to enhance user experience and add a "mark all read" feature for improved notification management. Adjustments include styling updates for better visual organization of threads.