### PR TITLE
Rebuild PRD: ADHD-native reframe + Copilot as the spine

### DIFF
--- a/requirements/milestones-v1-archive.md
+++ b/requirements/milestones-v1-archive.md
@@ -1,0 +1,128 @@
+# Milestones
+
+Each milestone leaves the app in a stable, usable state. Later milestones build on earlier ones without requiring rewrites.
+
+---
+
+## M1 — Project Scaffold
+
+**Goal:** A working Electron + React app that boots, nothing more.
+
+- Electron shell with a single BrowserWindow
+- Vite dev server with hot reload
+- TypeScript configured (`strict`, `strictNullChecks`)
+- SQLite wired up in the main process (`better-sqlite3`)
+- IPC skeleton: typed channel definitions in `src/shared/ipc-channels.ts`
+- Basic migration runner in `db/migrations/`
+- `npm run dev`, `npm run build`, `npm run typecheck` all work
+
+**Shippable signal:** App opens, shows a placeholder UI, no crashes.
+
+---
+
+## M2 — GitHub Authentication
+
+**Goal:** User can connect their GitHub account and the app can make API calls.
+
+- GitHub OAuth flow (main process handles the redirect)
+- Token stored securely (macOS Keychain via `keytar` or equivalent)
+- `@octokit/rest` client instantiated in main process, authenticated
+- IPC channel to expose auth status to renderer
+- Renderer shows "Connect GitHub" → "Connected as @user" state
+- Token refresh / re-auth on expiry
+
+**Shippable signal:** User can authenticate and the app reflects their identity.
+
+---
+
+## M3 — Core Project Management
+
+**Goal:** The app is useful as a standalone project tracker, independent of GitHub.
+
+- `projects` DB table + migrations
+- CRUD IPC channels: `projects:create`, `projects:update`, `projects:delete`, `projects:list`
+- Dashboard view: list of active projects, each showing name + next action
+- Project detail view: name, notes, next action, links (labeled URLs), todo list
+- Todo list: add, check off, reorder, delete tasks (`project_todos` table)
+- Active / Snoozed status field (snooze logic comes in M6)
+- Snoozed projects visible in a collapsed section (static for now)
+
+**Shippable signal:** App is a functional project tracker. GitHub features not yet needed.
+
+---
+
+## M4 — Notification Sync and Routing
+
+**Goal:** GitHub notifications appear in the right project.
+
+- Poll GitHub Notifications API on a configurable interval (main process, fully async)
+- `notification_threads` and `repo_rules` DB tables
+- Notifications stored locally; UI renders from local state only
+- Thread-level mapping: thread → project
+- Repo-level rules: repo → project (lower precedence than thread mapping)
+- Inbox view: unmapped notifications
+- Assign-to-project flow from Inbox
+- Post-assignment repo rule offer (opt-in / opt-out / no offer logic from PRD)
+- Repo rules editable/deletable in Settings
+- Unread count badge on each project in the dashboard
+
+**Shippable signal:** Notifications arrive, route to projects, Inbox captures the rest.
+
+---
+
+## M5 — Thread Lifecycle and Unsubscribe
+
+**Goal:** Closed work disappears automatically; manual unsubscribe works.
+
+- Async content prefetch: after notification list syncs, fetch thread details in background; content populates in-place
+- Content staleness: re-fetch only when a new notification arrives on the thread
+- Thread closure: auto-remove threads when GitHub signals PR merged / issue closed
+- Read state: tracked locally, no write-back to GitHub
+- Unsubscribe: IPC channel calls GitHub API, removes thread locally
+
+**Shippable signal:** Merged PRs and closed issues vanish without user action. Unsubscribe works.
+
+---
+
+## M6 — Snooze
+
+**Goal:** Projects can be silenced until they matter again.
+
+- Three snooze modes: manual, date-based, notification-triggered
+- `snooze_until` and `snooze_mode` fields on `projects` table
+- Background job in main process wakes date-based snoozes
+- Notification-triggered snooze: un-snooze fires when a new notification routes to that project
+- Snoozed projects collapsed on dashboard (was static in M3, now functional)
+
+**Shippable signal:** Snooze works in all three modes end-to-end.
+
+---
+
+## M7 — Notification Filtering
+
+**Goal:** Noise is suppressible at multiple dimensions with a clear hierarchy.
+
+- `filters` DB table (author, org, repo, reason, state, type)
+- Filter evaluation runs in main process before storing/displaying notifications
+- Two-tier type filtering: global floor + per-repo additive rules
+- Renderer: filter management UI with removable chips
+- UI makes global vs. per-repo hierarchy visually explicit
+
+> **Note:** PRD specifies filters are session-scoped in v1. Persist to DB now anyway — session-only is a regression risk and the cost is negligible.
+
+**Shippable signal:** Filtering works across all dimensions; global type floor cannot be overridden per-repo.
+
+---
+
+## M8 — Appearance and Polish
+
+**Goal:** The app feels crafted, not like a default Electron shell.
+
+- Native macOS dark/light mode (`prefers-color-scheme`)
+- At least two built-in themes beyond light/dark
+- Theme switcher in Settings
+- Typography, spacing, and color pass — no default browser/Electron styling visible
+- App icon, window chrome appropriate for macOS
+- No layout jank or flash of unstyled content on launch
+
+**Shippable signal:** All 10 success criteria from the PRD are met. App is ready to use daily.

--- a/requirements/milestones.md
+++ b/requirements/milestones.md
@@ -43,7 +43,7 @@ Order rule: don't build the brain UI (C) on an unproven resolver, and don't buil
 
 **Goal:** hand the tedious finish to Copilot and get re-oriented on the result.
 
-- Launch a `gh agent-task` from a next-action / todo / notification (evolves current read-only `copilot/`).
+- Launch a `gh agent-task` from a next-action / todo / notification (evolves current read-only `src/main/copilot/`).
 - Track in the shared session model; rail status dot; result folded into the digest.
 - Read-only vs. GitHub beyond launch + unsubscribe.
 

--- a/requirements/milestones.md
+++ b/requirements/milestones.md
@@ -1,128 +1,88 @@
-# Milestones
+# Milestones (staged gates)
 
-Each milestone leaves the app in a stable, usable state. Later milestones build on earlier ones without requiring rewrites.
+Smallest-first. Each gate ships daily personal value on its own. Two independent tracks converge:
+- **Track 1 (no brain dependency):** MVP A (focus + re-entry) → MVP B (cloud-agent loop). Worth shipping even if the resolver never pans out.
+- **Track 2 (gated on Gate 0):** the resolver proof → MVP C (brain in-app) → MVP D (embedded agent, last, behind validations).
 
----
+Order rule: don't build the brain UI (C) on an unproven resolver, and don't build the agent platform (D) before the cheaper value lands. A/B and Gate 0 can proceed in parallel.
 
-## M1 — Project Scaffold
-
-**Goal:** A working Electron + React app that boots, nothing more.
-
-- Electron shell with a single BrowserWindow
-- Vite dev server with hot reload
-- TypeScript configured (`strict`, `strictNullChecks`)
-- SQLite wired up in the main process (`better-sqlite3`)
-- IPC skeleton: typed channel definitions in `src/shared/ipc-channels.ts`
-- Basic migration runner in `db/migrations/`
-- `npm run dev`, `npm run build`, `npm run typecheck` all work
-
-**Shippable signal:** App opens, shows a placeholder UI, no crashes.
+> The v1 app's milestone plan is archived at `milestones-v1-archive.md`.
 
 ---
 
-## M2 — GitHub Authentication
+## Gate 0 - Resolver spike (proof, throwaway UI)
 
-**Goal:** User can connect their GitHub account and the app can make API calls.
+**Goal:** prove the "project brain" is real before building anything around it.
 
