### PR TITLE
fix: re-check open notification threads on every sync

### DIFF
--- a/src/main/db/notifications.integration.test.ts
+++ b/src/main/db/notifications.integration.test.ts
@@ -20,7 +20,6 @@ import {
   deleteThread,
   getThreadsNeedingPrefetch,
   updateThreadContent,
-  invalidateOpenThreadPrefetch,
   type ThreadSyncData,
 } from './notifications'
 import { createProject, snoozeProject } from './projects'
@@ -273,7 +272,7 @@ describe('deleteThread', () => {
 // ── getThreadsNeedingPrefetch ─────────────────────────────────────────────────
 
 describe('getThreadsNeedingPrefetch', () => {
-  it('returns threads where content_fetched_at is null and subject_url is set', () => {
+  it('returns threads where subject_state is null and subject_url is set', () => {
     upsertThreads([makeThread({ id: 't-1', subjectUrl: 'https://api.github.com/repos/a/b/pulls/1' })])
     const candidates = getThreadsNeedingPrefetch()
     expect(candidates.map((c) => c.id)).toContain('t-1')
@@ -285,23 +284,29 @@ describe('getThreadsNeedingPrefetch', () => {
     expect(candidates.find((c) => c.id === 't-no-url')).toBeUndefined()
   })
 
-  it('returns a thread when updated_at is newer than content_fetched_at', () => {
-    upsertThreads([makeThread({ id: 't-1', subjectUrl: 'https://api.github.com/repos/a/b/pulls/1', updatedAt: '2024-01-01T00:00:00Z' })])
-    // Simulate a completed prefetch with an older timestamp
-    db.prepare(
-      `UPDATE notification_threads SET content_fetched_at = '2023-01-01T00:00:00Z' WHERE id = 't-1'`
-    ).run()
+  it('always returns open threads so closed/merged state is detected on every sync', () => {
+    upsertThreads([makeThread({ id: 't-open', subjectUrl: 'https://api.github.com/repos/a/b/pulls/1' })])
+    // Simulate a recently completed prefetch that resolved the thread as open.
+    updateThreadContent('t-open', 'open', 'https://github.com/a/b/pull/1')
+
     const candidates = getThreadsNeedingPrefetch()
-    expect(candidates.find((c) => c.id === 't-1')).toBeDefined()
+    expect(candidates.find((c) => c.id === 't-open')).toBeDefined()
   })
 
-  it('excludes threads where content_fetched_at is current', () => {
-    upsertThreads([makeThread({ id: 't-1', subjectUrl: 'https://api.github.com/repos/a/b/pulls/1', updatedAt: '2024-01-01T00:00:00Z' })])
-    db.prepare(
-      `UPDATE notification_threads SET content_fetched_at = '2025-01-01T00:00:00Z' WHERE id = 't-1'`
-    ).run()
+  it('excludes threads that already resolved as closed', () => {
+    upsertThreads([makeThread({ id: 't-closed', subjectUrl: 'https://api.github.com/repos/a/b/pulls/1' })])
+    updateThreadContent('t-closed', 'closed', 'https://github.com/a/b/pull/1')
+
     const candidates = getThreadsNeedingPrefetch()
-    expect(candidates.find((c) => c.id === 't-1')).toBeUndefined()
+    expect(candidates.find((c) => c.id === 't-closed')).toBeUndefined()
+  })
+
+  it('excludes threads that already resolved as merged', () => {
+    upsertThreads([makeThread({ id: 't-merged', subjectUrl: 'https://api.github.com/repos/a/b/pulls/1' })])
+    updateThreadContent('t-merged', 'merged', 'https://github.com/a/b/pull/1')
+
+    const candidates = getThreadsNeedingPrefetch()
+    expect(candidates.find((c) => c.id === 't-merged')).toBeUndefined()
   })
 })
 
@@ -319,52 +324,5 @@ describe('updateThreadContent', () => {
     expect(row.subject_state).toBe('open')
     expect(row.html_url).toBe('https://github.com/acme/repo/pull/1')
     expect(row.content_fetched_at).not.toBeNull()
-  })
-})
-
-// ── invalidateOpenThreadPrefetch ──────────────────────────────────────────────
-
-describe('invalidateOpenThreadPrefetch', () => {
-  it('resets content_fetched_at for threads with subject_state = "open"', () => {
-    upsertThreads([makeThread({ id: 't-open' })])
-    db.prepare(
-      `UPDATE notification_threads SET subject_state = 'open', content_fetched_at = datetime('now') WHERE id = 't-open'`
-    ).run()
-
-    invalidateOpenThreadPrefetch()
-
-    const row = db
-      .prepare('SELECT content_fetched_at FROM notification_threads WHERE id = ?')
-      .get('t-open') as { content_fetched_at: string | null }
-    expect(row.content_fetched_at).toBeNull()
-  })
-
-  it('resets content_fetched_at for threads with subject_state IS NULL', () => {
-    upsertThreads([makeThread({ id: 't-null-state' })])
-    db.prepare(
-      `UPDATE notification_threads SET subject_state = NULL, content_fetched_at = datetime('now') WHERE id = 't-null-state'`
-    ).run()
-
-    invalidateOpenThreadPrefetch()
-
-    const row = db
-      .prepare('SELECT content_fetched_at FROM notification_threads WHERE id = ?')
-      .get('t-null-state') as { content_fetched_at: string | null }
-    expect(row.content_fetched_at).toBeNull()
-  })
-
-  it('does not reset content_fetched_at for closed or merged threads', () => {
-    upsertThreads([makeThread({ id: 't-closed' })])
-    const ts = '2024-06-01T00:00:00Z'
-    db.prepare(
-      `UPDATE notification_threads SET subject_state = 'closed', content_fetched_at = ? WHERE id = 't-closed'`
-    ).run(ts)
-
-    invalidateOpenThreadPrefetch()
-
-    const row = db
-      .prepare('SELECT content_fetched_at FROM notification_threads WHERE id = ?')
-      .get('t-closed') as { content_fetched_at: string | null }
-    expect(row.content_fetched_at).toBe(ts)
   })
 })

--- a/src/main/db/notifications.integration.test.ts
+++ b/src/main/db/notifications.integration.test.ts
@@ -284,13 +284,21 @@ describe('getThreadsNeedingPrefetch', () => {
     expect(candidates.find((c) => c.id === 't-no-url')).toBeUndefined()
   })
 
-  it('always returns open threads so closed/merged state is detected on every sync', () => {
-    upsertThreads([makeThread({ id: 't-open', subjectUrl: 'https://api.github.com/repos/a/b/pulls/1' })])
+  it('always returns open PullRequest threads so closure/merge is detected on every sync', () => {
+    upsertThreads([makeThread({ id: 't-open-pr', type: 'PullRequest', subjectUrl: 'https://api.github.com/repos/a/b/pulls/1' })])
     // Simulate a recently completed prefetch that resolved the thread as open.
-    updateThreadContent('t-open', 'open', 'https://github.com/a/b/pull/1')
+    updateThreadContent('t-open-pr', 'open', 'https://github.com/a/b/pull/1')
 
     const candidates = getThreadsNeedingPrefetch()
-    expect(candidates.find((c) => c.id === 't-open')).toBeDefined()
+    expect(candidates.find((c) => c.id === 't-open-pr')).toBeDefined()
+  })
+
+  it('always returns open Issue threads so closure is detected on every sync', () => {
+    upsertThreads([makeThread({ id: 't-open-issue', type: 'Issue', subjectUrl: 'https://api.github.com/repos/a/b/issues/1' })])
+    updateThreadContent('t-open-issue', 'open', 'https://github.com/a/b/issues/1')
+
+    const candidates = getThreadsNeedingPrefetch()
+    expect(candidates.find((c) => c.id === 't-open-issue')).toBeDefined()
   })
 
   it('excludes threads that already resolved as closed', () => {
@@ -307,6 +315,51 @@ describe('getThreadsNeedingPrefetch', () => {
 
     const candidates = getThreadsNeedingPrefetch()
     expect(candidates.find((c) => c.id === 't-merged')).toBeUndefined()
+  })
+
+  // Non-stateful subject types (Commit, Release, Discussion, CheckSuite) lack
+  // a `state` field on their API payload, so prefetchThreadContent falls back
+  // to storing subject_state = 'open'. Those threads must NOT be re-fetched
+  // every sync, or they would generate runaway API traffic forever.
+  it('does not re-fetch non-stateful Commit threads with stored state "open"', () => {
+    upsertThreads([
+      makeThread({ id: 't-commit', type: 'Commit', subjectUrl: 'https://api.github.com/repos/a/b/commits/sha', updatedAt: '2024-01-01T00:00:00Z' }),
+    ])
+    updateThreadContent('t-commit', 'open', 'https://github.com/a/b/commit/sha')
+    // Push content_fetched_at into the future so updated_at <= content_fetched_at
+    db.prepare(
+      `UPDATE notification_threads SET content_fetched_at = '2025-01-01T00:00:00Z' WHERE id = 't-commit'`
+    ).run()
+
+    const candidates = getThreadsNeedingPrefetch()
+    expect(candidates.find((c) => c.id === 't-commit')).toBeUndefined()
+  })
+
+  it('does not re-fetch non-stateful Release threads with stored state "open"', () => {
+    upsertThreads([
+      makeThread({ id: 't-release', type: 'Release', subjectUrl: 'https://api.github.com/repos/a/b/releases/1', updatedAt: '2024-01-01T00:00:00Z' }),
+    ])
+    updateThreadContent('t-release', 'open', 'https://github.com/a/b/releases/tag/v1')
+    db.prepare(
+      `UPDATE notification_threads SET content_fetched_at = '2025-01-01T00:00:00Z' WHERE id = 't-release'`
+    ).run()
+
+    const candidates = getThreadsNeedingPrefetch()
+    expect(candidates.find((c) => c.id === 't-release')).toBeUndefined()
+  })
+
+  it('re-fetches non-stateful threads when updated_at is newer than content_fetched_at', () => {
+    upsertThreads([
+      makeThread({ id: 't-discussion', type: 'Discussion', subjectUrl: 'https://api.github.com/repos/a/b/discussions/1', updatedAt: '2024-01-01T00:00:00Z' }),
+    ])
+    updateThreadContent('t-discussion', 'open', 'https://github.com/a/b/discussions/1')
+    // Push content_fetched_at to BEFORE updated_at to simulate a new event
+    db.prepare(
+      `UPDATE notification_threads SET content_fetched_at = '2023-01-01T00:00:00Z' WHERE id = 't-discussion'`
+    ).run()
+
+    const candidates = getThreadsNeedingPrefetch()
+    expect(candidates.find((c) => c.id === 't-discussion')).toBeDefined()
   })
 })
 

--- a/src/main/db/notifications.ts
+++ b/src/main/db/notifications.ts
@@ -404,24 +404,21 @@ export interface PrefetchCandidate {
 }
 
 /**
- * Clears content_fetched_at for all threads whose subject_state is 'open' or
- * not yet determined (NULL). Called before a manual sync so that prefetch
- * re-verifies the current state of every open thread rather than assuming
- * the cached state is still current.
- */
-export function invalidateOpenThreadPrefetch(): void {
-  getDb()
-    .prepare(
-      `UPDATE notification_threads
-       SET content_fetched_at = NULL, state_checked_at = NULL
-       WHERE subject_state IS NULL OR subject_state = 'open'`
-    )
-    .run()
-}
-
-/**
- * Returns threads whose content has never been fetched, or whose updated_at
- * is newer than the last fetch (meaning a new notification arrived on the thread).
+ * Returns threads that may need a content fetch:
+ *   - subject_state IS NULL (never determined — brand-new thread)
+ *   - subject_state = 'open' (could have closed/merged since last check)
+ *
+ * Closed/merged threads are deleted from the DB on detection, so any thread
+ * still present with state 'closed' or 'merged' is treated as terminal and
+ * not re-fetched.
+ *
+ * GitHub only bumps a notification's `updated_at` when the user is notified
+ * about an event; closing your own PR (or other self-triggered closures)
+ * doesn't always emit a notification, so we cannot rely on `updated_at` to
+ * detect closure. Re-checking every open thread each sync is the only
+ * reliable way to keep the inbox in sync with GitHub. The 429 rate-limit
+ * handler in prefetchThreadContent protects against runaway API usage.
+ *
  * Only returns threads that have a subject_url to fetch from.
  */
 export function getThreadsNeedingPrefetch(): PrefetchCandidate[] {
@@ -430,15 +427,7 @@ export function getThreadsNeedingPrefetch(): PrefetchCandidate[] {
       `SELECT id, subject_url AS subjectUrl, type
        FROM notification_threads
        WHERE subject_url IS NOT NULL
-         AND (
-           content_fetched_at IS NULL
-           OR updated_at > content_fetched_at
-           OR subject_state IS NULL
-           OR (
-             subject_state = 'open'
-             AND (state_checked_at IS NULL OR state_checked_at < datetime('now', '-2 hours'))
-           )
-         )`
+         AND (subject_state IS NULL OR subject_state = 'open')`
     )
     .all() as PrefetchCandidate[]
   return rows

--- a/src/main/db/notifications.ts
+++ b/src/main/db/notifications.ts
@@ -405,19 +405,23 @@ export interface PrefetchCandidate {
 
 /**
  * Returns threads that may need a content fetch:
- *   - subject_state IS NULL (never determined — brand-new thread)
- *   - subject_state = 'open' (could have closed/merged since last check)
  *
- * Closed/merged threads are deleted from the DB on detection, so any thread
- * still present with state 'closed' or 'merged' is treated as terminal and
- * not re-fetched.
+ *   - subject_state IS NULL or content_fetched_at IS NULL (never fetched)
+ *   - updated_at > content_fetched_at (a new event arrived on the thread)
+ *   - PullRequest/Issue threads with subject_state = 'open' (always recheck so
+ *     we detect closure/merge even when GitHub doesn't bump updated_at, e.g.,
+ *     when the user closes their own PR)
  *
- * GitHub only bumps a notification's `updated_at` when the user is notified
- * about an event; closing your own PR (or other self-triggered closures)
- * doesn't always emit a notification, so we cannot rely on `updated_at` to
- * detect closure. Re-checking every open thread each sync is the only
- * reliable way to keep the inbox in sync with GitHub. The 429 rate-limit
- * handler in prefetchThreadContent protects against runaway API usage.
+ * For non-stateful subject types (Commit, Release, Discussion, CheckSuite),
+ * `prefetchThreadContent` falls back to subject_state = 'open' because their
+ * API payloads lack a `state` field. Treating those as "always recheck" would
+ * cause every sync to re-fetch them forever, so they fall through to the
+ * standard updated_at-based gating.
+ *
+ * Closed/merged threads are deleted from the DB on detection, so any survivor
+ * with a terminal state is genuinely terminal and stays excluded. The 429
+ * rate-limit handler in prefetchThreadContent protects against runaway API
+ * usage if the open set grows large.
  *
  * Only returns threads that have a subject_url to fetch from.
  */
@@ -427,7 +431,12 @@ export function getThreadsNeedingPrefetch(): PrefetchCandidate[] {
       `SELECT id, subject_url AS subjectUrl, type
        FROM notification_threads
        WHERE subject_url IS NOT NULL
-         AND (subject_state IS NULL OR subject_state = 'open')`
+         AND (
+           content_fetched_at IS NULL
+           OR subject_state IS NULL
+           OR updated_at > content_fetched_at
+           OR (type IN ('PullRequest', 'Issue') AND subject_state = 'open')
+         )`
     )
     .all() as PrefetchCandidate[]
   return rows

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -19,7 +19,6 @@ import {
   listRepoRules,
   createRepoRule,
   deleteRepoRule,
-  invalidateOpenThreadPrefetch,
 } from './db/notifications'
 import { listRoutingRules, createRoutingRule, deleteRoutingRule, applyRoutingRulesToInbox } from './db/routing-rules'
 import { startNotificationSync, syncOnce, prefetchThreadContent, getSyncIntervalMinutes, setSyncIntervalMinutes, rescheduleSync, getMaxSyncDays, setMaxSyncDays } from './notifications/sync'
@@ -169,10 +168,6 @@ app.whenReady().then(async () => {
     void syncCopilotSessions()
   })
   ipcMain.handle('notifications:sync', async () => {
-    // Reset content_fetched_at for open/unfetched threads so prefetch re-verifies
-    // their current state. This handles threads that were already closed/merged
-    // before they appeared in an incremental sync window.
-    invalidateOpenThreadPrefetch()
     await syncOnce()
     try { await prefetchThreadContent() } catch (err) { console.error('[notifications] Prefetch after manual sync failed:', err) }
     // Keep Copilot sessions in sync with notifications so sidebar dots stay current


### PR DESCRIPTION
The background (partial) sync was leaving closed/merged PRs in the inbox for hours. Example: https://github.com/robert-crandall/dotfiles/pull/7 stayed in the inbox 3+ hours after closure. Manual "Sync" worked because it called `invalidateOpenThreadPrefetch()` to reset state before re-fetching; the background loop had no such reset.

## Root cause

`getThreadsNeedingPrefetch` (src/main/db/notifications.ts) threw a 2-hour throttle on open-thread re-checks:

```sql
subject_state = 'open'
AND (state_checked_at IS NULL OR state_checked_at < datetime('now', '-2 hours'))
```

That throttle was the partial sync's only mechanism for catching a closure when GitHub does **not** bump the thread's `updated_at`. This happens when you close your own PR (or a Copilot agent closes/merges on your behalf): GitHub usually doesn't generate a new notification, the thread's `updated_at` doesn't move, and the `updated_at > content_fetched_at` clause never fires. So the inbox lags by up to ~2 hours (throttle) + one sync interval.

## Fix

Always treat NULL/`open` threads as prefetch candidates:

```sql
WHERE subject_url IS NOT NULL
  AND (subject_state IS NULL OR subject_state = 'open')
```

Closed/merged threads are deleted from the DB on detection (`deleteThread` in `prefetchThreadContent`), so any survivor with a terminal `subject_state` is genuinely terminal and stays excluded. The 429 handler in `prefetchThreadContent` remains the safety net against rate-limit blowouts.

## Knock-on cleanup

- Manual and background sync now have identical re-fetch behavior, so `invalidateOpenThreadPrefetch()` and its call site in the `notifications:sync` IPC handler are removed as dead code.
- Refreshed `getThreadsNeedingPrefetch` integration tests to cover the new contract (open always returned; closed/merged excluded).

## Validation

- `bun run typecheck` clean
- `bun --bun vitest run` — 118/118 pass (including the 25 notification integration tests, 4 of which were rewritten for the new contract)
- Lint has 2 pre-existing errors in `src/main/copilot/github-source.ts` unrelated to this change

## Expected behavior after merge

Within one background sync cycle (default 5 min), any open PR/Issue that has since been closed/merged on GitHub will be auto-removed from inbox and project views, matching what manual Sync already does.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
