### PR TITLE
Hide handled notifications

### DIFF
--- a/db/migrations/010_state_checked_at.sql
+++ b/db/migrations/010_state_checked_at.sql
@@ -1,0 +1,3 @@
+-- Tracks when the subject state (open/merged/closed) was last verified for a thread.
+-- Allows the prefetch to throttle re-checks of open threads to avoid unnecessary API calls.
+ALTER TABLE notification_threads ADD COLUMN state_checked_at TEXT; -- ISO 8601; NULL = never checked

--- a/src/main/db/notifications.ts
+++ b/src/main/db/notifications.ts
@@ -379,7 +379,7 @@ export function invalidateOpenThreadPrefetch(): void {
   getDb()
     .prepare(
       `UPDATE notification_threads
-       SET content_fetched_at = NULL
+       SET content_fetched_at = NULL, state_checked_at = NULL
        WHERE subject_state IS NULL OR subject_state = 'open'`
     )
     .run()
@@ -396,7 +396,15 @@ export function getThreadsNeedingPrefetch(): PrefetchCandidate[] {
       `SELECT id, subject_url AS subjectUrl, type
        FROM notification_threads
        WHERE subject_url IS NOT NULL
-         AND (content_fetched_at IS NULL OR updated_at > content_fetched_at)`
+         AND (
+           content_fetched_at IS NULL
+           OR updated_at > content_fetched_at
+           OR subject_state IS NULL
+           OR (
+             subject_state = 'open'
+             AND (state_checked_at IS NULL OR state_checked_at < datetime('now', '-2 hours'))
+           )
+         )`
     )
     .all() as PrefetchCandidate[]
   return rows
@@ -415,8 +423,8 @@ export function updateThreadContent(
   getDb()
     .prepare(
       `UPDATE notification_threads
-       SET subject_state = ?, html_url = ?, content_fetched_at = ?
+       SET subject_state = ?, html_url = ?, content_fetched_at = ?, state_checked_at = ?
        WHERE id = ?`
     )
-    .run(subjectState, htmlUrl, now, threadId)
+    .run(subjectState, htmlUrl, now, now, threadId)
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -116,19 +116,35 @@ app.whenReady().then(async () => {
       win.webContents.send('notifications:updated')
     })
   })
-  ipcMain.handle('notifications:mark-read', (_event, threadId: string) => {
+  ipcMain.handle('notifications:mark-read', async (_event, threadId: string) => {
     markThreadRead(threadId)
     // Emit update event so unread badges refresh immediately
     BrowserWindow.getAllWindows().forEach((win) => {
       win.webContents.send('notifications:updated')
     })
+    // Best-effort: mark read on GitHub so the next sync doesn't re-surface it
+    try {
+      const octokit = getOctokit()
+      await octokit.rest.activity.markThreadAsRead({ thread_id: parseInt(threadId, 10) })
+    } catch (err) {
+      console.error('[notifications] Failed to mark thread read on GitHub:', err)
+    }
   })
-  ipcMain.handle('notifications:mark-read-many', (_event, threadIds: string[]) => {
+  ipcMain.handle('notifications:mark-read-many', async (_event, threadIds: string[]) => {
     markThreadsReadMany(threadIds)
     // Emit a single update event after bulk operation
     BrowserWindow.getAllWindows().forEach((win) => {
       win.webContents.send('notifications:updated')
     })
+    // Best-effort: mark each thread read on GitHub in parallel
+    try {
+      const octokit = getOctokit()
+      await Promise.allSettled(
+        threadIds.map((id) => octokit.rest.activity.markThreadAsRead({ thread_id: parseInt(id, 10) }))
+      )
+    } catch (err) {
+      console.error('[notifications] Failed to mark threads read on GitHub:', err)
+    }
   })
   ipcMain.handle('notifications:unsubscribe', async (_event, threadId: string) => {
     const octokit = getOctokit()

--- a/src/renderer/src/components/ThreadedNotificationList.module.css
+++ b/src/renderer/src/components/ThreadedNotificationList.module.css
@@ -412,3 +412,27 @@
   color: var(--text);
   cursor: pointer;
 }
+
+/* ── Read section ── */
+.readSection {
+  margin-top: 8px;
+  border-top: 1px solid var(--border);
+  padding-top: 2px;
+}
+
+.readSectionHeader {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 0 6px;
+  cursor: pointer;
+  user-select: none;
+}
+
+.readSectionLabel {
+  flex-shrink: 0;
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--text-3);
+  letter-spacing: 0.02em;
+}

--- a/src/renderer/src/components/ThreadedNotificationList.tsx
+++ b/src/renderer/src/components/ThreadedNotificationList.tsx
@@ -14,6 +14,8 @@ export interface ThreadedNotificationListProps {
   /** Called when a thread is assigned to a project. Requires `projects` to be set. */
   onAssign?: (threadId: string, projectId: number) => Promise<void>
   emptyMessage?: string
+  /** When true, read threads appear in a collapsible "Read" section below active threads. */
+  showReadSection?: boolean
 }
 
 // ── Grouping helpers ─────────────────────────────────────────────────────────
@@ -56,18 +58,23 @@ export function ThreadedNotificationList({
   onUnsubscribe,
   onAssign,
   emptyMessage = 'No notifications.',
+  showReadSection = false,
 }: ThreadedNotificationListProps) {
   const [assigningId, setAssigningId] = useState<string | null>(null)
   const [collapsedRepos, setCollapsedRepos] = useState<Set<string>>(new Set())
   const [collapsedTypes, setCollapsedTypes] = useState<Set<string>>(new Set())
   const [markingAllRepoKey, setMarkingAllRepoKey] = useState<string | null>(null)
   const [markingAllTypeKey, setMarkingAllTypeKey] = useState<string | null>(null)
+  const [readCollapsed, setReadCollapsed] = useState(true)
 
   if (threads.length === 0) {
     return <div className={styles.empty}>{emptyMessage}</div>
   }
 
-  const groups = groupThreads(threads)
+  const activeThreads = showReadSection ? threads.filter((t) => t.unread) : threads
+  const readThreads = showReadSection ? threads.filter((t) => !t.unread) : []
+  const groups = groupThreads(activeThreads)
+  const readGroups = groupThreads(readThreads)
 
   const toggleRepo = (repoKey: string) => {
     setCollapsedRepos((prev) => {
@@ -105,21 +112,22 @@ export function ThreadedNotificationList({
     }
   }
 
-  return (
-    <div className={styles.root}>
-      {Array.from(groups.entries()).map(([repoKey, typeGroups]) => {
-        const repoThreads = Array.from(typeGroups.values()).flat()
-        const repoCollapsed = collapsedRepos.has(repoKey)
-        const repoHasUnread = repoThreads.some((t) => t.unread)
+  // Renders a map of repo → type → threads. keyPrefix avoids React key collisions
+  // between the active section and the Read section when the same repo appears in both.
+  const renderRepoGroups = (groupMap: RepoGroups, keyPrefix: string) =>
+    Array.from(groupMap.entries()).map(([repoKey, typeGroups]) => {
+      const fullRepoKey = keyPrefix ? `${keyPrefix}:${repoKey}` : repoKey
+      const repoThreads = Array.from(typeGroups.values()).flat()
+      const repoCollapsed = collapsedRepos.has(fullRepoKey)
+      const repoHasUnread = repoThreads.some((t) => t.unread)
+      const repoSectionId = `repo-section-${fullRepoKey.replace(/[^a-zA-Z0-9_-]/g, '-')}`
 
-        const repoSectionId = `repo-section-${repoKey.replace(/[^a-zA-Z0-9_-]/g, '-')}`
-
-        return (
-        <div key={repoKey} id={repoSectionId} className={styles.repoGroup}>
+      return (
+        <div key={fullRepoKey} id={repoSectionId} className={styles.repoGroup}>
           <div className={styles.repoHeader}>
             <button
               className={styles.collapseBtn}
-              onClick={() => toggleRepo(repoKey)}
+              onClick={() => toggleRepo(fullRepoKey)}
               aria-label={`${repoCollapsed ? 'Expand' : 'Collapse'} ${repoKey}`}
               aria-expanded={!repoCollapsed}
               aria-controls={repoSectionId}
@@ -132,11 +140,11 @@ export function ThreadedNotificationList({
               <button
                 className={styles.markAllBtn}
                 onClick={async () => {
-                  setMarkingAllRepoKey(repoKey)
+                  setMarkingAllRepoKey(fullRepoKey)
                   await markAllRead(repoThreads)
                   setMarkingAllRepoKey(null)
                 }}
-                disabled={markingAllRepoKey === repoKey}
+                disabled={markingAllRepoKey === fullRepoKey}
                 title="Mark all as read"
               >
                 Mark all read
@@ -145,135 +153,159 @@ export function ThreadedNotificationList({
           </div>
 
           {!repoCollapsed && Array.from(typeGroups.entries()).map(([type, typeThreads]) => {
-            const typeKey = `${repoKey}:${type}`
+            const typeKey = `${fullRepoKey}:${type}`
             const typeCollapsed = collapsedTypes.has(typeKey)
             const typeHasUnread = typeThreads.some((t) => t.unread)
-            const typeRegionId = `type-group-${repoKey}-${type}`.replace(/[^a-zA-Z0-9_-]/g, '-')
+            const typeRegionId = `type-group-${typeKey}`.replace(/[^a-zA-Z0-9_-]/g, '-')
 
             return (
-            <div key={type} id={typeRegionId} className={styles.typeGroup}>
-              <div className={styles.typeHeader}>
-                <button
-                  className={styles.collapseBtn}
-                  onClick={() => toggleType(typeKey)}
-                  aria-label={`${typeCollapsed ? 'Expand' : 'Collapse'} ${repoKey} ${typeLabel(type)}`}
-                  aria-expanded={!typeCollapsed}
-                  aria-controls={typeRegionId}
-                >
-                  <ChevronIcon collapsed={typeCollapsed} />
-                </button>
-                <span className={styles.typeLabel}>{typeLabel(type)}</span>
-                <span className={styles.typeCount}>{typeThreads.length}</span>
-                {typeHasUnread && (
+              <div key={type} id={typeRegionId} className={styles.typeGroup}>
+                <div className={styles.typeHeader}>
                   <button
-                    className={styles.markAllBtn}
-                    onClick={async () => {
-                      setMarkingAllTypeKey(typeKey)
-                      await markAllRead(typeThreads)
-                      setMarkingAllTypeKey(null)
-                    }}
-                    disabled={markingAllTypeKey === typeKey}
-                    title="Mark all as read"
+                    className={styles.collapseBtn}
+                    onClick={() => toggleType(typeKey)}
+                    aria-label={`${typeCollapsed ? 'Expand' : 'Collapse'} ${repoKey} ${typeLabel(type)}`}
+                    aria-expanded={!typeCollapsed}
+                    aria-controls={typeRegionId}
                   >
-                    Mark all read
+                    <ChevronIcon collapsed={typeCollapsed} />
                   </button>
-                )}
-              </div>
+                  <span className={styles.typeLabel}>{typeLabel(type)}</span>
+                  <span className={styles.typeCount}>{typeThreads.length}</span>
+                  {typeHasUnread && (
+                    <button
+                      className={styles.markAllBtn}
+                      onClick={async () => {
+                        setMarkingAllTypeKey(typeKey)
+                        await markAllRead(typeThreads)
+                        setMarkingAllTypeKey(null)
+                      }}
+                      disabled={markingAllTypeKey === typeKey}
+                      title="Mark all as read"
+                    >
+                      Mark all read
+                    </button>
+                  )}
+                </div>
 
-              {!typeCollapsed && typeThreads.map((thread) => (
-                <div key={thread.id} className={styles.threadRow}>
-                  <div className={styles.threadDot} data-unread={thread.unread} />
+                {!typeCollapsed && typeThreads.map((thread) => (
+                  <div key={thread.id} className={styles.threadRow}>
+                    <div className={styles.threadDot} data-unread={thread.unread} />
 
-                  <div className={styles.threadBody}>
-                    <div className={styles.threadTitle}>
-                      {thread.htmlUrl ? (
-                        <button
-                          className={`${styles.threadName} ${styles.threadNameLink}`}
-                          data-unread={thread.unread}
-                          onClick={() => window.electron.openExternal(thread.htmlUrl!)}
-                          title="Open in browser"
-                        >
-                          {thread.title}
-                        </button>
-                      ) : (
-                        <span className={styles.threadName} data-unread={thread.unread}>
-                          {thread.title}
-                        </span>
-                      )}
-                      {thread.subjectState && thread.subjectState !== 'open' && (
-                        <StateChip state={thread.subjectState} />
-                      )}
-                      <ReasonPill reason={thread.reason} />
+                    <div className={styles.threadBody}>
+                      <div className={styles.threadTitle}>
+                        {thread.htmlUrl ? (
+                          <button
+                            className={`${styles.threadName} ${styles.threadNameLink}`}
+                            data-unread={thread.unread}
+                            onClick={() => window.electron.openExternal(thread.htmlUrl!)}
+                            title="Open in browser"
+                          >
+                            {thread.title}
+                          </button>
+                        ) : (
+                          <span className={styles.threadName} data-unread={thread.unread}>
+                            {thread.title}
+                          </span>
+                        )}
+                        {thread.subjectState && thread.subjectState !== 'open' && (
+                          <StateChip state={thread.subjectState} />
+                        )}
+                        <ReasonPill reason={thread.reason} />
+                      </div>
                     </div>
-                  </div>
 
-                  <div className={styles.threadActions}>
-                    <div className={styles.threadIconGroup}>
-                      {thread.htmlUrl && (
+                    <div className={styles.threadActions}>
+                      <div className={styles.threadIconGroup}>
+                        {thread.htmlUrl && (
+                          <button
+                            className={styles.iconBtn}
+                            title="Open in GitHub"
+                            aria-label="Open in GitHub"
+                            onClick={() => window.electron.openExternal(thread.htmlUrl!)}
+                          >
+                            <ExternalLinkIcon />
+                          </button>
+                        )}
                         <button
                           className={styles.iconBtn}
-                          title="Open in GitHub"
-                          aria-label="Open in GitHub"
-                          onClick={() => window.electron.openExternal(thread.htmlUrl!)}
+                          title="Mark as read"
+                          aria-label="Mark as read"
+                          disabled={!thread.unread}
+                          onClick={() => void onMarkRead(thread.id)}
                         >
-                          <ExternalLinkIcon />
+                          <MarkReadIcon />
                         </button>
-                      )}
-                      <button
-                        className={styles.iconBtn}
-                        title="Mark as read"
-                        aria-label="Mark as read"
-                        disabled={!thread.unread}
-                        onClick={() => void onMarkRead(thread.id)}
-                      >
-                        <MarkReadIcon />
-                      </button>
-                      <button
-                        className={styles.iconBtn}
-                        title="Unsubscribe"
-                        aria-label="Unsubscribe"
-                        onClick={() => void onUnsubscribe(thread.id)}
-                      >
-                        <UnsubscribeIcon />
-                      </button>
-                    </div>
-
-                    {projects && onAssign && (
-                      assigningId === thread.id ? (
-                        <select
-                          className={styles.projectSelect}
-                          autoFocus
-                          defaultValue=""
-                          onChange={(e) => {
-                            const val = e.target.value
-                            if (val) void onAssign(thread.id, parseInt(val, 10))
-                            setAssigningId(null)
-                          }}
-                          onBlur={() => setAssigningId(null)}
-                        >
-                          <option value="" disabled>Assign to…</option>
-                          {projects.map((p) => (
-                            <option key={p.id} value={p.id}>{p.name}</option>
-                          ))}
-                        </select>
-                      ) : (
                         <button
-                          className={styles.assignBtn}
-                          onClick={() => setAssigningId(thread.id)}
+                          className={styles.iconBtn}
+                          title="Unsubscribe"
+                          aria-label="Unsubscribe"
+                          onClick={() => void onUnsubscribe(thread.id)}
                         >
-                          Assign
+                          <UnsubscribeIcon />
                         </button>
-                      )
-                    )}
+                      </div>
+
+                      {projects && onAssign && (
+                        assigningId === thread.id ? (
+                          <select
+                            className={styles.projectSelect}
+                            autoFocus
+                            defaultValue=""
+                            onChange={(e) => {
+                              const val = e.target.value
+                              if (val) void onAssign(thread.id, parseInt(val, 10))
+                              setAssigningId(null)
+                            }}
+                            onBlur={() => setAssigningId(null)}
+                          >
+                            <option value="" disabled>Assign to…</option>
+                            {projects.map((p) => (
+                              <option key={p.id} value={p.id}>{p.name}</option>
+                            ))}
+                          </select>
+                        ) : (
+                          <button
+                            className={styles.assignBtn}
+                            onClick={() => setAssigningId(thread.id)}
+                          >
+                            Assign
+                          </button>
+                        )
+                      )}
+                    </div>
                   </div>
-                </div>
-              ))}
-            </div>
+                ))}
+              </div>
             )
           })}
         </div>
-        )
-      })}
+      )
+    })
+
+  return (
+    <div className={styles.root}>
+      {renderRepoGroups(groups, '')}
+      {showReadSection && readThreads.length > 0 && (
+        <div className={styles.readSection}>
+          <div
+            className={styles.readSectionHeader}
+            onClick={() => setReadCollapsed((c) => !c)}
+          >
+            <button
+              className={styles.collapseBtn}
+              aria-label={readCollapsed ? 'Expand read notifications' : 'Collapse read notifications'}
+              aria-expanded={!readCollapsed}
+            >
+              <ChevronIcon collapsed={readCollapsed} />
+            </button>
+            <span className={styles.readSectionLabel}>Read</span>
+            <span className={styles.typeCount}>{readThreads.length}</span>
+            <div className={styles.repoDivider} />
+          </div>
+          {!readCollapsed && renderRepoGroups(readGroups, 'read')}
+        </div>
+      )}
     </div>
   )
 }

--- a/src/renderer/src/pages/Inbox.test.tsx
+++ b/src/renderer/src/pages/Inbox.test.tsx
@@ -179,4 +179,120 @@ describe('Inbox', () => {
       })
     })
   })
+
+  describe('mark as read', () => {
+    it('removes a single thread from the list when marked as read', async () => {
+      const threads = [
+        makeThread({ id: 'thread-1', title: 'First thread' }),
+        makeThread({ id: 'thread-2', title: 'Second thread' }),
+      ]
+      setupElectron({
+        authStatus: { authenticated: true, login: 'octocat', avatarUrl: '' },
+        inbox: threads,
+      })
+      render(<Inbox onAssigned={vi.fn()} />)
+      await waitFor(() => {
+        expect(screen.getByText('First thread')).toBeInTheDocument()
+        expect(screen.getByText('Second thread')).toBeInTheDocument()
+      })
+
+      // Find and click the mark as read button for the first thread
+      const markReadButtons = screen.getAllByLabelText('Mark as read')
+      await userEvent.click(markReadButtons[0])
+
+      // Wait for the mark read to complete
+      await waitFor(() => {
+        expect(screen.queryByText('First thread')).not.toBeInTheDocument()
+      })
+      expect(screen.getByText('Second thread')).toBeInTheDocument()
+    })
+
+    it('removes multiple threads from the list when marked as read in bulk', async () => {
+      const threads = [
+        makeThread({ id: 'thread-1', title: 'First thread', repoName: 'repo1' }),
+        makeThread({ id: 'thread-2', title: 'Second thread', repoName: 'repo1' }),
+        makeThread({ id: 'thread-3', title: 'Third thread', repoName: 'repo1' }),
+      ]
+      setupElectron({
+        authStatus: { authenticated: true, login: 'octocat', avatarUrl: '' },
+        inbox: threads,
+      })
+      render(<Inbox onAssigned={vi.fn()} />)
+      await waitFor(() => {
+        expect(screen.getByText('First thread')).toBeInTheDocument()
+        expect(screen.getByText('Second thread')).toBeInTheDocument()
+        expect(screen.getByText('Third thread')).toBeInTheDocument()
+      })
+
+      // Find and click the first "Mark all read" button (for the repo)
+      const markAllReadButtons = screen.getAllByTitle('Mark all as read')
+      await userEvent.click(markAllReadButtons[0])
+
+      // Verify all threads were removed from the list
+      await waitFor(() => {
+        expect(screen.queryByText('First thread')).not.toBeInTheDocument()
+        expect(screen.queryByText('Second thread')).not.toBeInTheDocument()
+        expect(screen.queryByText('Third thread')).not.toBeInTheDocument()
+      })
+    })
+
+    it('keeps threads removed after a simulated notifications:updated refresh', async () => {
+      const threads = [
+        makeThread({ id: 'thread-1', title: 'First thread' }),
+        makeThread({ id: 'thread-2', title: 'Second thread' }),
+      ]
+      let inboxResponse = threads
+      let onNotificationsUpdatedCallback: (() => void) | undefined
+      const mockInvoke = vi.fn((channel: string) => {
+        switch (channel) {
+          case 'notifications:inbox':
+            return Promise.resolve(inboxResponse)
+          case 'projects:list': return Promise.resolve([])
+          case 'auth:status': return Promise.resolve({ authenticated: true, login: 'octocat', avatarUrl: '' })
+          case 'notifications:last-sync-time': return Promise.resolve(null)
+          case 'notifications:mark-read':
+            // Simulate backend filtering out the marked thread
+            inboxResponse = threads.filter((t) => t.id !== 'thread-1')
+            return Promise.resolve(undefined)
+          default: return Promise.resolve(null)
+        }
+      })
+
+      ;(window as unknown as Record<string, unknown>).electron = {
+        ipc: { invoke: mockInvoke },
+        openExternal: vi.fn(),
+        onNotificationsUpdated: vi.fn((callback: () => void) => {
+          onNotificationsUpdatedCallback = callback
+          return vi.fn()
+        }),
+      }
+
+      render(<Inbox onAssigned={vi.fn()} />)
+      await waitFor(() => {
+        expect(screen.getByText('First thread')).toBeInTheDocument()
+        expect(screen.getByText('Second thread')).toBeInTheDocument()
+      })
+
+      // Mark first thread as read
+      const markReadButtons = screen.getAllByLabelText('Mark as read')
+      await userEvent.click(markReadButtons[0])
+
+      await waitFor(() => {
+        expect(screen.queryByText('First thread')).not.toBeInTheDocument()
+      })
+
+      // Simulate notifications:updated event
+      onNotificationsUpdatedCallback?.()
+
+      // Wait for potential re-render
+      await waitFor(() => {
+        // Ensure load() was called again
+        expect(mockInvoke).toHaveBeenCalledWith('notifications:inbox')
+      })
+
+      // Verify thread is still not in the list (because backend now filters it)
+      expect(screen.queryByText('First thread')).not.toBeInTheDocument()
+      expect(screen.getByText('Second thread')).toBeInTheDocument()
+    })
+  })
 })

--- a/src/renderer/src/pages/Inbox.tsx
+++ b/src/renderer/src/pages/Inbox.tsx
@@ -97,7 +97,7 @@ export function Inbox({ onAssigned }: Props) {
   const handleMarkRead = async (threadId: string) => {
     try {
       await window.electron.ipc.invoke('notifications:mark-read', threadId)
-      setThreads((prev) => prev.map((t) => t.id === threadId ? { ...t, unread: false } : t))
+      setThreads((prev) => prev.filter((t) => t.id !== threadId))
     } catch (err) {
       console.error('[Inbox] Mark read failed:', err)
     }
@@ -106,7 +106,7 @@ export function Inbox({ onAssigned }: Props) {
   const handleMarkReadMany = async (threadIds: string[]) => {
     try {
       await window.electron.ipc.invoke('notifications:mark-read-many', threadIds)
-      setThreads((prev) => prev.map((t) => threadIds.includes(t.id) ? { ...t, unread: false } : t))
+      setThreads((prev) => prev.filter((t) => !threadIds.includes(t.id)))
     } catch (err) {
       console.error('[Inbox] Mark read many failed:', err)
     }

--- a/src/renderer/src/pages/Inbox.tsx
+++ b/src/renderer/src/pages/Inbox.tsx
@@ -106,7 +106,8 @@ export function Inbox({ onAssigned }: Props) {
   const handleMarkReadMany = async (threadIds: string[]) => {
     try {
       await window.electron.ipc.invoke('notifications:mark-read-many', threadIds)
-      setThreads((prev) => prev.filter((t) => !threadIds.includes(t.id)))
+      const threadIdSet = new Set(threadIds)
+      setThreads((prev) => prev.filter((t) => !threadIdSet.has(t.id)))
     } catch (err) {
       console.error('[Inbox] Mark read many failed:', err)
     }

--- a/src/renderer/src/pages/ProjectDetail.tsx
+++ b/src/renderer/src/pages/ProjectDetail.tsx
@@ -114,7 +114,8 @@ export function ProjectDetail({ projectId, onBack, onProjectChanged, onDelete }:
   const loadNotifications = useCallback(async () => {
     try {
       const threads = await window.electron.ipc.invoke('notifications:list', projectId)
-      setNotifications(threads)
+      // Filter to unread threads so that marking threads as read removes them persistently
+      setNotifications(threads.filter((t) => t.unread))
     } catch (err) {
       console.error('[ProjectDetail] Failed to load notifications:', err)
       // Notifications table may not be ready on first launch, but log unexpected errors
@@ -539,7 +540,8 @@ export function ProjectDetail({ projectId, onBack, onProjectChanged, onDelete }:
               onMarkReadMany={async (ids) => {
                 try {
                   await window.electron.ipc.invoke('notifications:mark-read-many', ids)
-                  setNotifications((prev) => prev.filter((n) => !ids.includes(n.id)))
+                  const idSet = new Set(ids)
+                  setNotifications((prev) => prev.filter((n) => !idSet.has(n.id)))
                   onProjectChanged()
                 } catch (err) {
                   console.error('[ProjectDetail] Mark read many failed:', err)

--- a/src/renderer/src/pages/ProjectDetail.tsx
+++ b/src/renderer/src/pages/ProjectDetail.tsx
@@ -128,23 +128,6 @@ export function ProjectDetail({ projectId, onBack, onProjectChanged, onDelete }:
     return unsub
   }, [loadNotifications])
 
-  // Mark all notifications as read when the notifications tab is opened
-  useEffect(() => {
-    if (activeTab !== 'notifications') return
-    
-    const unread = notifications.filter((n) => n.unread)
-    if (unread.length === 0) return
-    
-    setNotifications((prev) => prev.map((n) => ({ ...n, unread: false })))
-    
-    void (async () => {
-      await Promise.allSettled(
-        unread.map((n) => window.electron.ipc.invoke('notifications:mark-read', n.id))
-      )
-      onProjectChanged()
-    })()
-  }, [activeTab, notifications, onProjectChanged])
-
   useEffect(() => {
     if (editingAction && actionRef.current) {
       actionRef.current.focus()
@@ -531,7 +514,7 @@ export function ProjectDetail({ projectId, onBack, onProjectChanged, onDelete }:
               onMarkRead={async (id) => {
                 try {
                   await window.electron.ipc.invoke('notifications:mark-read', id)
-                  setNotifications((prev) => prev.filter((n) => n.id !== id))
+                  setNotifications((prev) => prev.map((n) => n.id === id ? { ...n, unread: false } : n))
                   onProjectChanged()
                 } catch (err) {
                   console.error('[ProjectDetail] Mark read failed:', err)
@@ -541,7 +524,7 @@ export function ProjectDetail({ projectId, onBack, onProjectChanged, onDelete }:
                 try {
                   await window.electron.ipc.invoke('notifications:mark-read-many', ids)
                   const idSet = new Set(ids)
-                  setNotifications((prev) => prev.filter((n) => !idSet.has(n.id)))
+                  setNotifications((prev) => prev.map((n) => idSet.has(n.id) ? { ...n, unread: false } : n))
                   onProjectChanged()
                 } catch (err) {
                   console.error('[ProjectDetail] Mark read many failed:', err)
@@ -580,6 +563,7 @@ function NotificationsTab({ notifications, onMarkRead, onMarkReadMany, onUnsubsc
       onMarkReadMany={onMarkReadMany}
       onUnsubscribe={onUnsubscribe}
       emptyMessage="No notifications for this project."
+      showReadSection={true}
     />
   )
 }

--- a/src/renderer/src/pages/ProjectDetail.tsx
+++ b/src/renderer/src/pages/ProjectDetail.tsx
@@ -530,10 +530,19 @@ export function ProjectDetail({ projectId, onBack, onProjectChanged, onDelete }:
               onMarkRead={async (id) => {
                 try {
                   await window.electron.ipc.invoke('notifications:mark-read', id)
-                  setNotifications((prev) => prev.map((n) => n.id === id ? { ...n, unread: false } : n))
+                  setNotifications((prev) => prev.filter((n) => n.id !== id))
                   onProjectChanged()
                 } catch (err) {
                   console.error('[ProjectDetail] Mark read failed:', err)
+                }
+              }}
+              onMarkReadMany={async (ids) => {
+                try {
+                  await window.electron.ipc.invoke('notifications:mark-read-many', ids)
+                  setNotifications((prev) => prev.filter((n) => !ids.includes(n.id)))
+                  onProjectChanged()
+                } catch (err) {
+                  console.error('[ProjectDetail] Mark read many failed:', err)
                 }
               }}
               onUnsubscribe={async (id) => {
@@ -557,24 +566,16 @@ export function ProjectDetail({ projectId, onBack, onProjectChanged, onDelete }:
 interface NotificationsTabProps {
   notifications: NotificationThread[]
   onMarkRead: (id: string) => Promise<void>
+  onMarkReadMany: (ids: string[]) => Promise<void>
   onUnsubscribe: (id: string) => Promise<void>
 }
 
-function NotificationsTab({ notifications, onMarkRead, onUnsubscribe }: NotificationsTabProps) {
-  const handleMarkReadMany = async (threadIds: string[]) => {
-    try {
-      await window.electron.ipc.invoke('notifications:mark-read-many', threadIds)
-      // Parent will refresh via onNotificationsUpdated listener
-    } catch (err) {
-      console.error('[NotificationsTab] Mark read many failed:', err)
-    }
-  }
-
+function NotificationsTab({ notifications, onMarkRead, onMarkReadMany, onUnsubscribe }: NotificationsTabProps) {
   return (
     <ThreadedNotificationList
       threads={notifications}
       onMarkRead={onMarkRead}
-      onMarkReadMany={handleMarkReadMany}
+      onMarkReadMany={onMarkReadMany}
       onUnsubscribe={onUnsubscribe}
       emptyMessage="No notifications for this project."
     />


### PR DESCRIPTION
Marking notifications as read now removes them from the displayed list, improving the user experience by hiding handled notifications. Additionally, support for marking multiple notifications as read has been added.