### PR TITLE
fix: marking a notification done now removes it from view immediately

### DIFF
--- a/src/main/db/notifications.integration.test.ts
+++ b/src/main/db/notifications.integration.test.ts
@@ -83,11 +83,16 @@ describe('upsertThreads', () => {
     upsertThreads([makeThread({ id: 't-1', unread: true, title: 'Original' })])
     upsertThreads([makeThread({ id: 't-1', unread: false, title: 'Updated', updatedAt: '2024-06-01T00:00:00Z' })])
 
-    const threads = listInboxThreads()
-    expect(threads).toHaveLength(1)
-    expect(threads[0].title).toBe('Updated')
-    expect(threads[0].unread).toBe(false)
-    expect(threads[0].updatedAt).toBe('2024-06-01T00:00:00Z')
+    // Verify the DB row was updated correctly
+    const row = db
+      .prepare('SELECT title, unread, updated_at FROM notification_threads WHERE id = ?')
+      .get('t-1') as { title: string; unread: number; updated_at: string }
+    expect(row.title).toBe('Updated')
+    expect(row.unread).toBe(0)
+    expect(row.updated_at).toBe('2024-06-01T00:00:00Z')
+
+    // A read thread must not appear in the inbox view
+    expect(listInboxThreads()).toHaveLength(0)
   })
 
   it('does not overwrite an existing project_id on re-upsert', () => {
@@ -243,12 +248,14 @@ describe('assignThread', () => {
 // ── markThreadRead ────────────────────────────────────────────────────────────
 
 describe('markThreadRead', () => {
-  it('sets unread = false locally', () => {
+  it('sets unread = false locally and removes the thread from list views', () => {
     upsertThreads([makeThread({ id: 't-1', unread: true })])
     markThreadRead('t-1')
-    const thread = listInboxThreads().find((t) => t.id === 't-1')
-    expect(thread).toBeDefined()
-    // listInboxThreads filters by project_id IS NULL but also the thread should still be there
+
+    // Thread must no longer appear in inbox or project views (read = done)
+    expect(listInboxThreads().find((t) => t.id === 't-1')).toBeUndefined()
+
+    // The underlying DB row should have unread = 0
     const row = db
       .prepare('SELECT unread FROM notification_threads WHERE id = ?')
       .get('t-1') as { unread: number }

--- a/src/main/db/notifications.ts
+++ b/src/main/db/notifications.ts
@@ -87,7 +87,7 @@ export function listThreadsByProject(projectId: number): NotificationThread[] {
   const rows = getDb()
     .prepare(
       `SELECT * FROM notification_threads
-       WHERE project_id = ?
+       WHERE project_id = ? AND unread = 1
        ORDER BY updated_at DESC`
     )
     .all(projectId) as ThreadRow[]
@@ -100,7 +100,7 @@ export function listInboxThreads(): NotificationThread[] {
   const rows = getDb()
     .prepare(
       `SELECT * FROM notification_threads
-       WHERE project_id IS NULL
+       WHERE project_id IS NULL AND unread = 1
        ORDER BY updated_at DESC`
     )
     .all() as ThreadRow[]

--- a/src/main/notifications/sync.ts
+++ b/src/main/notifications/sync.ts
@@ -8,7 +8,7 @@
 
 import { BrowserWindow } from 'electron'
 import { getOctokit, isOctokitReady } from '../auth/octokit'
-import { upsertThreads, getThreadsNeedingPrefetch, updateThreadContent, deleteThread } from '../db/notifications'
+import { upsertThreads, deleteReadThreads, getThreadsNeedingPrefetch, updateThreadContent, deleteThread } from '../db/notifications'
 import { getDb } from '../db'
 import { syncCopilotSessions } from '../copilot/sync'
 import type { NotificationType, SyncIntervalMinutes, MaxSyncDays } from '../../shared/ipc-channels'
@@ -140,6 +140,7 @@ export async function syncOnce(): Promise<void> {
     }))
 
     upsertThreads(threads)
+    deleteReadThreads()
     
     // Persist the fetch start time (not end time) so that notifications
     // arriving during pagination are caught on the next sync cycle.


### PR DESCRIPTION
Two bugs made a dismissed notification come back from the dead.

I had a notification (ID 23862882032) that I marked as done. It disappeared. Then on the next sync it came back, and I couldn't get rid of it. Turns out there were two separate problems conspiring together.

**Bug 1: The list queries had no `unread` filter.**

`listInboxThreads()` and `listThreadsByProject()` returned every thread in the DB regardless of read state. When `markThreadRead()` set `unread = 0`, the IPC handler also emitted `notifications:updated` to refresh badges. That event triggered `load()` in the UI, which re-fetched from DB - and the thread came right back. The optimistic UI removal was immediately overwritten.

**Bug 2: `deleteReadThreads()` was never called.**

Its own JSDoc says "called after each sync" but `syncOnce()` never actually called it. So read threads accumulated in the DB forever and kept reappearing after every sync cycle.

**Fixes:**

- Added `AND unread = 1` to both list queries - read threads are invisible to all views the moment they're dismissed, regardless of the reload
- Added `deleteReadThreads()` call in `syncOnce()` after `upsertThreads()` - DB gets pruned on each cycle, so if GitHub doesn't send a thread back (because you marked it read there too), it's gone

Updated the test for `markThreadRead` to assert the thread is absent from list views (the old test was checking it was *present* after being marked read - which was testing the broken behavior).

Typechecks clean. Didn't run the integration test suite locally because it requires `bun:sqlite` which isn't available in vitest; those tests were already broken before this change.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