-- GitHub OAuth flow (main process handles the redirect)
-- Token stored securely (macOS Keychain via `keytar` or equivalent)
-- `@octokit/rest` client instantiated in main process, authenticated
-- IPC channel to expose auth status to renderer
-- Renderer shows "Connect GitHub" → "Connected as @user" state
-- Token refresh / re-auth on expiry
+- Pick one real project; ingest ~25 real dashboards/queries as typed records with known-correct answers.
+- Build the minimal resolver + context assembler (no app shell).
+- **Define the pass rubric before writing resolver code:** fixed corpus, expected source ID per question, target % right-source, target % correct "no source saved" on negatives, and correct clarify-or-top-candidates behavior on ambiguous queries.
+- Run the eval set (~20 fuzzy questions + deliberate negative/ambiguous cases); keep it as a regression harness in the repo.
 
-**Shippable signal:** User can authenticate and the app reflects their identity.
+**Kill criterion (scoped):** if the resolver can't clear the rubric, stop and rethink the brain **before building MVP C or D**. It does *not* block MVP A/B - the focus shell, re-entry, and cloud-agent loop are worth shipping regardless.
 
----
-
-## M3 — Core Project Management
-
-**Goal:** The app is useful as a standalone project tracker, independent of GitHub.
-
-- `projects` DB table + migrations
-- CRUD IPC channels: `projects:create`, `projects:update`, `projects:delete`, `projects:list`
-- Dashboard view: list of active projects, each showing name + next action
-- Project detail view: name, notes, next action, links (labeled URLs), todo list
-- Todo list: add, check off, reorder, delete tasks (`project_todos` table)
-- Active / Snoozed status field (snooze logic comes in M6)
-- Snoozed projects visible in a collapsed section (static for now)
-
-**Shippable signal:** App is a functional project tracker. GitHub features not yet needed.
+**Uses:** MCP tools directly. Needs none of the embedded-agent machinery.
 
 ---
 
-## M4 — Notification Sync and Routing
+## MVP A - Single-focus shell + re-entry
 
-**Goal:** GitHub notifications appear in the right project.
+**Goal:** the app is worth opening daily even with zero agent features.
 
-- Poll GitHub Notifications API on a configurable interval (main process, fully async)
-- `notification_threads` and `repo_rules` DB tables
-- Notifications stored locally; UI renders from local state only
-- Thread-level mapping: thread → project
-- Repo-level rules: repo → project (lower precedence than thread mapping)
-- Inbox view: unmapped notifications
-- Assign-to-project flow from Inbox
-- Post-assignment repo rule offer (opt-in / opt-out / no offer logic from PRD)
-- Repo rules editable/deletable in Settings
-- Unread count badge on each project in the dashboard
+- Primer-inspired token layer stood up (drop DaisyUI); light + dark.
+- Single-focus home: one project front-and-center; others are rail landmarks + ⌘K.
+- Re-entry digest from **existing** notification/session data (no new agent needed).
+- Parked vs. drifting classification; gentle resurfacing that doesn't rely on ⌘K.
+- All I/O off the render thread; undo on destructive actions.
 
-**Shippable signal:** Notifications arrive, route to projects, Inbox captures the rest.
+**Shippable signal:** I open it, see one thing, get caught up, and nothing nags.
 
 ---
 
-## M5 — Thread Lifecycle and Unsubscribe
+## MVP B - Cloud-agent completion loop
 
-**Goal:** Closed work disappears automatically; manual unsubscribe works.
+**Goal:** hand the tedious finish to Copilot and get re-oriented on the result.
 
-- Async content prefetch: after notification list syncs, fetch thread details in background; content populates in-place
-- Content staleness: re-fetch only when a new notification arrives on the thread
-- Thread closure: auto-remove threads when GitHub signals PR merged / issue closed
-- Read state: tracked locally, no write-back to GitHub
-- Unsubscribe: IPC channel calls GitHub API, removes thread locally
+- Launch a `gh agent-task` from a next-action / todo / notification (evolves current read-only `copilot/`).
+- Track in the shared session model; rail status dot; result folded into the digest.
+- Read-only vs. GitHub beyond launch + unsubscribe.
 
-**Shippable signal:** Merged PRs and closed issues vanish without user action. Unsubscribe works.
+**Shippable signal:** I delegate a boring task, walk away, and the digest tells me when it's done.
 
 ---
 
-## M6 — Snooze
+## MVP C - Project brain in the app (the heart)
 
-**Goal:** Projects can be silenced until they matter again.
+**Goal:** ship Gate 0's proven resolver as a real feature. **No embedded agent required.**
 
-- Three snooze modes: manual, date-based, notification-triggered
-- `snooze_until` and `snooze_mode` fields on `projects` table
-- Background job in main process wakes date-based snoozes
-- Notification-triggered snooze: un-snooze fires when a new notification routes to that project
-- Snoozed projects collapsed on dashboard (was static in M3, now functional)
+- Resource registry (typed records + provenance/health) in SQLite.
+- Capture: paste/drop URL → proposed typed record → one-tap accept (undoable).
+- Retrieve: ask in English → cited answer, run via wired MCP when available.
+- Maintenance-by-use: failures mark records suspect; stale surfaces only when relevant.
+- Auto-grouped browse view; overrides rare + visible.
 
-**Shippable signal:** Snooze works in all three modes end-to-end.
-
----
-
-## M7 — Notification Filtering
-
-**Goal:** Noise is suppressible at multiple dimensions with a clear hierarchy.
-
-- `filters` DB table (author, org, repo, reason, state, type)
-- Filter evaluation runs in main process before storing/displaying notifications
-- Two-tier type filtering: global floor + per-repo additive rules
-- Renderer: filter management UI with removable chips
-- UI makes global vs. per-repo hierarchy visually explicit
-
-> **Note:** PRD specifies filters are session-scoped in v1. Persist to DB now anyway — session-only is a regression risk and the cost is negligible.
-
-**Shippable signal:** Filtering works across all dimensions; global type floor cannot be overridden per-repo.
+**Shippable signal:** "how's mesh latency?" answers from the brain, with a citation, instead of a bookmark hunt.
 
 ---
 
-## M8 — Appearance and Polish
+## MVP D - Embedded local agent (last, gated)
 
-**Goal:** The app feels crafted, not like a default Electron shell.
+**Goal:** the "sit and steer" spine - only after the validations pass.
 
-- Native macOS dark/light mode (`prefers-color-scheme`)
-- At least two built-in themes beyond light/dark
-- Theme switcher in Settings
-- Typography, spacing, and color pass — no default browser/Electron styling visible
-- App icon, window chrome appropriate for macOS
-- No layout jank or flash of unstyled content on launch
+**Precondition:** validations 2-6 in the PRD (SDK availability, CLI auth/bundling, worktree ergonomics, permission coverage, MCP wiring) clear. If the SDK path fails, this degrades to a richer cloud-agent experience and the brain still stands.
 
