### PR TITLE
fix: auto-remove draft PR notification threads on sync

### DIFF
--- a/src/main/notifications/sync.ts
+++ b/src/main/notifications/sync.ts
@@ -231,22 +231,26 @@ export async function prefetchThreadContent(): Promise<void> {
             html_url: string
             merged?: boolean
             merged_at?: string | null
+            draft?: boolean
           }
 
           const isMerged =
             candidate.type === 'PullRequest' &&
             (data.merged_at != null || data.merged === true)
+          const isDraft = candidate.type === 'PullRequest' && data.draft === true
           const subjectState = isMerged ? 'merged' : (data.state ?? 'open')
           const htmlUrl: string = data.html_url
 
           // Auto-remove resolved threads per PRD M5 spec:
-          // merged PRs, closed PRs (rejected/abandoned), and closed issues
+          // merged PRs, closed PRs (rejected/abandoned), draft PRs, and closed issues
           const shouldRemove =
+            isDraft ||
             (candidate.type === 'Issue' && subjectState === 'closed') ||
             (candidate.type === 'PullRequest' && (subjectState === 'merged' || subjectState === 'closed'))
 
           if (shouldRemove) {
-            console.log(`[notifications] Auto-removing ${candidate.type} thread ${candidate.id} (state: ${subjectState})`)
+            const reason = isDraft ? 'draft' : subjectState
+            console.log(`[notifications] Auto-removing ${candidate.type} thread ${candidate.id} (state: ${reason})`)
             deleteThread(candidate.id)
           } else {
             updateThreadContent(candidate.id, subjectState, htmlUrl)

--- a/src/main/notifications/sync.ts
+++ b/src/main/notifications/sync.ts
@@ -227,7 +227,7 @@ export async function prefetchThreadContent(): Promise<void> {
         try {
           const response = await octokit.request(`GET ${candidate.subjectUrl}`)
           const data = response.data as {
-            state: string
+            state?: string
             html_url: string
             merged?: boolean
             merged_at?: string | null
@@ -250,7 +250,7 @@ export async function prefetchThreadContent(): Promise<void> {
 
           if (shouldRemove) {
             const reason = isDraft ? 'draft' : subjectState
-            console.log(`[notifications] Auto-removing ${candidate.type} thread ${candidate.id} (state: ${reason})`)
+            console.log(`[notifications] Auto-removing ${candidate.type} thread ${candidate.id} (reason: ${reason})`)
             deleteThread(candidate.id)
           } else {
             updateThreadContent(candidate.id, subjectState, htmlUrl)


### PR DESCRIPTION
Auto-remove draft PR notification threads during sync. Draft PRs are work-in-progress and haven't been submitted for review, so surfacing them as actionable notifications adds noise without value.

Treats draft PRs the same as merged/closed threads per the PRD M5 spec: they are removed on the next sync pass. Also adds a `'draft'` reason to the removal log so it's clear why a thread was dropped.

**Changes:**
- Added `draft?: boolean` to the GitHub API response type
- Added `isDraft` detection for PullRequest threads
- `isDraft` is now a removal condition alongside merged/closed
- Log message now shows `'draft'` as the reason when removing a draft thread