-**Shippable signal:** All 10 success criteria from the PRD are met. App is ready to use daily.
+- Backend port + `copilot-local` backend (SDK/CLI subprocess).
+- Turn normalizer → throttled `session:view` snapshots; state-machine-driven UI.
+- Scoped inline permission cards.
+- Transcript persistence + re-hydrate on resume.
+- Per-project worktree sandbox.
+
+**Shippable signal:** I start a local turn scoped to a project, watch it stream, approve tools inline, and pick it back up later re-oriented.
+
+---
+
+## Cross-cutting (lands across gates, not a big-bang)
+
+- Notifications: sync / route / filter / auto-close / unsubscribe - carried from v1, demoted behind ⌘K + the Notifications tab. (Feeds MVP A's digest.)
+- Snooze: three modes, no nagging. (Ties into MVP A's parked/drifting.)
+- Design system: extra theme modes (dim / high-contrast) + polish. Deliberately not gating the cognition-layer proof.

--- a/requirements/milestones.md
+++ b/requirements/milestones.md
@@ -10,7 +10,7 @@ Order rule: don't build the brain UI (C) on an unproven resolver, and don't buil
 
 ---
 
-## Gate 0 - Resolver spike (proof, throwaway UI)
+## Gate 0 - Resolver spike (proof, not shippable)
 
 **Goal:** prove the "project brain" is real before building anything around it.
 

--- a/requirements/prd-v1-archive.md
+++ b/requirements/prd-v1-archive.md
@@ -1,0 +1,177 @@
+# Product Requirements Document: GH Projects (Working Title)
+
+**Target User:** Solo developer with ADHD, managing personal projects with heavy GitHub involvement  
+**Platform:** macOS desktop app (Electron + React, SQLite)
+
+---
+
+## What This App Is
+
+A personal project management tool for developers. It answers the question "what am I working on and what do I need to do next?" — and, as a second-order capability, it surfaces GitHub notifications in the context of the projects they belong to.
+
+This is not a GitHub notification manager. GitHub notifications are one input into a project-centric view of your work.
+
+---
+
+## Design Principles
+
+- **Project-first.** The app opens to your projects, not your notifications.
+- **Aesthetically considered.** Native dark/light mode, theme support, and a UI that feels crafted — not utilitarian. The visual quality of the app is a feature.
+- **Non-blocking.** All network I/O (GitHub sync, notification fetch, content prefetch) is async and happens behind the scenes. The UI is never waiting on the network.
+- **Low friction.** State management is simple. Features that require ongoing manual upkeep are a red flag.
+
+---
+
+## Core Concepts
+
+### Projects
+The primary unit of the app. A project is a container for your work context and anything related to it.
+
+Each project has:
+- **Name**
+- **Notes** — free-form text for context, requirements, links to docs, etc.
+- **Next action** — a short text field; single most important next step
+- **Todo list** — a lightweight ordered task list scoped to this project
+- **Links** — a labeled URL list (e.g., "Staging", "Figma", "Linear board")
+- **GitHub notifications** — threaded notifications routed to this project
+- **Status** — Active or Snoozed
+
+### Inbox
+Notifications that have arrived but haven't been assigned to a project yet. The inbox is a first-class view, not a fallback bucket.
+
+### Notification Threads
+The app tracks GitHub notifications at the thread level. Each thread belongs to at most one project (or sits in the inbox if unmapped).
+
+### Routing Rules
+Two-tier system for routing incoming notifications to projects:
+- **Thread-level mapping** — explicit: this thread goes to this project
+- **Repo-level rule** — implicit: all notifications from this repo go to this project (unless a thread-level mapping overrides it)
+
+Precedence: thread-level > repo-level > inbox.
+
+---
+
+## Features
+
+### 1. Project Management
+
+Users can create, edit, and delete projects. Within a project, they can:
+- Edit the name, notes, next action, and links at any time
+- Manage a todo list (add, check off, reorder, delete tasks)
+- View all GitHub notification threads routed to this project
+- Snooze the project
+
+The dashboard shows all active projects with their next action and unread notification count. Snoozed projects are visible in a collapsed section.
+
+### 2. GitHub Integration
+
+**Authentication:** GitHub OAuth.
+
+**Notification sync:** Polls the GitHub Notifications API on a configurable interval. Sync is fully async — the app never blocks on it.
+
+**Async content prefetch:** After the notification list syncs, notification content (thread details) is fetched in the background. The list renders immediately from local data; fetched content populates in place. Content is considered stale only when a new notification arrives on that thread.
+
+**Thread closure:** When GitHub signals that a thread is resolved — PR merged, issue closed, etc. — the thread is automatically removed from view globally. No acknowledgment, no archive step, just gone. Unsubscribe (write-back to GitHub API) is the manual equivalent.
+
+**Read state:** Tracked locally. Marking a notification read does not write back to GitHub.
+
+**Unsubscribe:** Calls the GitHub API to unsubscribe from a thread, which also closes it locally.
+
+### 3. Inbox and Routing
+
+When a notification arrives from an unmapped thread:
+- It appears in the Inbox
+- The user assigns it to a project (or creates a new one)
+- The app records the thread → project mapping for future notifications on that thread
+
+After assigning a thread, the app evaluates whether to offer a repo-level rule:
+- **No other mapped threads from that repo:** Offer an opt-in — "Always route [repo] to [project]?"
+- **All other threads from that repo already go to the same project:** Offer an opt-out (pre-checked) — pattern is already established
+- **Threads from that repo are split across projects:** No offer — thread-level mapping is appropriate
+
+If a repo rule is created, the user can optionally migrate already-mapped threads from that repo to the new rule.
+
+Repo-level rules can be edited and deleted from Settings.
+
+### 4. Notification Filtering
+
+Filters suppress notifications from appearing anywhere in the app. Filtering operates on multiple dimensions:
+
+| Dimension | Match type |
+|-----------|-----------|
+| Author | Substring (case-insensitive) |
+| Org | Substring |
+| Repo | Substring |
+| Reason | Select (enum) |
+| State | Select (enum) |
+| Type | Select (enum) |
+
+Multiple filters combine with AND logic. Active filters are displayed as removable chips.
+
+**Two-tier type filtering:**
+- **Global rules** are a non-overridable floor. A notification type suppressed globally is suppressed everywhere.
+- **Per-repo rules** are strictly additive. A repo rule can suppress additional types beyond the global set; it cannot un-suppress a globally suppressed type.
+
+The UI makes this hierarchy visually explicit.
+
+Filters are session-scoped in v1.
+
+### 5. Snooze
+
+Projects can be snoozed in three modes:
+- **Manual** — hidden until the user manually un-snoozes
+- **Date-based** — hidden until a specific date, then auto-surfaced
+- **Notification-triggered** — hidden until a new GitHub notification arrives for this project
+
+Snoozed projects appear in a collapsed section of the dashboard.
+
+### 6. Appearance
+
+- Native macOS dark/light mode support
+- Theme support (multiple built-in themes, at minimum)
+- UI is visually distinctive — not a default Electron app
+
+---
+
+## Technical Constraints
+
+- **Platform:** macOS only (Electron app bundle)
+- **Frontend:** React
+- **Backend:** Node.js (Electron main process)
+- **Data:** SQLite (local, no server)
+- **API:** GitHub REST API v3
+
+All GitHub API calls and DB writes happen off the render thread. The UI never blocks on I/O.
+
+---
+
+## Out of Scope
+
+- GitHub write-back beyond unsubscribe
+- Multi-user or team features
+- Mobile
+- Integrations beyond GitHub
+- Gantt charts, sprints, velocity, or any "enterprise PM" concepts
+
+---
+
+## Success Criteria
+
+The app is shippable when:
+
+1. User can authenticate with GitHub and pull notifications
+2. Notifications are routed to projects via thread and repo rules
+3. Unmapped notifications surface in the Inbox
+4. Projects display name, notes, next action, todo list, links, and notifications
+5. Closed/merged threads disappear automatically
+6. Unsubscribe works
+7. Filtering works across all specified dimensions with global/per-repo type hierarchy
+8. Snooze works in all three modes
+9. Dark/light mode and at least one theme variant work correctly
+10. No UI lockup — all network I/O is async
+
+**Success looks like:**
+- Opening the app tells you what you're working on and what to do next
+- GitHub notifications appear where they're relevant, not as a firehose
+- Snoozed work stays invisible until it matters
+- The app feels good to use

--- a/requirements/prd.md
+++ b/requirements/prd.md
@@ -8,7 +8,7 @@
 
 ---
 
-## Read this first (the whole thing in 8 bullets)
+## Read this first (the whole thing in 9 bullets)
 
 - The old app was a **project-centric notification manager**. That framing quietly fights how I think.
 - The real problem isn't missed notifications. It's **losing the thread** - I hyperfocus, drop a thing thinking "back in 2h," lose days, and shame makes re-entry hard.
@@ -26,7 +26,7 @@
 
 The v1 problem statement: "what am I working on and what do I do next?" - answered with a project dashboard + a GitHub notification router.
 
-Held against my [ADHD Profile] and [Cognitive Interface Model], three things are wrong at the *problem* layer, not the feature layer:
+Held against my *ADHD Profile* and *Cognitive Interface Model*, three things are wrong at the *problem* layer, not the feature layer:
 
 | v1 assumption | What my profiles actually say | Implication |
 |---|---|---|

--- a/requirements/prd.md
+++ b/requirements/prd.md
@@ -1,177 +1,344 @@
-# Product Requirements Document: GH Projects (Working Title)
+# Product Requirements Document: Focus (working title)
 
-**Target User:** Solo developer with ADHD, managing personal projects with heavy GitHub involvement  
-**Platform:** macOS desktop app (Electron + React, SQLite)
+> Rebuild of "GH Projects." The v1 PRD is preserved at `prd-v1-archive.md`.
+> Working title only - naming genuinely doesn't matter yet (candidates: Focus, Throughline, Workbench). Pick later.
 
----
-
-## What This App Is
-
-A personal project management tool for developers. It answers the question "what am I working on and what do I need to do next?" — and, as a second-order capability, it surfaces GitHub notifications in the context of the projects they belong to.
-
-This is not a GitHub notification manager. GitHub notifications are one input into a project-centric view of your work.
+**Target user:** Solo developer with ADHD, running several personal projects with heavy GitHub + Copilot involvement.
+**Platform:** macOS desktop (Electron + React + TypeScript + SQLite).
 
 ---
 
-## Design Principles
+## Read this first (the whole thing in 8 bullets)
 
-- **Project-first.** The app opens to your projects, not your notifications.
-- **Aesthetically considered.** Native dark/light mode, theme support, and a UI that feels crafted — not utilitarian. The visual quality of the app is a feature.
-- **Non-blocking.** All network I/O (GitHub sync, notification fetch, content prefetch) is async and happens behind the scenes. The UI is never waiting on the network.
-- **Low friction.** State management is simple. Features that require ongoing manual upkeep are a red flag.
+- The old app was a **project-centric notification manager**. That framing quietly fights how I think.
+- The real problem isn't missed notifications. It's **losing the thread** - I hyperfocus, drop a thing thinking "back in 2h," lose days, and shame makes re-entry hard.
+- A dashboard of *N projects with counts* is the exact "6 unrelated items" surface that de-motivates me.
+- So the rebuild does three ADHD-native jobs: **hold one thing** · **re-orient me on return** · **absorb the tedious finish**.
+- The home is **one project in focus**, not a grid. Everything else is one keystroke away.
+- On open, a **"since you were last here"** digest catches me up - blame-free, no streaks, no time-shaming.
+- **Copilot is the spine, not a status dot.** Two modes: delegate-and-walk-away (cloud agent) and sit-and-steer (embedded local agent chat).
+- Projects accumulate **hundreds** of dashboards, queries, and docs. I won't remember them and I won't curate bookmarks - so the agent holds a per-project **context brain** and I retrieve by *asking* ("how's the service mesh latency?"), not by navigating a list.
+- Notifications, inbox, routing, filters all still exist - demoted to *supporting inputs* behind a quick-switcher.
 
 ---
 
-## Core Concepts
+## Why rebuild (the reframe)
 
-### Projects
-The primary unit of the app. A project is a container for your work context and anything related to it.
+The v1 problem statement: "what am I working on and what do I do next?" - answered with a project dashboard + a GitHub notification router.
 
-Each project has:
-- **Name**
-- **Notes** — free-form text for context, requirements, links to docs, etc.
-- **Next action** — a short text field; single most important next step
-- **Todo list** — a lightweight ordered task list scoped to this project
-- **Links** — a labeled URL list (e.g., "Staging", "Figma", "Linear board")
-- **GitHub notifications** — threaded notifications routed to this project
-- **Status** — Active or Snoozed
+Held against my [ADHD Profile] and [Cognitive Interface Model], three things are wrong at the *problem* layer, not the feature layer:
 
-### Inbox
-Notifications that have arrived but haven't been assigned to a project yet. The inbox is a first-class view, not a fallback bucket.
+| v1 assumption | What my profiles actually say | Implication |
+|---|---|---|
+| A dashboard of all projects orients me | "Avoid surfaces like 'you have 6 pending items across 6 areas' - actively de-motivating." Uncoupled complexity is shallow + irritating. | Default to **one** focus. Others behind a switcher, not a competing grid. |
+| The job is routing notifications | The job is not losing the thread. Time blindness turns "back in 2h" into 3 days; I over-trust recall. | The app is **insurance for my context** + **re-entry**, not a firehose. |
+| Nothing addresses finishing | My hardest part is the last 10% (tests, review nits, lint, docs). Boredom (not difficulty) ends tasks. | Hand the tedious finish to **Copilot**. That's the point of the integration. |
+| A PM tool is inherently helpful | Meta-work watch item: building trackers can *become* the avoidance task. | **Zero grooming.** Auto-capture, auto-route, auto-close. If it needs upkeep, it fails. |
 
-### Notification Threads
-The app tracks GitHub notifications at the thread level. Each thread belongs to at most one project (or sits in the inbox if unmapped).
+---
 
-### Routing Rules
-Two-tier system for routing incoming notifications to projects:
-- **Thread-level mapping** — explicit: this thread goes to this project
-- **Repo-level rule** — implicit: all notifications from this repo go to this project (unless a thread-level mapping overrides it)
+## Design principles (derived from the profiles, not invented)
 
-Precedence: thread-level > repo-level > inbox.
+- **One primary thing.** Calm surface, vim-not-Bloomberg. The focus fills the screen; the rest is a keystroke away.
+- **Protect against tedium, not difficulty.** Keep easy paths instant. Never add hand-holding to routine flows. Let hard things stay hard.
+- **External state is insurance.** Persist my working context automatically; never rely on my recall.
+- **Capture without hand-filing; let the machine hold the structure - but keep decay visible.** Never make me build or groom a taxonomy of tags/folders. I dump; the agent enriches, files, and groups; I interact by asking. But the brain has a half-life - so surface staleness *in context when it's relevant* (a failed lookup, a broken link) rather than pretending the system self-heals or handing me a chore list.
+- **Re-orient on return.** Actively catch me up ("here's where you were, here's what changed"), don't silently restore and leave me to reconstruct.
+- **Blame-free re-entry.** No streaks, no "you haven't touched this in 12 days," no guilt. Stale work waits quietly and greets me warmly.
+- **Undo over confirmation.** Recoverable by design (soft-delete everywhere). Reserve hard confirms for the genuinely unrecoverable.
+- **Verdict + tradeoffs.** Surfaces that decide (routing, "what next") lead with a recommendation, with the trade space underneath.
+- **Vanilla defaults, all overridable.** Standard choices as a relief; every default visible and changeable.
+- **Explicit-but-terse success; verbose failure.** A checkmark when it worked; full diagnostics when it broke. Instant signal.
+- **Scannable by default.** Bullets, short chunks, strong headings. Never gate comprehension behind a wall of prose.
+- **Click-first, shortcuts as reward.** Mouse-friendly discovery; hotkeys accelerate once fluent; nothing core gated behind a chord.
+- **Automate anything done twice.** Repeated workflows are scriptable (routing rules, agent launch templates, snooze).
+
+---
+
+## The shape of the app
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  ⌘K quick-switcher (projects · inbox · settings · new)        │
+├───────────────┬──────────────────────────────────────────────┤
+│               │  SINCE YOU WERE HERE                          │
+│  Focus rail   │  • Copilot finished 2 turns on #142           │
+│  (thin,       │  • PR #131 is now ready to review             │
+│  collapsible) │  • 3 new notifications routed here            │
+│               ├──────────────────────────────────────────────┤
+│  ● project A  │  NEXT ACTION                                  │
+│  ○ project B  │  Wire the retry backoff into the sync loop    │
+│  ○ project C  │  [ Hand to Copilot ]  [ Edit ]  [ Done ]      │
+│               ├───────────────┬──────────────────────────────┤
+│  inbox (2)    │  Todos/Notes  │  Copilot (embedded agent)     │
+│               │  Resources ⌕  │  live streaming · tool status │
+│               │  Notifications│  inline permission cards      │
+└───────────────┴───────────────┴──────────────────────────────┘
+```
+
+- **Focus rail (left, thin):** the projects list as *landmarks*, not a dashboard. One is in focus at a time. Small status dot per project (agent working / needs you / quiet). Inbox pinned at the bottom. Collapsible so the focus can go full-bleed.
+- **Re-entry digest (top of focus):** the signature feature. See below.
+- **Next action (center):** one line, big, editable inline. Primary button: **Hand to Copilot**. Secondary: Edit, Done.
+- **Working column:** Todos · Notes (scratch) · **Resources** (ask-first, see below) · Notifications for this project, as tabs. Progressive disclosure - operating shows the whole territory, but only for the *one* focus.
+- **Copilot panel (right):** the embedded agent conversation scoped to this project. This is the Scout-style spine (details below).
+- **⌘K quick-switcher:** everything not the focus - jump projects, open inbox, settings, new project, launch a task. Keeps the surface calm while making the whole territory a keystroke away.
+
+Nothing here forces me to hold several unrelated projects in my head at once. The focus is deep and coupled; the rest is a landmark I navigate to.
+
+---
+
+## Core concepts
+
+### Project (unchanged in essence, re-centered)
+Container for one body of work: name, notes (freeform scratch), next action, todo list, a **project context brain + resource corpus** (see below), routed notifications, and **agent sessions**. Status: active / snoozed. Exactly one project is *in focus* at a time.
+
+### Project Context & Resources (the "project brain")
+Replaces the flat links list, and it's arguably the strongest reason to rebuild. **The load-bearing piece is the resolver, not a markdown doc** - "put my notes in the agent's context" would just be a fancy notes field. Three parts:
+
+- **Project card (tiny, always in context).** A short, structured brief per project: purpose, repos, services, active goal, key aliases/glossary. This is the *only* thing injected into the agent every turn. Small and stable - it changes rarely. Its fields are **suggested/updated as a byproduct of use** (the agent proposes an alias or a shifted "active goal" from what I actually ask and what resolves), so it doesn't quietly become its own manual-upkeep chore.
+- **Resource registry (typed, retrieved on demand).** Each dashboard / saved query / doc / repo / link is a typed record, not a bookmark:
+  `{ title, kind, url-or-query, service/system, env, aliases[], description, provenance, confidence, last_used, last_verified, failure_count }`.
+  Hundreds of these are fine because they are **never all injected** - the resolver pulls only the top matches for a given question.
+- **Resolver.** Maps fuzzy language → the right record(s). "Service mesh latency" → the mesh-latency Datadog dashboard for *this* service/env. It returns a scored, **cited** answer, runs the source via a wired MCP tool when possible, and says **"no source saved for that"** instead of guessing. **On low confidence or a near-tie it asks a one-line clarifying question or shows the top candidates - a cited-but-wrong answer is worse than "not sure, is it X or Y?"** Suspect / low-confidence records are **down-ranked, not just labeled**. This is the part I have to get right; it is where prior attempts failed.
+
+Interaction model (this is the whole point):
+
+- **Retrieve by question, not navigation.** I ask in English; the resolver picks the source (with a citation I can inspect), runs it via the wired MCP tool (Datadog / Splunk / Kusto) when one exists, and answers with the live value + link. "How's the service mesh latency?" → "p99 240ms, +15% d/d - [dashboard]," not "here's your bookmark." No confident answer without a cited source.
+- **Capture as a byproduct of use.** Paste/drop a URL → the agent proposes a typed record (title, service, description) for one-click accept (undoable). Save a query straight from chat. I never hand-file into folders.
+- **Maintenance as a byproduct of use, not a chore.** Every record carries `last_used` / `last_verified` / `confidence` / `failure_count`. When a retrieval fails or a link/query breaks, the record is marked *suspect* automatically. Stale records surface **only when they're relevant to what I'm asking**, never as a to-do list of chores. The agent may propose corrections; semantic rewrites of important mappings need my one-tap approval. (Honest about the profile's "every system has a half-life" - the brain decays; the design makes decay visible in-context instead of pretending it's self-healing.)
+- **Browse an auto-derived hierarchy.** When I want the visual/spatial map, resources are grouped (by tool / service / derived topic). Grouping is **computed, not maintained**. Overrides (pin/rename a group) are rare and visible - so tags don't quietly become grooming.
+
+**Verdict on the user's hierarchy vs. tags question:** neither, as a thing I maintain. The primary interface is the *question* answered by the resolver; structure is agent-derived and powers browsing only. This resolves the profile tension (I love hierarchy, but I can't sustain grooming) by putting the machine in charge of structure - but with honest decay signals rather than a false "self-maintaining" promise.
+
+### Focus
+The single project currently front-and-center. Switching focus is cheap (⌘K or click a rail item) and recomputes the re-entry digest for the newly-focused project.
+
+### Re-entry digest ("Since you were here")
+A computed, blame-free catch-up shown at the top of a focus when I return after being away. Sources:
+- Agent turns completed / awaiting my input / PRs opened or merged.
+- Notifications that routed here since last seen.
+- Todos the agent checked off; files it changed.
+- Never phrased as time-shame ("gone 3 days"). Phrased as orientation ("here's what moved").
+Dismissable; regenerates from a per-project `last_seen_at` watermark.
+
+### Parked vs. forgotten (peripheral memory)
+Single-focus has a real failure mode for a time-blind person: out of sight, out of mind. The re-entry digest catches me up on the *focused* project, but something has to keep the *unfocused* ones from silently rotting. So the app distinguishes two states and never conflates them:
+
+- **Parked (intentional):** I snoozed it, or set it aside on purpose. Quiet. Resurfaces on its own terms (date / notification / manual).
+- **Drifting (accidental):** an active project I simply haven't returned to. The app *knows* the difference via last-touched + whether I ever chose to park it.
+
+Resurfacing rules (blame-free, no counts, no streaks):
+- Rail landmarks show **quiet status** (a dot: agent working / needs you / drifting), not unread counts.
+- A gentle, periodic **"threads you left open"** review surfaces drifting projects - framed as orientation ("still want this warm?"), never guilt.
+- **Suppression is explicit:** each surfaced thread has one-tap park / snooze / "not now," and there's a frequency cap so resurfacing can never become a nag. Parking something moves it from drifting → parked (intentional).
+- Resurfacing does **not** depend on me remembering to open ⌘K. The app brings a drifting thread back into view on its own.
+
+This is the deliberate answer to "won't single-focus make me forget everything else?" - the machine holds the periphery so I don't have to.
+
+### Agent session (the Copilot spine)
+A unit of Copilot work attached to a project. Two sources, **one session model + one state machine**:
+
+1. **Local embedded agent (interactive - "sit and steer")**
+   - Runs the **Copilot CLI as a subprocess** via `@github/copilot-sdk`, cwd = the project's local repo/worktree.
+   - Live: streaming text, in-flight tool-status row, reasoning, token usage.
+   - **Inline permission cards** (not modal dialogs) for tool actions: allow / allow-for-session / always-allow (persists a *pattern*, not a literal) / deny.
+   - This is where I *work with* the agent on the interesting, coupled problem.
+
+2. **Cloud agent task (delegate - "walk away")**
+   - The existing `gh agent-task` path. Launch from a next-action / todo / notification, then leave.
+   - It surfaces back through the re-entry digest and the rail status dot when it's done or needs me.
+   - This is where I offload the tedious **last 10%**.
+
+Both are `AgentSession` rows with a shared status machine:
+`idle → submitted → streaming → waiting(needs input / needs approval) → done | error`
+(cloud maps `in_progress → waiting → pr_ready → completed` onto the same shape).
+
+### Inbox / routing / filters (demoted, not deleted)
+Unmapped notifications land in the Inbox (behind ⌘K, not on the home). Routing precedence unchanged: thread mapping > repo rule > inbox. Filters (author/org/repo/reason/state/type, AND logic, global floor + per-repo additive) unchanged. These are *inputs* that feed the digest and can spawn agent work - not the main surface.
 
 ---
 
 ## Features
 
-### 1. Project Management
+### 1. Focus & navigation
+- Home opens to the last-focused project (or a gentle empty state if none).
+- Focus rail lists projects as landmarks with a status dot; inbox pinned at bottom; collapsible.
+- ⌘K quick-switcher: fuzzy jump to any project, inbox, settings; create project; launch a task. Click-first; the shortcut is the reward.
+- Switching focus recomputes the re-entry digest.
 
-Users can create, edit, and delete projects. Within a project, they can:
-- Edit the name, notes, next action, and links at any time
-- Manage a todo list (add, check off, reorder, delete tasks)
-- View all GitHub notification threads routed to this project
-- Snooze the project
+### 2. Re-entry digest
+- Auto-computed on focus open from the `last_seen_at` watermark.
+- Groups: agent activity · PR/issue state changes · new notifications · todos closed by agents.
+- Blame-free copy; scannable bullets; one-click to the relevant thing (open PR, open agent panel, view notification).
+- Dismiss updates the watermark. Fully recoverable (watermark is data, resettable).
 
-The dashboard shows all active projects with their next action and unread notification count. Snoozed projects are visible in a collapsed section.
+### 3. Project management
+- Create/edit/delete (soft-delete, undoable) projects.
+- Inline-edit name, next action, notes. Todo list: add / check / reorder / delete, done items sink.
+- Notes are freeform scratch - the native offload format, not a rigid form.
 
-### 2. GitHub Integration
+### 4. Project context & resource retrieval (the new heart)
+- **Project card** (tiny, structured): purpose, repos, services, active goal, key aliases. The *only* thing always injected into the agent. No growing markdown dump in every turn.
+- **Resource registry** replaces the flat link list: typed records (title, kind, url-or-query, service, env, aliases, description, provenance, confidence, last_used, last_verified, failure_count). Retrieved on demand, never all injected - so hundreds scale fine.
+- **Resolver** maps fuzzy language → the right record(s), returns a **cited** answer, and says "no source saved" instead of guessing. This is the load-bearing part.
+- **Capture:** paste/drop a URL → agent proposes a typed record for one-click accept (undoable); "remember this" from chat; save a run query as a named resource. No hand-filing into folders.
+- **Retrieve:** ask in English ("how's the service mesh latency?") → resolver picks the source (inspectable citation), runs it via the wired MCP server when possible, answers with the live value + link. Honest when a source is missing.
+- **Maintenance as a byproduct of use:** failed retrievals / broken links mark records *suspect* automatically; stale records surface only when relevant to the current question, never as a chore list. Semantic rewrites of important mappings need one-tap approval.
+- **Browse:** auto-grouped Resources view (by tool / service / derived topic); grouping computed, overrides rare + visible. Never a taxonomy I maintain.
+- **MCP wiring:** the embedded agent is configured with the project's relevant MCP servers (Datadog, Splunk, Kusto, …) - Scout-style - so retrieval *answers* instead of just pointing.
 
-**Authentication:** GitHub OAuth.
+### 5. Copilot - embedded local agent (the new spine)
+- Per-project agent conversation panel. Start a turn from the next action, a todo, a notification, or a freeform prompt.
+- Backend-agnostic **session port** (borrowed from Scout): shared code never couples to the SDK; Copilot is one backend, cloud `gh agent-task` is another, future backends slot in.
+- Renderer subscribes to **throttled `session:view` snapshots** (~100ms), not raw event firehose. State machine drives the UI.
+- Inline permission cards with risk/category badges + output preview; always-allow persists a reproducible *pattern* with an **explicit, narrow scope** (per-project, per-tool, bounded arg pattern) so it can't silently widen into blanket permission.
+- Transcripts persisted locally and **re-hydrated on resume** so returning to a session re-orients me.
+- **Sandbox:** the agent works in a per-project git **worktree** by default, so "YOLO speed" has a trailing safety net (recoverable by design, matches my risk profile).
 
-**Notification sync:** Polls the GitHub Notifications API on a configurable interval. Sync is fully async — the app never blocks on it.
+### 6. Copilot - cloud agent tasks (delegate)
+- Launch a `gh agent-task` from any action/todo/notification with one click; then walk away.
+- Tracked in the same session model; status dot on the rail; result folded into the re-entry digest.
+- Read-only w.r.t. GitHub beyond launching + unsubscribe (no commenting, no review write-back) in v1.
 
-**Async content prefetch:** After the notification list syncs, notification content (thread details) is fetched in the background. The list renders immediately from local data; fetched content populates in place. Content is considered stale only when a new notification arrives on that thread.
+### 7. GitHub notifications (supporting input)
+- Async sync off the render thread (unchanged). Local-first render; content prefetch in background.
+- Auto-close on PR merged / issue closed. Unsubscribe write-back. Read state local.
+- Routing + filters as v1, but the surface lives behind ⌘K / the project's Notifications tab, and feeds the digest.
 
-**Thread closure:** When GitHub signals that a thread is resolved — PR merged, issue closed, etc. — the thread is automatically removed from view globally. No acknowledgment, no archive step, just gone. Unsubscribe (write-back to GitHub API) is the manual equivalent.
+### 8. Snooze (blame-free)
+- Manual / date-based / notification-triggered (unchanged mechanics).
+- Snoozed projects drop off the rail into a quiet collapsed section. No nag, no guilt, no streak.
 
-**Read state:** Tracked locally. Marking a notification read does not write back to GitHub.
-
-**Unsubscribe:** Calls the GitHub API to unsubscribe from a thread, which also closes it locally.
-
-### 3. Inbox and Routing
-
-When a notification arrives from an unmapped thread:
-- It appears in the Inbox
-- The user assigns it to a project (or creates a new one)
-- The app records the thread → project mapping for future notifications on that thread
-
-After assigning a thread, the app evaluates whether to offer a repo-level rule:
-- **No other mapped threads from that repo:** Offer an opt-in — "Always route [repo] to [project]?"
-- **All other threads from that repo already go to the same project:** Offer an opt-out (pre-checked) — pattern is already established
-- **Threads from that repo are split across projects:** No offer — thread-level mapping is appropriate
-
-If a repo rule is created, the user can optionally migrate already-mapped threads from that repo to the new rule.
-
-Repo-level rules can be edited and deleted from Settings.
-
-### 4. Notification Filtering
-
-Filters suppress notifications from appearing anywhere in the app. Filtering operates on multiple dimensions:
-
-| Dimension | Match type |
-|-----------|-----------|
-| Author | Substring (case-insensitive) |
-| Org | Substring |
-| Repo | Substring |
-| Reason | Select (enum) |
-| State | Select (enum) |
-| Type | Select (enum) |
-
-Multiple filters combine with AND logic. Active filters are displayed as removable chips.
-
-**Two-tier type filtering:**
-- **Global rules** are a non-overridable floor. A notification type suppressed globally is suppressed everywhere.
-- **Per-repo rules** are strictly additive. A repo rule can suppress additional types beyond the global set; it cannot un-suppress a globally suppressed type.
-
-The UI makes this hierarchy visually explicit.
-
-Filters are session-scoped in v1.
-
-### 5. Snooze
-
-Projects can be snoozed in three modes:
-- **Manual** — hidden until the user manually un-snoozes
-- **Date-based** — hidden until a specific date, then auto-surfaced
-- **Notification-triggered** — hidden until a new GitHub notification arrives for this project
-
-Snoozed projects appear in a collapsed section of the dashboard.
-
-### 6. Appearance
-
-- Native macOS dark/light mode support
-- Theme support (multiple built-in themes, at minimum)
-- UI is visually distinctive — not a default Electron app
+### 9. Appearance (professional)
+- New **Primer-inspired token layer** (see Design System). Drop DaisyUI.
+- Light / dark / dim / high-contrast via data attributes; system-preference aware; overridable.
+- Mona Sans (UI) + Monaspace Neon (code/agent output); Lucide icons; 4px grid; 150ms transitions; native macOS chrome.
 
 ---
 
-## Technical Constraints
+## Design system
 
-- **Platform:** macOS only (Electron app bundle)
-- **Frontend:** React
-- **Backend:** Node.js (Electron main process)
-- **Data:** SQLite (local, no server)
-- **API:** GitHub REST API v3
+Replace the current DaisyUI + DM Sans + warm-linen look with a **Primer-inspired** system (modeled on `~/repos/github-app`), kept lightweight (CSS Modules + Tailwind v4 tokens; **not** heavyweight `@primer/react`).
 
-All GitHub API calls and DB writes happen off the render thread. The UI never blocks on I/O.
+- **Color:** monochrome neutral ramp (11 steps) + a single blue accent. Red/green/yellow semantic only. Borders semi-transparent (~40% of a mid neutral). Restraint over decoration.
+- **Type:** Mona Sans (UI, 400 body / 600 headings+buttons), Monaspace Neon (code + agent transcripts). `-apple-system` fallback.
+- **Icons:** Lucide (consistent 2px stroke), sized 12/16/24.
+- **Spacing:** 4px grid → 8/12/16/24. **Radii:** 2 small / 4 default / 8 large / full. **Transitions:** 150ms.
+- **Theming:** `data-color-mode` / `data-theme-tone` attributes + CSS-var injection; theme choice persisted; `prefers-color-scheme` when "system"; `prefers-reduced-motion` respected.
+- **Native details:** 12px root corner radius, traffic-light padding, native overlay scrollbars, 2px blue focus outline (-1px offset), F6 landmark navigation.
+- **Feel:** calm, restrained, generous whitespace, one primary action per surface.
 
----
-
-## Out of Scope
-
-- GitHub write-back beyond unsubscribe
-- Multi-user or team features
-- Mobile
-- Integrations beyond GitHub
-- Gantt charts, sprints, velocity, or any "enterprise PM" concepts
+The existing HTML design handoff (`requirements/design_handoff/`) is now **superseded** for the color/type language (it's the warm-linen direction). Its layout instincts (focus banner, links strip, tabbed detail) still inform the working column.
 
 ---
 
-## Success Criteria
+## Architecture
 
-The app is shippable when:
+Non-negotiable constraints (carried from v1, reinforced by the profiles):
 
-1. User can authenticate with GitHub and pull notifications
-2. Notifications are routed to projects via thread and repo rules
-3. Unmapped notifications surface in the Inbox
-4. Projects display name, notes, next action, todo list, links, and notifications
-5. Closed/merged threads disappear automatically
-6. Unsubscribe works
-7. Filtering works across all specified dimensions with global/per-repo type hierarchy
-8. Snooze works in all three modes
-9. Dark/light mode and at least one theme variant work correctly
-10. No UI lockup — all network I/O is async
+- **All I/O off the render thread.** GitHub API, SQLite, and agent subprocess management live in the Electron **main process**. Renderer never blocks.
+- **Local-first.** UI always renders from local SQLite; network/agent results populate in place.
+- **Typed IPC** only (`src/shared/ipc-channels.ts`), `domain:action` naming, `invoke/handle` + push events.
+- **No `any`.** Named exports. `async/await`. Strict null checks.
 
-**Success looks like:**
-- Opening the app tells you what you're working on and what to do next
-- GitHub notifications appear where they're relevant, not as a firehose
-- Snoozed work stays invisible until it matters
-- The app feels good to use
+New/changed pieces:
+
+- **Agent backend port** (`IAgentBackend`): `start(prompt, ctx)`, `send(sessionId, msg)`, `abort(sessionId)`, `resolvePermission(...)`, event stream. Implementations: `copilot-local` (SDK/CLI subprocess) and `github-cloud` (`gh agent-task`). Shared session/session-view code is backend-blind.
+- **Turn accumulator + normalizer:** raw SDK/CLI events → canonical `TurnEvent`s → throttled `session:view` snapshots broadcast to the renderer.
+- **Agent session store:** metadata in SQLite; transcripts on disk (encrypted via Electron `safeStorage`, Scout-style); re-hydrate on resume.
+- **Context & resource subsystem** (the make-or-break piece): a **two-layer context model**, not a markdown dump.
+  - *Project card* (small, always injected): purpose, repos, services, active goal, aliases.
+  - *Resource registry* (typed records in SQLite, retrieved on demand): title, kind, url-or-query, service, env, aliases, description, provenance, confidence, last_used, last_verified, failure_count.
+  - *Context assembler* (own module, tested + hard-capped): given a question, injects the project card + top-scored resources only.
+  - *Resolver* (own module, backed by the eval harness): fuzzy question → cited source; runs it via MCP when available; returns "no source saved" instead of guessing; marks records suspect on failure.
+- **Per-project MCP config:** the `copilot-local` backend starts each session with the project's wired MCP servers (Datadog / Splunk / Kusto / …) so retrieval can run live queries, not just point at links (Scout pattern).
+- **Worktree manager:** create/reuse a git worktree per project for the local agent's cwd; the safety net for agent file writes.
+- **Digest engine:** computes the re-entry digest from `last_seen_at` + session/notification/PR deltas, and classifies projects parked vs. drifting.
+
+```
+main/
+  agent/
+    port.ts              # IAgentBackend + shared session types
+    copilot-local/       # @github/copilot-sdk subprocess backend (+ per-project MCP config)
+    github-cloud/        # gh agent-task backend (evolves current copilot/)
+    normalize.ts         # raw events -> canonical TurnEvent
+    session-view.ts      # accumulate + throttle -> snapshots
+    store.ts             # metadata (SQLite) + transcript (disk, encrypted)
+    worktree.ts          # per-project git worktree sandbox
+  context/
+    registry.ts          # typed resource records (SQLite) + provenance/health
+    assemble.ts          # two-layer context: project card + on-demand retrieval (capped)
+    resolve.ts           # fuzzy question -> cited source (+ eval harness)
+    capture.ts           # paste/enrich -> proposed typed record
+  digest/                # re-entry digest + parked/drifting classification
+  notifications/         # sync + routing + filters (existing, demoted)
+  db/ auth/ snooze.ts    # existing
+shared/  ipc-channels.ts # + agent + context + digest channels
+renderer/
+  pages/Focus.tsx        # the single-focus home (replaces Dashboard as primary)
+  components/FocusRail, ReentryDigest, AgentPanel, PermissionCard, QuickSwitcher, ResourcePanel
+```
+
+---
+
+## Open technical validations (do NOT hand-wave these)
+
+Before committing to the embedded-agent milestones, verify:
+
+1. **Resolver quality (the make-or-break spike, do this FIRST).** Pick one real project; ingest ~25 real dashboards/queries as typed records with known-correct answers. Ask ~20 real fuzzy questions ("how's mesh latency?") **plus deliberate negative/ambiguous cases** (things with no saved source, and things that could match two sources). Define the **pass rubric up front**: fixed corpus, expected source ID per question, ≥ target % right-source-chosen, ≥ target % correct "no source saved" on negatives, and correct clarify-or-top-candidates behavior on ambiguous ones. Keep it as a regression harness in the repo. **If this doesn't clear the bar, the "project brain" thesis (MVP C/D) is wrong - but MVP A/B don't depend on it, so they can still ship.**
+2. **`@github/copilot-sdk` availability + licensing** for a personal, non-Microsoft app. Scout bundles it; confirm we can depend on it (or fall back to spawning the `copilot` CLI directly with our own protocol). **Blocker-class risk.**
+3. **Copilot CLI bundling / auth** - how the subprocess authenticates (reuse `~/.copilot`? isolated home like Scout's `~/.scout/copilot`?), and build-size impact.
+4. **Worktree sandbox ergonomics** - creating/cleaning worktrees per project without surprising the user's real checkout.
+5. **Permission-card coverage** - which tool categories must prompt (shell, file write, network) vs. auto-allow (reads).
+6. **Resource enrichment + per-project MCP config** - enriching a pasted dashboard URL may need auth (Datadog/Splunk/Kusto behind SSO); prefer resolving titles/metadata *through the wired MCP server* over scraping the URL. Confirm the SDK lets us attach per-project MCP servers and that the observability MCPs expose the lookups the resolver needs.
+7. **`better-sqlite3` + new native deps** still build against Electron's ABI under `bun run setup`.
+
+These become spikes at the front of the milestone plan. Note the dependency: the resolver spike (1) validates the *core value* and needs almost none of the embedded-agent machinery (2-6) - it can run against MCP tools directly. If (2) fails, the embedded-agent spine degrades gracefully to a richer cloud-agent experience; the project brain survives either way.
+
+---
+
+## Out of scope
+
+- GitHub write-back beyond launching agent tasks + unsubscribe (no commenting, no review submission) in v1.
+- Multi-user / team / cloud sync of local state (single machine).
+- Mobile or non-macOS targets.
+- Gantt/sprints/velocity/enterprise-PM concepts.
+- Streaks, activity graphs, or any engagement-nag mechanic (actively harmful for this user).
+
+**Integrations - reclassified (not a flat "GitHub + Copilot only"):**
+- **App-native:** GitHub + Copilot. The app talks to these directly.
+- **Resource providers (via MCP):** Datadog / Splunk / Kusto and similar. These are *optional* per project, but at least one real provider is **required to validate the project-brain concept** (the "how's mesh latency?" success criterion is fake without one). New providers are added as MCP servers, not bespoke integrations - so "beyond GitHub" is in scope specifically as pluggable resource providers, and nothing else.
+
+---
+
+## Success criteria (staged gates, smallest-first)
+
+Not one all-or-nothing bar. Each gate ships daily personal value on its own, and the risky embedded-agent platform is deliberately last.
+
+**Gate 0 - Resolver spike (proof, not shippable):**
+- The resolver picks the right source and answers with a citation (or honestly says "no source saved") on the real eval set - run against MCP tools directly, no app shell yet. This gates everything else; if it fails, rethink the brain before building UI.
+
+**MVP A - Single-focus shell + re-entry:**
+1. Home opens to a single focused project; other projects are landmarks + ⌘K, never a competing dashboard.
+2. Returning to a focus shows a blame-free "since you were here" digest computed from real deltas (from existing notification/session data).
+3. Drifting vs. parked projects are distinguished; drifting ones resurface gently without me remembering to look.
+4. No UI lockup (I/O off the render thread); undo covers destructive actions.
+
+**MVP B - Cloud-agent completion loop:**
+5. I can launch a **cloud** `gh agent-task` from an action/todo/notification and get re-oriented on its result later via the digest + rail status.
+
+**MVP C - Project brain (the heart), no embedded agent required:**
+6. Asking "how's the service mesh latency?" resolves to the right saved resource and, where an MCP source is wired, returns the live value with an inspectable citation.
+7. Adding a resource is one low-friction step (paste → agent proposes a typed record → one-tap accept); no hand-built tree/taxonomy; browse view auto-grouped.
+8. Stale/broken resources are marked suspect on failure and surface only when relevant - no chore list.
+
+**MVP D - Embedded local agent (only after Gate 0 + validations 2-6 pass):**
+9. I can start a **local embedded** Copilot turn scoped to a project, watch it stream, and approve tool actions via scoped inline permission cards.
+10. Agent sessions persist and re-hydrate on resume.
+
+**Cross-cutting (land across the gates, not a final big-bang):**
+11. Notifications still sync, route, filter, auto-close, and unsubscribe - from the demoted surface.
+12. Snooze works in all three modes with no nagging.
+13. The Primer-inspired design system (monochrome + blue, Mona Sans/Monaspace, Lucide, data-attribute theming) in light + dark + one more mode. Deliberately not gating the cognition-layer proof.
+
+**Success looks like:** I open the app, it tells me *one* thing and catches me up on what moved. I ask it "how's X?" and it answers from the project's brain, with a citation, instead of making me hunt a bookmark. The boring finish is one click from being handed to Copilot. Drifting threads come back to me on their own. Nothing nags, nothing shames, nothing needs grooming.

--- a/requirements/prd.md
+++ b/requirements/prd.md
@@ -119,7 +119,7 @@ A computed, blame-free catch-up shown at the top of a focus when I return after 
 - Notifications that routed here since last seen.
 - Todos the agent checked off; files it changed.
 - Never phrased as time-shame ("gone 3 days"). Phrased as orientation ("here's what moved").
-Dismissable; regenerates from a per-project `last_seen_at` watermark.
+Dismissible; regenerates from a per-project `last_seen_at` watermark.
 
 ### Parked vs. forgotten (peripheral memory)
 Single-focus has a real failure mode for a time-blind person: out of sight, out of mind. The re-entry digest catches me up on the *focused* project, but something has to keep the *unfocused* ones from silently rotting. So the app distinguishes two states and never conflates them:
@@ -260,7 +260,7 @@ main/
   agent/
     port.ts              # IAgentBackend + shared session types
     copilot-local/       # @github/copilot-sdk subprocess backend (+ per-project MCP config)
-    github-cloud/        # gh agent-task backend (evolves current copilot/)
+    github-cloud/        # gh agent-task backend (evolves current src/main/copilot/)
     normalize.ts         # raw events -> canonical TurnEvent
     session-view.ts      # accumulate + throttle -> snapshots
     store.ts             # metadata (SQLite) + transcript (disk, encrypted)


### PR DESCRIPTION
## What this is

A ground-up rewrite of the product plan (PRD + milestones). No code changes - this is the direction doc for rebuilding the app. The v1 PRD and milestone plan are archived alongside the new ones so nothing is lost.

## Why

Held against my ADHD Profile and Cognitive Interface Model, the v1 framing ("project-centric GitHub notification manager") quietly fights how I actually work. Three mismatches drove the rewrite:

- A dashboard of N projects with counts is the exact "6 unrelated items" surface that de-motivates me.
- The real problem isn't missed notifications - it's **losing the thread** (hyperfocus → drop it "for 2 hours" → lose days → shame blocks re-entry).
- Nothing helped me **finish** (the last 10%), which is exactly what a coding agent is good at.

## What changed at the problem layer

- **One focus at a time** - the home is a single project; everything else is a landmark + ⌘K, not a competing dashboard.
- **Re-entry digest** ("since you were here") + **parked-vs-drifting** resurfacing - insurance against time-blindness, blame-free, no streaks.
- **Project brain** - the answer to "remembering hundreds of Datadog/Splunk/Kusto dashboards without hoarding bookmarks." A typed resource registry + a scored, **cited** resolver: I ask "how's the service mesh latency?" and it resolves to the right source, runs it via the wired MCP server, and answers with a citation - or says "no source saved" instead of guessing. Retrieve-by-asking, never a taxonomy I maintain.
- **Copilot as the spine** - cloud delegate loop (hand off the tedious finish) + embedded local agent (sit and steer), one session model. Observability tools are MCP-backed resource providers.
- **Primer-inspired design language** (drops DaisyUI): monochrome + one blue accent, Mona Sans / Monaspace Neon, Lucide, data-attribute theming.

## Staging (riskiest work last)

- **Gate 0** - resolver spike with a defined pass rubric + real eval harness. Proves the brain before any UI.
- **Track 1** (no brain dependency): MVP A (focus + re-entry) → MVP B (cloud-agent loop) - ship value regardless.
- **Track 2** (gated on Gate 0): MVP C (brain in-app) → MVP D (embedded agent, last, behind SDK/worktree/permission validations).

## How this was reviewed

- Grounded in two reference apps: `github-app` (design language) and Scout (`m`, deep Copilot integration).
- **Adversarial review by GPT 5.5 over two rounds**, with emphasis on "solving at the right layer." Round 1: NOT SOUND, 8 must-fix concerns (incl. "is the brain just a fancy notes field?", "does injecting the whole doc every turn scale?", "is the embedded-agent spine over-building?"). All addressed. Round 2: **SOUND to proceed**, no blocking concerns; 5 tightenings folded in.
- Docs-only change - no build/test applies.

## Files

- `requirements/prd.md` - rewritten PRD
- `requirements/milestones.md` - staged gates
- `requirements/prd-v1-archive.md`, `requirements/milestones-v1-archive.md` - preserved v1