### PR TITLE
MVP B: launch + track cloud gh agent-tasks

### DIFF
--- a/db/migrations/014_copilot_pinned_project.sql
+++ b/db/migrations/014_copilot_pinned_project.sql
@@ -1,0 +1,13 @@
+-- Migration: 014_copilot_pinned_project.sql
+-- MVP B: sticky project assignment for launched / manually-assigned agent tasks.
+--
+-- A session launched from (or manually assigned to) a project must stay there.
+-- But `gh agent-task list` re-resolves project on every sync, and a just-launched
+-- task usually resolves to NULL (no notification thread / repo rule yet), so it
+-- would jump to the Unassigned surface on the next sync. pinned_project_id records
+-- the explicit user intent; the sync writer preserves it and prefers it (when the
+-- pinned project is still live) over auto-resolution. ON DELETE SET NULL is a
+-- backstop; deleteProject also nulls it explicitly (matching how notifications
+-- drop to the Inbox on project delete).
+ALTER TABLE copilot_sessions
+  ADD COLUMN pinned_project_id INTEGER REFERENCES projects(id) ON DELETE SET NULL;

--- a/requirements/copilot.md
+++ b/requirements/copilot.md
@@ -90,12 +90,63 @@ If no rule matches, `project_id = null`. Unlinked sessions are stored but not su
 ## IPC Channels
 
 ```
-copilot:sessions-for-project   args: [projectId: number]   result: CopilotSession[]
-copilot:all-statuses           args: []                     result: Record<number, CopilotSessionStatus>
-copilot:sync                   args: []                     result: void
+copilot:sessions-for-project   args: [projectId: number]              result: CopilotSession[]
+copilot:all-statuses           args: []                                result: Record<number, CopilotSessionStatus>
+copilot:sync                   args: []                                result: void
+copilot:launch                 args: [payload: LaunchAgentTaskPayload] result: CopilotSession
+copilot:unassigned             args: []                                result: CopilotSession[]
+copilot:unassigned-count       args: []                                result: number
+copilot:assign                 args: [sessionId, projectId]            result: void
+copilot:launch-targets         args: [projectId: number]              result: LaunchTarget[]
 ```
 
 A push event `onCopilotUpdated` is added to `ElectronApi` (same pattern as `onNotificationsUpdated`) to notify the renderer when session state changes.
+
+---
+
+## MVP B — Launch + Track (evolution of the read-only design)
+
+MVP B evolves the integration above from read-only tracking to **launch + track**.
+Everything below is additive; the `gh agent-task list` sync, rail dot, and digest
+folding from MVP A are reused unchanged in shape.
+
+### Launching a task
+
+- `copilot:launch` shells out to `gh agent-task create -R <owner>/<repo> [-b <base>]`
+  off the render thread, piping the prompt on stdin (`-F -`). Launchable from a
+  next action, a todo, or a notification via a small **Delegate to Copilot**
+  confirm composer (not pure one-click: a cloud launch spends premium requests and
+  can't be cleanly undone read-only).
+- `create` prints the agent-session URL (`…/pull/<n>/agent-sessions/<uuid>`); we
+  parse the session UUID + PR number and **optimistically insert** a
+  `copilot_sessions` row (status `in_progress`) so the rail/digest light up before
+  the next list sync. A background sync then reconciles the real title/status.
+- **Auth:** `gh agent-task` requires gh's keyring OAuth token. The subprocess env
+  strips `GH_TOKEN`/`GITHUB_TOKEN` (which agent-task rejects) for the `agent-task`
+  calls only.
+
+### Sticky project assignment (`pinned_project_id`)
+
+A launched (or manually assigned) session must stay on its project, but the list
+sync re-resolves project every cycle and a just-launched task usually resolves to
+null. A `pinned_project_id` column records the explicit intent: the sync UPSERT
+preserves it and prefers it (when the project is live) over auto-resolution. On
+project delete both `project_id` and `pinned_project_id` are nulled so the session
+drops to the Unassigned surface.
+
+### Status derivation
+
+`deriveStatus` makes the task lifecycle win over PR existence (a launch opens a
+draft PR immediately): `completed` + open PR → `pr_ready`; `completed` +
+merged/closed → `completed`; `failed`/`cancelled` → `completed`; `idle` →
+`waiting`; else → `in_progress`.
+
+### Unassigned surface ("Agent tasks")
+
+A dedicated rail entry near Inbox, badged with the count of **active** unassigned
+sessions, opening a list of sessions with `project_id IS NULL` (active-first, then
+newest, incl. recently-completed). Each row can be assigned to a project
+(`copilot:assign`, sticky) or opened on GitHub.
 
 ---
 
@@ -126,8 +177,8 @@ The tab renders a session list with sessions grouped by status. Each row shows:
 
 ## Out of Scope
 
-- Writing back to GitHub (e.g. commenting on issues, requesting reviews) — read-only only
+- Writing back to GitHub beyond **launching a cloud `gh agent-task`** and the existing unsubscribe (no commenting, requesting reviews, or cancelling a task)
 - Tracking Copilot code completions or inline suggestions
 - Showing full Copilot session transcripts inline in the app
-- Spawning, resuming, or controlling Copilot CLI sessions from this app
+- The embedded/local Copilot CLI agent — live streaming, permission cards, worktree sandbox (that's a later milestone, MVP D)
 - Any cross-machine or cloud sync of local session state

--- a/src/main/copilot/copilot-db.integration.test.ts
+++ b/src/main/copilot/copilot-db.integration.test.ts
@@ -1,0 +1,231 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Database as BunDb } from 'bun:sqlite'
+import type BetterSQLite3 from 'better-sqlite3'
+import type { CopilotSession } from '../../shared/ipc-channels'
+
+vi.mock('electron', () => ({
+  app: { isPackaged: false, getAppPath: () => process.cwd() },
+}))
+
+vi.mock('../db', () => ({ getDb: vi.fn() }))
+
+import { getDb } from '../db'
+import { runMigrations } from '../db/migrate'
+import {
+  upsertSessions,
+  insertLaunchedSession,
+  getSessionsForProject,
+  getUnassignedSessions,
+  getUnassignedActiveCount,
+  assignSession,
+} from './db'
+import { getLaunchTargets } from './launch-targets'
+import { deleteProject } from '../db/projects'
+import { getDigest } from '../digest'
+
+let db: BunDb
+
+beforeEach(() => {
+  db = new BunDb(':memory:')
+  db.exec('PRAGMA foreign_keys = ON')
+  const betterDb = db as unknown as BetterSQLite3.Database
+  runMigrations(betterDb)
+  vi.mocked(getDb).mockReturnValue(betterDb)
+})
+
+function makeProject(name: string): number {
+  const row = db.prepare('INSERT INTO projects (name) VALUES (?) RETURNING id').get(name) as { id: number }
+  return row.id
+}
+
+/** A synced CopilotSession as produced by the github source's mapRow. */
+function syncedSession(overrides: Partial<CopilotSession>): CopilotSession {
+  return {
+    id: 's1',
+    projectId: null,
+    source: 'github',
+    status: 'in_progress',
+    title: 'Synced title',
+    htmlUrl: null,
+    startedAt: '2026-07-02T00:00:00Z',
+    updatedAt: '2026-07-02T00:00:00Z',
+    repoOwner: 'o',
+    repoName: 'r',
+    branch: null,
+    linkedPrUrl: null,
+    pinnedProjectId: null,
+    ...overrides,
+  }
+}
+
+describe('pinned project stickiness', () => {
+  it('a launched session stays on its project when a later sync resolves to null', () => {
+    const p = makeProject('P')
+    insertLaunchedSession({
+      id: 's1', title: 'Fix it', repoOwner: 'o', repoName: 'r',
+      htmlUrl: 'https://x/pull/1', linkedPrUrl: 'https://x/pull/1', projectId: p,
+    })
+
+    // Sync sees the task but can't resolve a project (no thread/rule yet).
+    upsertSessions([syncedSession({ id: 's1', projectId: null, status: 'pr_ready' })])
+
+    const forProject = getSessionsForProject(p)
+    expect(forProject.map((s) => s.id)).toContain('s1')
+    expect(forProject[0].pinnedProjectId).toBe(p)
+    expect(forProject[0].status).toBe('pr_ready') // volatile field followed sync
+    expect(getUnassignedSessions().map((s) => s.id)).not.toContain('s1')
+  })
+
+  it('an unpinned session follows re-resolution across syncs', () => {
+    const p2 = makeProject('P2')
+    upsertSessions([syncedSession({ id: 's2', projectId: null })])
+    expect(getUnassignedSessions().map((s) => s.id)).toContain('s2')
+
+    upsertSessions([syncedSession({ id: 's2', projectId: p2 })])
+    expect(getSessionsForProject(p2).map((s) => s.id)).toContain('s2')
+    expect(getUnassignedSessions().map((s) => s.id)).not.toContain('s2')
+  })
+
+  it('optimistic launch UPSERT does not clobber an already-synced row', () => {
+    const p = makeProject('P')
+    // Sync created the row first (race): pr_ready with the real title.
+    upsertSessions([syncedSession({ id: 's3', projectId: null, status: 'pr_ready', title: 'Real title' })])
+    // Launch insert lands after — it should only pin, not downgrade status/title.
+    insertLaunchedSession({
+      id: 's3', title: 'Optimistic prompt', repoOwner: 'o', repoName: 'r',
+      htmlUrl: null, linkedPrUrl: null, projectId: p,
+    })
+
+    const forProject = getSessionsForProject(p)
+    expect(forProject).toHaveLength(1)
+    expect(forProject[0].status).toBe('pr_ready')
+    expect(forProject[0].title).toBe('Real title')
+    expect(forProject[0].pinnedProjectId).toBe(p)
+  })
+})
+
+describe('getUnassignedSessions / getUnassignedActiveCount', () => {
+  it('returns active-first, includes completed, and excludes assigned', () => {
+    makeProject('P')
+    upsertSessions([
+      syncedSession({ id: 'done', projectId: null, status: 'completed', updatedAt: '2026-07-02T10:00:00Z' }),
+      syncedSession({ id: 'active', projectId: null, status: 'in_progress', updatedAt: '2026-07-02T09:00:00Z' }),
+      syncedSession({ id: 'assigned', projectId: 1, status: 'in_progress' }),
+    ])
+
+    const ids = getUnassignedSessions().map((s) => s.id)
+    expect(ids).toEqual(['active', 'done']) // active sorts first despite older timestamp
+    expect(ids).not.toContain('assigned')
+    expect(getUnassignedActiveCount()).toBe(1)
+  })
+})
+
+describe('assignSession', () => {
+  it('pins a session to a project and survives a later sync', () => {
+    const p = makeProject('P')
+    upsertSessions([syncedSession({ id: 's1', projectId: null })])
+    assignSession('s1', p)
+
+    expect(getSessionsForProject(p).map((s) => s.id)).toContain('s1')
+
+    // A later sync that resolves to null must not un-home it.
+    upsertSessions([syncedSession({ id: 's1', projectId: null })])
+    expect(getSessionsForProject(p).map((s) => s.id)).toContain('s1')
+  })
+
+  it('rejects a missing session and a soft-deleted project', () => {
+    const p = makeProject('P')
+    upsertSessions([syncedSession({ id: 's1', projectId: null })])
+    expect(() => assignSession('nope', p)).toThrow(/SESSION_NOT_FOUND/)
+    deleteProject(p)
+    expect(() => assignSession('s1', p)).toThrow(/PROJECT_NOT_FOUND/)
+  })
+})
+
+describe('deleteProject clears the pin', () => {
+  it('a launched session drops to unassigned when its project is deleted', () => {
+    const p = makeProject('P')
+    insertLaunchedSession({
+      id: 's1', title: 'Fix it', repoOwner: 'o', repoName: 'r',
+      htmlUrl: null, linkedPrUrl: null, projectId: p,
+    })
+    deleteProject(p)
+
+    const unassigned = getUnassignedSessions()
+    expect(unassigned.map((s) => s.id)).toContain('s1')
+    expect(unassigned[0].pinnedProjectId).toBeNull()
+  })
+})
+
+describe('launched session folds into the re-entry digest', () => {
+  it('a just-launched session appears as a working item on its project digest', () => {
+    const p = makeProject('P')
+    insertLaunchedSession({
+      id: 's1', title: 'Fix the flaky test', repoOwner: 'o', repoName: 'r',
+      htmlUrl: 'https://x/pull/1', linkedPrUrl: 'https://x/pull/1', projectId: p,
+    })
+
+    const digest = getDigest(p)
+    const kinds = digest.items.map((i) => i.kind)
+    expect(kinds).toContain('agent-in-progress')
+    const item = digest.items.find((i) => i.kind === 'agent-in-progress')
+    expect(item?.text).toMatch(/Fix the flaky test/)
+  })
+})
+
+describe('launch liveness + pin hygiene', () => {
+  it('a launch targeting a soft-deleted project is tracked as unassigned, not lost', () => {
+    const p = makeProject('P')
+    deleteProject(p)
+    const s = insertLaunchedSession({
+      id: 's1', title: 't', repoOwner: 'o', repoName: 'r', htmlUrl: null, linkedPrUrl: null, projectId: p,
+    })
+    expect(s.projectId).toBeNull()
+    expect(s.pinnedProjectId).toBeNull()
+    expect(getUnassignedSessions().map((x) => x.id)).toContain('s1')
+  })
+
+  it('a launch with a non-existent project id does not throw and tracks unassigned', () => {
+    const s = insertLaunchedSession({
+      id: 's2', title: 't', repoOwner: 'o', repoName: 'r', htmlUrl: null, linkedPrUrl: null, projectId: 9999,
+    })
+    expect(s.projectId).toBeNull()
+    expect(getUnassignedSessions().map((x) => x.id)).toContain('s2')
+  })
+
+  it('a sync clears a pin whose project is gone (no snap-back on restore)', () => {
+    const p = makeProject('P')
+    insertLaunchedSession({
+      id: 's3', title: 't', repoOwner: 'o', repoName: 'r', htmlUrl: null, linkedPrUrl: null, projectId: p,
+    })
+    // Soft-delete directly (bypassing deleteProject's own pin-clearing) to prove
+    // the sync writer independently drops a dead pin.
+    db.prepare('UPDATE projects SET deleted_at = ? WHERE id = ?').run('2026-07-02T00:00:00Z', p)
+    upsertSessions([syncedSession({ id: 's3', projectId: null })])
+    const row = db
+      .prepare('SELECT project_id, pinned_project_id FROM copilot_sessions WHERE id = ?')
+      .get('s3') as { project_id: number | null; pinned_project_id: number | null }
+    expect(row.pinned_project_id).toBeNull()
+    expect(row.project_id).toBeNull()
+  })
+})
+
+describe('getLaunchTargets', () => {
+  it('unions repo rules and notification threads, distinct, rules first', () => {
+    const p = makeProject('P')
+    db.prepare('INSERT INTO repo_rules (repo_owner, repo_name, project_id) VALUES (?, ?, ?)').run('o', 'ruled', p)
+    db.prepare(
+      `INSERT INTO notification_threads (id, project_id, repo_owner, repo_name, title, type, reason, updated_at, api_url)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run('n1', p, 'o', 'threaded', 'T', 'PullRequest', 'review_requested', '2026-07-02T00:00:00Z', 'https://api')
+    // A duplicate of the ruled repo via a thread should not double up.
+    db.prepare(
+      `INSERT INTO notification_threads (id, project_id, repo_owner, repo_name, title, type, reason, updated_at, api_url)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run('n2', p, 'o', 'ruled', 'T2', 'Issue', 'mention', '2026-07-03T00:00:00Z', 'https://api')
+
+    const targets = getLaunchTargets(p)
+    const keys = targets.map((t) => `${t.repoOwner}/${t.repoName}`)
+    expect(keys).toEqual(['o/ruled', 'o/threaded']) // rule repo first, distinct
+  })
+})

--- a/src/main/copilot/db.ts
+++ b/src/main/copilot/db.ts
@@ -20,6 +20,7 @@ interface CopilotSessionRow {
   repo_name: string | null
   branch: string | null
   linked_pr_url: string | null
+  pinned_project_id: number | null
   synced_at: string
 }
 
@@ -37,39 +38,139 @@ function toSession(row: CopilotSessionRow): CopilotSession {
     repoName: row.repo_name,
     branch: row.branch,
     linkedPrUrl: row.linked_pr_url,
+    pinnedProjectId: row.pinned_project_id,
   }
 }
 
-/** Upserts a batch of sessions. Existing rows are fully replaced. */
+/**
+ * Upserts a batch of sessions from a `gh agent-task list` sync.
+ *
+ * On conflict this preserves the sticky `pinned_project_id` (owned by launch /
+ * manual assignment, never by the sync) while it points at a live project, and
+ * prefers it over the freshly-resolved `project_id`. A pin whose project is gone
+ * (soft-deleted) is cleared so a later restore can't make the session snap back.
+ * All volatile fields are updated to GitHub truth. New rows keep
+ * `pinned_project_id` NULL (its default).
+ */
 export function upsertSessions(sessions: CopilotSession[]): void {
   const db = getDb()
   const stmt = db.prepare(`
-    INSERT OR REPLACE INTO copilot_sessions
+    INSERT INTO copilot_sessions
       (id, project_id, source, status, title, html_url, started_at, updated_at,
        repo_owner, repo_name, branch, linked_pr_url, synced_at)
     VALUES
-      (@id, @project_id, @source, @status, @title, @html_url, @started_at, @updated_at,
-       @repo_owner, @repo_name, @branch, @linked_pr_url, datetime('now'))
+      (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
+    ON CONFLICT(id) DO UPDATE SET
+      pinned_project_id = CASE
+        WHEN copilot_sessions.pinned_project_id IS NOT NULL
+         AND EXISTS (
+           SELECT 1 FROM projects p
+           WHERE p.id = copilot_sessions.pinned_project_id AND p.deleted_at IS NULL
+         )
+        THEN copilot_sessions.pinned_project_id
+        ELSE NULL
+      END,
+      project_id = CASE
+        WHEN copilot_sessions.pinned_project_id IS NOT NULL
+         AND EXISTS (
+           SELECT 1 FROM projects p
+           WHERE p.id = copilot_sessions.pinned_project_id AND p.deleted_at IS NULL
+         )
+        THEN copilot_sessions.pinned_project_id
+        ELSE excluded.project_id
+      END,
+      source        = excluded.source,
+      status        = excluded.status,
+      title         = excluded.title,
+      html_url      = excluded.html_url,
+      started_at    = excluded.started_at,
+      updated_at    = excluded.updated_at,
+      repo_owner    = excluded.repo_owner,
+      repo_name     = excluded.repo_name,
+      branch        = excluded.branch,
+      linked_pr_url = excluded.linked_pr_url,
+      synced_at     = datetime('now')
   `)
   const insertMany = db.transaction((rows: CopilotSession[]) => {
     for (const s of rows) {
-      stmt.run({
-        id: s.id,
-        project_id: s.projectId,
-        source: s.source,
-        status: s.status,
-        title: s.title,
-        html_url: s.htmlUrl,
-        started_at: s.startedAt,
-        updated_at: s.updatedAt,
-        repo_owner: s.repoOwner,
-        repo_name: s.repoName,
-        branch: s.branch,
-        linked_pr_url: s.linkedPrUrl,
-      })
+      stmt.run(
+        s.id,
+        s.projectId,
+        s.source,
+        s.status,
+        s.title,
+        s.htmlUrl,
+        s.startedAt,
+        s.updatedAt,
+        s.repoOwner,
+        s.repoName,
+        s.branch,
+        s.linkedPrUrl,
+      )
     }
   })
   insertMany(sessions)
+}
+
+export interface LaunchedSessionInput {
+  id: string
+  title: string
+  repoOwner: string
+  repoName: string
+  htmlUrl: string | null
+  linkedPrUrl: string | null
+  /** Originating project to pin (null = launched against a repo with no project). */
+  projectId: number | null
+}
+
+/**
+ * Optimistically records a just-launched agent task so the rail/digest light up
+ * before the next `gh agent-task list` sync. Status starts `in_progress`.
+ *
+ * Only a *live* project is pinned/pointed at: if the originating project vanished
+ * mid-launch (or is soft-deleted), the task is tracked as unassigned instead —
+ * so a successful remote launch is never lost to an FK failure or an invisible
+ * row pointing at a dead project.
+ *
+ * This is an UPSERT: if a sync already created the row (race), we only set the
+ * pin + effective project_id and do NOT clobber the already-synced
+ * status/title/timestamps. Returns the resulting row.
+ */
+export function insertLaunchedSession(input: LaunchedSessionInput): CopilotSession {
+  const db = getDb()
+  const now = new Date().toISOString()
+  const projectIsLive =
+    input.projectId !== null &&
+    db.prepare('SELECT 1 FROM projects WHERE id = ? AND deleted_at IS NULL').get(input.projectId) != null
+  const pin = projectIsLive ? input.projectId : null
+  db.prepare(`
+    INSERT INTO copilot_sessions
+      (id, project_id, source, status, title, html_url, started_at, updated_at,
+       repo_owner, repo_name, branch, linked_pr_url, pinned_project_id, synced_at)
+    VALUES
+      (?, ?, 'github', 'in_progress', ?, ?, ?, ?, ?, ?, NULL, ?, ?, datetime('now'))
+    ON CONFLICT(id) DO UPDATE SET
+      pinned_project_id = excluded.pinned_project_id,
+      project_id = CASE
+        WHEN excluded.pinned_project_id IS NOT NULL
+        THEN excluded.pinned_project_id
+        ELSE copilot_sessions.project_id
+      END
+  `).run(
+    input.id,
+    pin,
+    input.title,
+    input.htmlUrl,
+    now,
+    now,
+    input.repoOwner,
+    input.repoName,
+    input.linkedPrUrl,
+    pin,
+  )
+
+  const row = db.prepare('SELECT * FROM copilot_sessions WHERE id = ?').get(input.id) as CopilotSessionRow
+  return toSession(row)
 }
 
 /** Returns all sessions linked to a project, ordered by updated_at desc. */
@@ -82,6 +183,52 @@ export function getSessionsForProject(projectId: number): CopilotSession[] {
     `)
     .all(projectId) as CopilotSessionRow[]
   return rows.map(toSession)
+}
+
+/**
+ * Returns unassigned sessions (project_id IS NULL) for the Agent Tasks surface.
+ * Active sessions sort first (so a burst of completed ones can't push active
+ * orphaned work out of the cap), then newest first. Includes recently-completed
+ * sessions so a task that finishes before it's assigned doesn't vanish.
+ */
+export function getUnassignedSessions(limit = 50): CopilotSession[] {
+  const rows = getDb()
+    .prepare(`
+      SELECT * FROM copilot_sessions
+      WHERE project_id IS NULL
+      ORDER BY (status = 'completed') ASC, julianday(updated_at) DESC
+      LIMIT ?
+    `)
+    .all(limit) as CopilotSessionRow[]
+  return rows.map(toSession)
+}
+
+/** Count of active (non-completed) unassigned sessions, for the rail badge. */
+export function getUnassignedActiveCount(): number {
+  const row = getDb()
+    .prepare(`
+      SELECT COUNT(*) AS cnt FROM copilot_sessions
+      WHERE project_id IS NULL AND status != 'completed'
+    `)
+    .get() as { cnt: number }
+  return row.cnt
+}
+
+/**
+ * Pins an unassigned session to a live project (sticky across syncs).
+ * Throws when the project is missing/soft-deleted or the session doesn't exist.
+ */
+export function assignSession(sessionId: string, projectId: number): void {
+  const db = getDb()
+  const project = db
+    .prepare('SELECT 1 FROM projects WHERE id = ? AND deleted_at IS NULL')
+    .get(projectId)
+  if (project === undefined || project === null) throw new Error('PROJECT_NOT_FOUND')
+
+  const result = db
+    .prepare('UPDATE copilot_sessions SET project_id = ?, pinned_project_id = ? WHERE id = ?')
+    .run(projectId, projectId, sessionId)
+  if (result.changes === 0) throw new Error('SESSION_NOT_FOUND')
 }
 
 /**

--- a/src/main/copilot/gh.ts
+++ b/src/main/copilot/gh.ts
@@ -1,0 +1,40 @@
+/**
+ * Shared helpers for the `gh agent-task` subprocess (list + launch).
+ *
+ * `gh agent-task` requires gh's own keyring OAuth token. When `GH_TOKEN` /
+ * `GITHUB_TOKEN` are present in the environment, agent-task rejects them
+ * ("requires an OAuth token"). We strip just those two variables for agent-task
+ * calls so gh falls back to its keyring auth. In the shipped app these vars are
+ * normally unset (Octokit auth is a separate PAT in safeStorage), so the strip
+ * is a no-op there and a fix when they happen to be present.
+ */
+
+import { accessSync, constants } from 'fs'
+
+/** Resolve the full path to the `gh` binary, checking common macOS install locations. */
+export function resolveGhPath(): string {
+  const candidates = [
+    '/opt/homebrew/bin/gh',
+    '/usr/local/bin/gh',
+    '/usr/bin/gh',
+  ]
+  for (const p of candidates) {
+    try {
+      accessSync(p, constants.X_OK)
+      return p
+    } catch { /* not found, try next */ }
+  }
+  // Fall back to bare `gh` and hope it's on PATH
+  return 'gh'
+}
+
+/**
+ * Build the environment for an `agent-task` subprocess: the current env with
+ * `GH_TOKEN` / `GITHUB_TOKEN` removed so gh uses its keyring OAuth token.
+ */
+export function agentTaskEnv(base: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
+  const env = { ...base }
+  delete env['GH_TOKEN']
+  delete env['GITHUB_TOKEN']
+  return env
+}

--- a/src/main/copilot/github-source.test.ts
+++ b/src/main/copilot/github-source.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest'
+import { deriveStatus, type AgentTaskRow } from './github-source'
+
+function row(overrides: Partial<AgentTaskRow>): AgentTaskRow {
+  return {
+    id: 't1',
+    name: 'A task',
+    state: 'in_progress',
+    repository: 'o/r',
+    createdAt: '2026-07-02T00:00:00Z',
+    updatedAt: '2026-07-02T00:00:00Z',
+    completedAt: null,
+    pullRequestUrl: null,
+    pullRequestState: null,
+    pullRequestTitle: null,
+    pullRequestNumber: null,
+    ...overrides,
+  }
+}
+
+describe('deriveStatus', () => {
+  it('an active task with a freshly-opened draft PR stays in_progress (not pr_ready)', () => {
+    expect(deriveStatus(row({ state: 'in_progress', pullRequestUrl: 'https://x/pull/1', pullRequestState: 'OPEN' })))
+      .toBe('in_progress')
+  })
+
+  it('unknown active states default to in_progress', () => {
+    expect(deriveStatus(row({ state: 'queued' }))).toBe('in_progress')
+  })
+
+  it('idle means waiting for input', () => {
+    expect(deriveStatus(row({ state: 'idle' }))).toBe('waiting')
+  })
+
+  it('completed with an open PR is pr_ready', () => {
+    expect(deriveStatus(row({ state: 'completed', pullRequestUrl: 'https://x/pull/1', pullRequestState: 'OPEN' })))
+      .toBe('pr_ready')
+  })
+
+  it('completed with a merged/closed PR is completed', () => {
+    expect(deriveStatus(row({ state: 'completed', pullRequestState: 'MERGED' }))).toBe('completed')
+    expect(deriveStatus(row({ state: 'completed', pullRequestState: 'CLOSED' }))).toBe('completed')
+    expect(deriveStatus(row({ state: 'completed', pullRequestState: null }))).toBe('completed')
+  })
+
+  it('failed or cancelled tasks are completed even with a stray open PR', () => {
+    expect(deriveStatus(row({ state: 'failed', pullRequestUrl: 'https://x/pull/1', pullRequestState: 'OPEN' })))
+      .toBe('completed')
+    expect(deriveStatus(row({ state: 'cancelled', pullRequestUrl: 'https://x/pull/1', pullRequestState: 'OPEN' })))
+      .toBe('completed')
+  })
+})

--- a/src/main/copilot/github-source.ts
+++ b/src/main/copilot/github-source.ts
@@ -6,9 +6,9 @@
  */
 
 import { execFile } from 'child_process'
-import { accessSync, constants } from 'fs'
 import { promisify } from 'util'
 import { resolveProjectId } from './resolve-project'
+import { resolveGhPath, agentTaskEnv } from './gh'
 import type { CopilotSession, CopilotSessionStatus } from '../../shared/ipc-channels'
 
 const execFileAsync = promisify(execFile)
@@ -34,11 +34,20 @@ interface AgentTaskRow {
   pullRequestNumber: number | null
 }
 
-const TERMINAL_STATES = new Set(['completed', 'cancelled', 'failed'])
+export type { AgentTaskRow }
 
-function deriveStatus(row: AgentTaskRow): CopilotSessionStatus {
-  if (TERMINAL_STATES.has(row.state)) return 'completed'
-  if (row.pullRequestUrl !== null && row.pullRequestState === 'OPEN') return 'pr_ready'
+/**
+ * Map an agent task's lifecycle to a session status. The task lifecycle wins
+ * over PR existence: `gh agent-task create` opens a draft PR immediately, so a
+ * still-working task must NOT read as `pr_ready` just because a PR is open. Only
+ * a *successfully completed* task with an open PR is review-ready — a
+ * failed/cancelled task's leftover open PR is not.
+ */
+export function deriveStatus(row: AgentTaskRow): CopilotSessionStatus {
+  if (row.state === 'completed') {
+    return row.pullRequestState === 'OPEN' ? 'pr_ready' : 'completed'
+  }
+  if (row.state === 'failed' || row.state === 'cancelled') return 'completed'
   if (row.state === 'idle') return 'waiting'
   return 'in_progress'
 }
@@ -70,24 +79,10 @@ function mapRow(row: AgentTaskRow): CopilotSession {
     repoName,
     branch: null,
     linkedPrUrl: row.pullRequestUrl,
+    // Sticky assignment is owned by the DB (preserved across syncs); the gh list
+    // output carries no such notion. upsertSessions ignores this incoming value.
+    pinnedProjectId: null,
   }
-}
-
-/** Resolve the full path to the `gh` binary, checking common macOS install locations. */
-function resolveGhPath(): string {
-  const candidates = [
-    '/opt/homebrew/bin/gh',
-    '/usr/local/bin/gh',
-    '/usr/bin/gh',
-  ]
-  for (const p of candidates) {
-    try {
-      accessSync(p, constants.X_OK)
-      return p
-    } catch { /* not found, try next */ }
-  }
-  // Fall back to bare `gh` and hope it's on PATH
-  return 'gh'
 }
 
 const ghPath = resolveGhPath()
@@ -99,7 +94,7 @@ export async function fetchGithubSessions(): Promise<CopilotSession[]> {
       'agent-task', 'list',
       '--json', GH_FIELDS,
       '-L', '200',
-    ])
+    ], { env: agentTaskEnv() })
 
     const rows = JSON.parse(stdout) as AgentTaskRow[]
     return rows.map(mapRow)

--- a/src/main/copilot/launch-targets.ts
+++ b/src/main/copilot/launch-targets.ts
@@ -1,0 +1,39 @@
+/**
+ * Resolve the candidate repos an agent task can target for a given project.
+ *
+ * Projects don't own a repo column. A project relates to repos only through its
+ * repo rules and its routed notification threads, so we union those two sources
+ * (distinct). Repo-rule repos come first (an explicit user mapping), then
+ * thread repos by recency, so the launch composer preselects the most relevant
+ * one when there's exactly one — and offers a sensible order when there are many.
+ */
+
+import { getDb } from '../db'
+import type { LaunchTarget } from '../../shared/ipc-channels'
+
+interface RepoRow {
+  repo_owner: string
+  repo_name: string
+}
+
+export function getLaunchTargets(projectId: number): LaunchTarget[] {
+  const rows = getDb()
+    .prepare(`
+      SELECT repo_owner, repo_name, MIN(rank) AS rank, MAX(recency) AS recency
+      FROM (
+        SELECT repo_owner, repo_name, 0 AS rank, '' AS recency
+        FROM repo_rules
+        WHERE project_id = ?
+        UNION ALL
+        SELECT repo_owner, repo_name, 1 AS rank, MAX(updated_at) AS recency
+        FROM notification_threads
+        WHERE project_id = ?
+        GROUP BY repo_owner, repo_name
+      )
+      GROUP BY LOWER(repo_owner), LOWER(repo_name)
+      ORDER BY rank ASC, recency DESC, repo_owner ASC, repo_name ASC
+    `)
+    .all(projectId, projectId) as RepoRow[]
+
+  return rows.map((r) => ({ repoOwner: r.repo_owner, repoName: r.repo_name }))
+}

--- a/src/main/copilot/launch-targets.ts
+++ b/src/main/copilot/launch-targets.ts
@@ -19,7 +19,8 @@ interface RepoRow {
 export function getLaunchTargets(projectId: number): LaunchTarget[] {
   const rows = getDb()
     .prepare(`
-      SELECT repo_owner, repo_name, MIN(rank) AS rank, MAX(recency) AS recency
+      SELECT MIN(repo_owner) AS repo_owner, MIN(repo_name) AS repo_name,
+             MIN(rank) AS rank, MAX(recency) AS recency
       FROM (
         SELECT repo_owner, repo_name, 0 AS rank, '' AS recency
         FROM repo_rules

--- a/src/main/copilot/launch.test.ts
+++ b/src/main/copilot/launch.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest'
+import { parseAgentTaskCreateOutput, normalizeLaunchPayload } from './launch'
+
+describe('parseAgentTaskCreateOutput', () => {
+  it('extracts the session id and PR from a standard agent-session URL', () => {
+    const url = 'https://github.com/robert-crandall/gh-notifier/pull/73/agent-sessions/932fbdd1-5ad5-49f5-8546-03d0db3f874e'
+    const parsed = parseAgentTaskCreateOutput(`${url}\n`)
+    expect(parsed.sessionId).toBe('932fbdd1-5ad5-49f5-8546-03d0db3f874e')
+    expect(parsed.prNumber).toBe(73)
+    expect(parsed.prUrl).toBe('https://github.com/robert-crandall/gh-notifier/pull/73')
+    expect(parsed.sessionUrl).toBe(url)
+  })
+
+  it('takes the last non-empty line when gh prints extra output', () => {
+    const url = 'https://github.com/o/r/pull/5/agent-sessions/abc-123'
+    const parsed = parseAgentTaskCreateOutput(`Some preamble\n\n${url}\n`)
+    expect(parsed.sessionId).toBe('abc-123')
+    expect(parsed.prNumber).toBe(5)
+  })
+
+  it('handles a session URL with no PR segment', () => {
+    const url = 'https://github.com/o/r/agent-sessions/deadbeef-0000'
+    const parsed = parseAgentTaskCreateOutput(url)
+    expect(parsed.sessionId).toBe('deadbeef-0000')
+    expect(parsed.prNumber).toBeNull()
+    expect(parsed.prUrl).toBeNull()
+  })
+
+  it('strips query/hash from the session id', () => {
+    const parsed = parseAgentTaskCreateOutput('https://github.com/o/r/pull/9/agent-sessions/xyz-9?tab=logs')
+    expect(parsed.sessionId).toBe('xyz-9')
+    expect(parsed.prNumber).toBe(9)
+  })
+
+  it('throws when no agent-session id is present', () => {
+    expect(() => parseAgentTaskCreateOutput('not a url')).toThrow()
+    expect(() => parseAgentTaskCreateOutput('')).toThrow()
+  })
+})
+
+describe('normalizeLaunchPayload', () => {
+  it('trims and composes owner/repo', () => {
+    const n = normalizeLaunchPayload({
+      prompt: '  fix the flaky test  ',
+      repoOwner: ' o ',
+      repoName: ' r ',
+      projectId: 1,
+    })
+    expect(n.prompt).toBe('fix the flaky test')
+    expect(n.repo).toBe('o/r')
+    expect(n.baseBranch).toBeNull()
+  })
+
+  it('keeps a non-empty base branch', () => {
+    const n = normalizeLaunchPayload({
+      prompt: 'x', repoOwner: 'o', repoName: 'r', baseBranch: ' develop ', projectId: null,
+    })
+    expect(n.baseBranch).toBe('develop')
+  })
+
+  it('rejects an empty prompt', () => {
+    expect(() => normalizeLaunchPayload({ prompt: '   ', repoOwner: 'o', repoName: 'r', projectId: null }))
+      .toThrow(/prompt/i)
+  })
+
+  it('rejects a missing repo', () => {
+    expect(() => normalizeLaunchPayload({ prompt: 'x', repoOwner: '', repoName: 'r', projectId: null }))
+      .toThrow(/repository/i)
+    expect(() => normalizeLaunchPayload({ prompt: 'x', repoOwner: 'o', repoName: '  ', projectId: null }))
+      .toThrow(/repository/i)
+  })
+})

--- a/src/main/copilot/launch.ts
+++ b/src/main/copilot/launch.ts
@@ -1,0 +1,130 @@
+/**
+ * Launch a cloud `gh agent-task` and parse its result.
+ *
+ * `gh agent-task create` prints a single agent-session URL to stdout, e.g.
+ *   https://github.com/OWNER/REPO/pull/73/agent-sessions/932fbdd1-...-3f874e
+ * from which we extract the session UUID (the row id used across the app) and,
+ * when present, the PR number + plain PR URL.
+ */
+
+import { spawn } from 'child_process'
+import { resolveGhPath, agentTaskEnv } from './gh'
+import type { LaunchAgentTaskPayload } from '../../shared/ipc-channels'
+
+export interface ParsedAgentTaskCreate {
+  /** The agent-task session UUID (used as the copilot_sessions row id). */
+  sessionId: string
+  /** The full agent-session URL printed by gh. */
+  sessionUrl: string
+  /** PR number when the URL includes `/pull/<n>/`, else null. */
+  prNumber: number | null
+  /** Plain PR URL (session URL minus the `/agent-sessions/...` suffix), else null. */
+  prUrl: string | null
+}
+
+/** UUID (or other id) directly after `agent-sessions/`, up to a delimiter. */
+const SESSION_ID_RE = /agent-sessions\/([^/?\s#]+)/
+/** PR number in a `/pull/<n>` path segment. */
+const PR_NUMBER_RE = /\/pull\/(\d+)(?:[/?#]|$)/
+
+/**
+ * Parse `gh agent-task create` stdout into its session id + PR bits. Pure.
+ * Throws when no agent-session id can be found (unexpected output shape).
+ */
+export function parseAgentTaskCreateOutput(stdout: string): ParsedAgentTaskCreate {
+  const trimmed = stdout.trim()
+  // gh prints the URL on its own line; take the last non-empty line defensively.
+  const line = trimmed
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0)
+    .pop() ?? ''
+
+  const idMatch = SESSION_ID_RE.exec(line)
+  if (idMatch === null || idMatch[1] === undefined) {
+    throw new Error(`Could not parse agent-task session id from output: ${JSON.stringify(trimmed)}`)
+  }
+  const sessionId = idMatch[1]
+
+  let prNumber: number | null = null
+  let prUrl: string | null = null
+  const prMatch = PR_NUMBER_RE.exec(line)
+  if (prMatch !== null && prMatch[1] !== undefined) {
+    prNumber = Number(prMatch[1])
+    const suffixIdx = line.indexOf('/agent-sessions/')
+    prUrl = suffixIdx !== -1 ? line.slice(0, suffixIdx) : null
+  }
+
+  return { sessionId, sessionUrl: line, prNumber, prUrl }
+}
+
+export interface NormalizedLaunch {
+  prompt: string
+  repoOwner: string
+  repoName: string
+  /** `owner/repo`. */
+  repo: string
+  baseBranch: string | null
+}
+
+/** Validate + normalize a launch payload. Pure. Throws `LAUNCH_FAILED: ...` on bad input. */
+export function normalizeLaunchPayload(payload: LaunchAgentTaskPayload): NormalizedLaunch {
+  const prompt = payload.prompt.trim()
+  if (prompt.length === 0) throw new Error('LAUNCH_FAILED: a prompt is required')
+  const repoOwner = payload.repoOwner.trim()
+  const repoName = payload.repoName.trim()
+  if (repoOwner.length === 0 || repoName.length === 0) {
+    throw new Error('LAUNCH_FAILED: a target repository is required')
+  }
+  const baseBranch = payload.baseBranch?.trim() ? payload.baseBranch.trim() : null
+  return { prompt, repoOwner, repoName, repo: `${repoOwner}/${repoName}`, baseBranch }
+}
+
+interface GhResult {
+  stdout: string
+  stderr: string
+  code: number
+}
+
+/** Spawn gh with the given args, piping `stdin`, and collect stdio. */
+function runGh(args: string[], stdin: string): Promise<GhResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(resolveGhPath(), args, { env: agentTaskEnv() })
+    let stdout = ''
+    let stderr = ''
+    child.stdout.on('data', (d: Buffer) => { stdout += d.toString() })
+    child.stderr.on('data', (d: Buffer) => { stderr += d.toString() })
+    child.on('error', (err) => reject(err))
+    child.on('close', (code) => resolve({ stdout, stderr, code: code ?? -1 }))
+    child.stdin.write(stdin)
+    child.stdin.end()
+  })
+}
+
+/**
+ * Launch an agent task via `gh agent-task create`. The prompt is piped on stdin
+ * (`-F -`) so arbitrary content — leading dashes, newlines, long text — is safe.
+ * Runs in the main process, off the render thread.
+ */
+export async function launchAgentTask(payload: LaunchAgentTaskPayload): Promise<ParsedAgentTaskCreate> {
+  const { prompt, repo, baseBranch } = normalizeLaunchPayload(payload)
+  const args = ['agent-task', 'create', '-R', repo, '-F', '-']
+  if (baseBranch !== null) args.push('-b', baseBranch)
+
+  let result: GhResult
+  try {
+    result = await runGh(args, prompt)
+  } catch (err) {
+    throw new Error(`LAUNCH_FAILED: ${err instanceof Error ? err.message : String(err)}`, { cause: err })
+  }
+
+  if (result.code !== 0) {
+    const msg = result.stderr.trim()
+    if (/OAuth token|auth login|not logged in|authentication/i.test(msg)) {
+      throw new Error('GH_NOT_AUTHENTICATED')
+    }
+    throw new Error(`LAUNCH_FAILED: ${msg.length > 0 ? msg : `gh exited ${result.code}`}`)
+  }
+
+  return parseAgentTaskCreateOutput(result.stdout)
+}

--- a/src/main/db/projects.integration.test.ts
+++ b/src/main/db/projects.integration.test.ts
@@ -147,20 +147,22 @@ describe('deleteProject', () => {
     expect(() => getProject(p.id)).toThrow()
   })
 
-  it('CASCADE deletes associated todos and links', () => {
+  it('soft-deletes but keeps todos and links attached for restore', () => {
     const p = createProject('Parent')
     createTodo(p.id, 'Task')
     createLink(p.id, 'Link', 'https://example.com')
     deleteProject(p.id)
 
+    // deleteProject is a soft delete: the project is tombstoned but its todos and
+    // links stay attached so they come back if the project is restored.
     const todos = db
       .prepare('SELECT * FROM project_todos WHERE project_id = ?')
       .all(p.id)
     const links = db
       .prepare('SELECT * FROM project_links WHERE project_id = ?')
       .all(p.id)
-    expect(todos).toHaveLength(0)
-    expect(links).toHaveLength(0)
+    expect(todos).toHaveLength(1)
+    expect(links).toHaveLength(1)
   })
 })
 

--- a/src/main/db/projects.ts
+++ b/src/main/db/projects.ts
@@ -306,7 +306,7 @@ export function deleteProject(id: number): void {
       "UPDATE projects SET deleted_at = ?, updated_at = datetime('now') WHERE id = ? AND deleted_at IS NULL"
     ).run(new Date().toISOString(), id)
     db.prepare('UPDATE notification_threads SET project_id = NULL WHERE project_id = ?').run(id)
-    db.prepare('UPDATE copilot_sessions SET project_id = NULL WHERE project_id = ?').run(id)
+    db.prepare('UPDATE copilot_sessions SET project_id = NULL, pinned_project_id = NULL WHERE project_id = ? OR pinned_project_id = ?').run(id, id)
   })
   run()
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -24,10 +24,12 @@ import { listRoutingRules, createRoutingRule, deleteRoutingRule, applyRoutingRul
 import { startNotificationSync, syncOnce, prefetchThreadContent, getSyncIntervalMinutes, setSyncIntervalMinutes, rescheduleSync, getMaxSyncDays, setMaxSyncDays } from './notifications/sync'
 import { startSnoozeWatcher } from './snooze'
 import { syncCopilotSessions } from './copilot/sync'
-import { getSessionsForProject, getAllStatuses } from './copilot/db'
+import { getSessionsForProject, getAllStatuses, insertLaunchedSession, getUnassignedSessions, getUnassignedActiveCount, assignSession } from './copilot/db'
+import { launchAgentTask } from './copilot/launch'
+import { getLaunchTargets } from './copilot/launch-targets'
 import { getDigest, markProjectFocused, markDigestSeen, dismissResurface } from './digest'
 import { getDb } from './db'
-import type { ProjectPatch, ProjectTodoPatch, ProjectLinkPatch, SnoozeMode, SyncIntervalMinutes, MaxSyncDays, CreateRoutingRulePayload } from '../shared/ipc-channels'
+import type { ProjectPatch, ProjectTodoPatch, ProjectLinkPatch, SnoozeMode, SyncIntervalMinutes, MaxSyncDays, CreateRoutingRulePayload, LaunchAgentTaskPayload } from '../shared/ipc-channels'
 import { SYNC_INTERVAL_OPTIONS, MAX_SYNC_DAYS_OPTIONS } from '../shared/ipc-channels'
 
 /** Broadcasts a push event to all renderer windows. */
@@ -264,6 +266,35 @@ app.whenReady().then(async () => {
   ipcMain.handle('copilot:sync', async () => {
     await syncCopilotSessions()
   })
+
+  // Launch a cloud agent task off the render thread, optimistically track it,
+  // then reconcile the real title/status from GitHub in the background.
+  ipcMain.handle('copilot:launch', async (_event, payload: LaunchAgentTaskPayload) => {
+    const parsed = await launchAgentTask(payload)
+    const session = insertLaunchedSession({
+      id: parsed.sessionId,
+      title: payload.prompt.trim(),
+      repoOwner: payload.repoOwner.trim(),
+      repoName: payload.repoName.trim(),
+      htmlUrl: parsed.prUrl ?? parsed.sessionUrl,
+      linkedPrUrl: parsed.prUrl,
+      projectId: payload.projectId,
+    })
+    broadcast('copilot:updated')
+    void syncCopilotSessions().catch((err: unknown) => {
+      console.error('[copilot] Post-launch reconcile sync failed:', err)
+    })
+    return session
+  })
+
+  ipcMain.handle('copilot:unassigned', () => getUnassignedSessions())
+  ipcMain.handle('copilot:unassigned-count', () => getUnassignedActiveCount())
+  ipcMain.handle('copilot:assign', (_event, sessionId: string, projectId: number) => {
+    assignSession(sessionId, projectId)
+    broadcast('copilot:updated')
+    broadcast('projects:updated')
+  })
+  ipcMain.handle('copilot:launch-targets', (_event, projectId: number) => getLaunchTargets(projectId))
 
   // Focus: re-entry digest + drift handlers
   ipcMain.handle('digest:get', (_event, projectId: number) => getDigest(projectId))

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -8,6 +8,7 @@ import { UndoToast } from './components/UndoToast'
 import { FocusPage } from './pages/FocusPage'
 import { InboxView } from './pages/InboxView'
 import { SettingsView } from './pages/SettingsView'
+import { AgentTasksView } from './pages/AgentTasksView'
 import { EmptyFocus } from './pages/EmptyFocus'
 import { useProjects } from './hooks/useProjects'
 import { useTheme } from './hooks/useTheme'
@@ -15,7 +16,7 @@ import { useFocus } from './hooks/useFocus'
 import { useUndo } from './hooks/useUndo'
 import { parseDbTimestampMs } from '@shared/time'
 
-type View = 'focus' | 'inbox' | 'settings'
+type View = 'focus' | 'inbox' | 'settings' | 'agent-tasks'
 
 const SNOOZE_DAYS = 7
 
@@ -28,6 +29,7 @@ export function App(): JSX.Element {
   const [paletteOpen, setPaletteOpen] = useState(false)
   const [railCollapsed, setRailCollapsed] = useState(false)
   const [inboxCount, setInboxCount] = useState(0)
+  const [agentTaskCount, setAgentTaskCount] = useState(0)
 
   // Keep focus on a valid project; fall back to the first active one.
   useEffect(() => {
@@ -53,6 +55,21 @@ export function App(): JSX.Element {
     const unsub = window.electron.onNotificationsUpdated(() => { void loadInboxCount() })
     return unsub
   }, [loadInboxCount])
+
+  const loadAgentTaskCount = useCallback(async () => {
+    try {
+      const count = await window.electron.ipc.invoke('copilot:unassigned-count')
+      setAgentTaskCount(count)
+    } catch (err) {
+      console.error('[App] Failed to load unassigned agent task count:', err)
+    }
+  }, [])
+
+  useEffect(() => {
+    void loadAgentTaskCount()
+    const unsub = window.electron.onCopilotUpdated(() => { void loadAgentTaskCount() })
+    return unsub
+  }, [loadAgentTaskCount])
 
   // ⌘K opens the palette.
   useEffect(() => {
@@ -185,15 +202,19 @@ export function App(): JSX.Element {
           projects={projects}
           focusedId={focusedId}
           inboxCount={inboxCount}
+          agentTaskCount={agentTaskCount}
           collapsed={railCollapsed}
           onToggleCollapse={() => setRailCollapsed((v) => !v)}
           onSelect={selectProject}
           onSelectInbox={() => setView('inbox')}
+          onSelectAgentTasks={() => setView('agent-tasks')}
           onNewProject={() => void handleNewProject()}
         />
 
         {view === 'inbox' ? (
           <InboxView onAssigned={() => { void refreshProjects(); void loadInboxCount() }} />
+        ) : view === 'agent-tasks' ? (
+          <AgentTasksView />
         ) : view === 'settings' ? (
           <SettingsView theme={theme} onClose={() => setView('focus')} />
         ) : focusedId === null ? (

--- a/src/renderer/src/components/DelegateComposer.module.css
+++ b/src/renderer/src/components/DelegateComposer.module.css
@@ -57,6 +57,11 @@
   color: var(--text-2);
 }
 
+.close:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .body {
   display: flex;
   flex-direction: column;

--- a/src/renderer/src/components/DelegateComposer.module.css
+++ b/src/renderer/src/components/DelegateComposer.module.css
@@ -1,0 +1,191 @@
+.backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(1, 4, 9, 0.5);
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 14vh;
+  z-index: 120;
+}
+
+.panel {
+  width: 480px;
+  max-width: 90vw;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow: 0 24px 60px -16px rgba(0, 0, 0, 0.6);
+  overflow: hidden;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 12px;
+  height: 44px;
+  border-bottom: 1px solid var(--border-muted);
+}
+
+.headerIcon {
+  color: var(--accent-text);
+}
+
+.headerTitle {
+  flex: 1;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.close {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  background: none;
+  border: none;
+  border-radius: var(--radius-sm);
+  color: var(--text-3);
+  cursor: pointer;
+}
+
+.close:hover {
+  background: var(--bg-subtle);
+  color: var(--text-2);
+}
+
+.body {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 14px;
+}
+
+.label {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-3);
+  margin-top: 6px;
+}
+
+.prompt {
+  width: 100%;
+  resize: vertical;
+  min-height: 74px;
+  padding: 8px 10px;
+  background: var(--bg-inset);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text);
+  font-size: 13px;
+  font-family: inherit;
+  line-height: 1.5;
+  outline: none;
+}
+
+.prompt:focus,
+.input:focus,
+.select:focus {
+  border-color: var(--accent-border);
+}
+
+.select,
+.input {
+  width: 100%;
+  height: 32px;
+  padding: 0 10px;
+  background: var(--bg-inset);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text);
+  font-size: 13px;
+  outline: none;
+}
+
+.repoLocked {
+  height: 32px;
+  display: flex;
+  align-items: center;
+  padding: 0 10px;
+  background: var(--bg-inset);
+  border: 1px solid var(--border-muted);
+  border-radius: var(--radius);
+  color: var(--text-2);
+  font-size: 13px;
+  font-family: var(--font-mono);
+}
+
+.customRepo {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 6px;
+}
+
+.slash {
+  color: var(--text-3);
+}
+
+.error {
+  margin-top: 8px;
+  padding: 8px 10px;
+  background: rgba(248, 81, 73, 0.1);
+  border: 1px solid rgba(248, 81, 73, 0.4);
+  border-radius: var(--radius);
+  color: var(--danger);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 12px 14px;
+  border-top: 1px solid var(--border-muted);
+}
+
+.secondary,
+.primary {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 30px;
+  padding: 0 12px;
+  border-radius: var(--radius);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.secondary {
+  background: none;
+  border: 1px solid var(--border);
+  color: var(--text-2);
+}
+
+.secondary:hover:not(:disabled) {
+  background: var(--bg-subtle);
+  color: var(--text);
+}
+
+.primary {
+  background: var(--accent);
+  border: 1px solid var(--accent);
+  color: var(--accent-fg);
+}
+
+.primary:hover:not(:disabled) {
+  background: var(--accent-hover);
+}
+
+.primary:disabled,
+.secondary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/src/renderer/src/components/DelegateComposer.test.tsx
+++ b/src/renderer/src/components/DelegateComposer.test.tsx
@@ -63,6 +63,21 @@ describe('DelegateComposer', () => {
     expect(screen.getByText('Launch task').closest('button')?.hasAttribute('disabled')).toBe(true)
   })
 
+  it('closes on Escape', () => {
+    const onClose = vi.fn()
+    render(
+      <DelegateComposer
+        initialPrompt="x"
+        projectId={1}
+        fixedRepo={{ repoOwner: 'o', repoName: 'r' }}
+        onClose={onClose}
+        onLaunched={vi.fn()}
+      />
+    )
+    fireEvent.keyDown(window, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalled()
+  })
+
   it('surfaces a friendly auth error', async () => {
     invoke.mockRejectedValue(new Error('GH_NOT_AUTHENTICATED'))
     render(

--- a/src/renderer/src/components/DelegateComposer.test.tsx
+++ b/src/renderer/src/components/DelegateComposer.test.tsx
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import type { CopilotSession } from '@shared/ipc-channels'
+import { DelegateComposer } from './DelegateComposer'
+
+const invoke = vi.fn()
+
+beforeEach(() => {
+  invoke.mockReset()
+  ;(globalThis as unknown as { window: Window }).window.electron = {
+    ipc: { invoke },
+  } as unknown as Window['electron']
+})
+
+const session: CopilotSession = {
+  id: 's1', projectId: 1, source: 'github', status: 'in_progress', title: 'Fix it',
+  htmlUrl: 'https://x/pull/1', startedAt: '', updatedAt: '', repoOwner: 'o', repoName: 'r',
+  branch: null, linkedPrUrl: 'https://x/pull/1', pinnedProjectId: 1,
+}
+
+describe('DelegateComposer', () => {
+  it('pre-fills the prompt and launches with the fixed repo', async () => {
+    invoke.mockResolvedValue(session)
+    const onLaunched = vi.fn()
+    const onClose = vi.fn()
+    render(
+      <DelegateComposer
+        initialPrompt="Fix the flaky test"
+        projectId={1}
+        fixedRepo={{ repoOwner: 'o', repoName: 'r' }}
+        onClose={onClose}
+        onLaunched={onLaunched}
+      />
+    )
+
+    expect((screen.getByLabelText('Task') as HTMLTextAreaElement).value).toBe('Fix the flaky test')
+    expect(screen.getByText('o/r')).toBeTruthy()
+
+    fireEvent.click(screen.getByText('Launch task'))
+
+    await waitFor(() => expect(invoke).toHaveBeenCalledWith('copilot:launch', {
+      prompt: 'Fix the flaky test',
+      repoOwner: 'o',
+      repoName: 'r',
+      baseBranch: undefined,
+      projectId: 1,
+    }))
+    await waitFor(() => expect(onLaunched).toHaveBeenCalledWith(session))
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('disables Launch when the prompt is empty', () => {
+    render(
+      <DelegateComposer
+        initialPrompt=""
+        projectId={1}
+        fixedRepo={{ repoOwner: 'o', repoName: 'r' }}
+        onClose={vi.fn()}
+        onLaunched={vi.fn()}
+      />
+    )
+    expect(screen.getByText('Launch task').closest('button')?.hasAttribute('disabled')).toBe(true)
+  })
+
+  it('surfaces a friendly auth error', async () => {
+    invoke.mockRejectedValue(new Error('GH_NOT_AUTHENTICATED'))
+    render(
+      <DelegateComposer
+        initialPrompt="do a thing"
+        projectId={1}
+        fixedRepo={{ repoOwner: 'o', repoName: 'r' }}
+        onClose={vi.fn()}
+        onLaunched={vi.fn()}
+      />
+    )
+    fireEvent.click(screen.getByText('Launch task'))
+    expect(await screen.findByText(/gh auth login/)).toBeTruthy()
+  })
+})

--- a/src/renderer/src/components/DelegateComposer.tsx
+++ b/src/renderer/src/components/DelegateComposer.tsx
@@ -118,12 +118,12 @@ export function DelegateComposer({
   }
 
   return (
-    <div className={styles.backdrop} onClick={onClose}>
+    <div className={styles.backdrop} onClick={() => { if (!busy) onClose() }}>
       <div className={styles.panel} onClick={(e) => e.stopPropagation()} role="dialog" aria-modal="true" aria-label="Delegate to Copilot">
         <div className={styles.header}>
           <Icon icon={Sparkles} size={15} className={styles.headerIcon} />
           <span className={styles.headerTitle}>Delegate to Copilot</span>
-          <button type="button" className={styles.close} onClick={onClose} aria-label="Close">
+          <button type="button" className={styles.close} onClick={onClose} disabled={busy} aria-label="Close">
             <Icon icon={X} size={15} />
           </button>
         </div>

--- a/src/renderer/src/components/DelegateComposer.tsx
+++ b/src/renderer/src/components/DelegateComposer.tsx
@@ -150,6 +150,7 @@ export function DelegateComposer({
                     className={styles.input}
                     value={customOwner}
                     placeholder="owner"
+                    aria-label="Repository owner"
                     onChange={(e) => setCustomOwner(e.target.value)}
                   />
                   <span className={styles.slash}>/</span>
@@ -157,6 +158,7 @@ export function DelegateComposer({
                     className={styles.input}
                     value={customName}
                     placeholder="repo"
+                    aria-label="Repository name"
                     onChange={(e) => setCustomName(e.target.value)}
                   />
                 </div>

--- a/src/renderer/src/components/DelegateComposer.tsx
+++ b/src/renderer/src/components/DelegateComposer.tsx
@@ -1,0 +1,191 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { Sparkles, X } from 'lucide-react'
+import type { CopilotSession, LaunchTarget } from '@shared/ipc-channels'
+import { Icon } from './Icon'
+import styles from './DelegateComposer.module.css'
+
+export interface DelegateComposerProps {
+  /** Pre-filled task description (from the next action / todo / notification). */
+  initialPrompt: string
+  /** Originating project to pin the launched session to, or null. */
+  projectId: number | null
+  /**
+   * A fixed target repo (e.g. launched from a notification, where the repo is
+   * unambiguous). When set, repo resolution is skipped.
+   */
+  fixedRepo?: LaunchTarget
+  onClose: () => void
+  onLaunched: (session: CopilotSession) => void
+}
+
+const OTHER_REPO = '__other__'
+
+function repoKey(t: LaunchTarget): string {
+  return `${t.repoOwner}/${t.repoName}`
+}
+
+function friendlyError(message: string): string {
+  if (message.includes('GH_NOT_AUTHENTICATED')) {
+    return 'gh isn’t authenticated for agent tasks. Run `gh auth login` in a terminal, then try again.'
+  }
+  const stripped = message.replace(/^Error:\s*/, '').replace(/^LAUNCH_FAILED:\s*/, '')
+  return stripped.length > 0 ? stripped : 'Could not launch the task.'
+}
+
+export function DelegateComposer({
+  initialPrompt,
+  projectId,
+  fixedRepo,
+  onClose,
+  onLaunched,
+}: DelegateComposerProps): JSX.Element {
+  const [prompt, setPrompt] = useState(initialPrompt)
+  const [targets, setTargets] = useState<LaunchTarget[]>(fixedRepo ? [fixedRepo] : [])
+  const [selected, setSelected] = useState<string>(fixedRepo ? repoKey(fixedRepo) : OTHER_REPO)
+  const [customOwner, setCustomOwner] = useState('')
+  const [customName, setCustomName] = useState('')
+  const [baseBranch, setBaseBranch] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const promptRef = useRef<HTMLTextAreaElement>(null)
+
+  // Resolve candidate repos for a project-originated launch (skip when fixed).
+  useEffect(() => {
+    if (fixedRepo || projectId === null) return
+    let active = true
+    void (async () => {
+      try {
+        const list = await window.electron.ipc.invoke('copilot:launch-targets', projectId)
+        if (!active) return
+        setTargets(list)
+        setSelected(list.length > 0 ? repoKey(list[0]) : OTHER_REPO)
+      } catch (err) {
+        console.error('[DelegateComposer] Failed to load launch targets:', err)
+        if (active) setSelected(OTHER_REPO)
+      }
+    })()
+    return () => { active = false }
+  }, [fixedRepo, projectId])
+
+  useEffect(() => {
+    promptRef.current?.focus()
+  }, [])
+
+  const repoLocked = fixedRepo !== undefined
+  const usingCustom = !repoLocked && selected === OTHER_REPO
+
+  const resolvedRepo = useMemo<LaunchTarget | null>(() => {
+    if (usingCustom) {
+      const owner = customOwner.trim()
+      const name = customName.trim()
+      return owner.length > 0 && name.length > 0 ? { repoOwner: owner, repoName: name } : null
+    }
+    return targets.find((t) => repoKey(t) === selected) ?? null
+  }, [usingCustom, customOwner, customName, targets, selected])
+
+  const canLaunch = prompt.trim().length > 0 && resolvedRepo !== null && !busy
+
+  const launch = async (): Promise<void> => {
+    if (resolvedRepo === null || prompt.trim().length === 0) return
+    setBusy(true)
+    setError(null)
+    try {
+      const session = await window.electron.ipc.invoke('copilot:launch', {
+        prompt: prompt.trim(),
+        repoOwner: resolvedRepo.repoOwner,
+        repoName: resolvedRepo.repoName,
+        baseBranch: baseBranch.trim() || undefined,
+        projectId,
+      })
+      onLaunched(session)
+      onClose()
+    } catch (err: unknown) {
+      setError(friendlyError(err instanceof Error ? err.message : String(err)))
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className={styles.backdrop} onClick={onClose}>
+      <div className={styles.panel} onClick={(e) => e.stopPropagation()} role="dialog" aria-label="Delegate to Copilot">
+        <div className={styles.header}>
+          <Icon icon={Sparkles} size={15} className={styles.headerIcon} />
+          <span className={styles.headerTitle}>Delegate to Copilot</span>
+          <button type="button" className={styles.close} onClick={onClose} aria-label="Close">
+            <Icon icon={X} size={15} />
+          </button>
+        </div>
+
+        <div className={styles.body}>
+          <label className={styles.label} htmlFor="delegate-prompt">Task</label>
+          <textarea
+            id="delegate-prompt"
+            ref={promptRef}
+            className={styles.prompt}
+            value={prompt}
+            rows={4}
+            placeholder="Describe the task for Copilot to finish…"
+            onChange={(e) => setPrompt(e.target.value)}
+          />
+
+          <label className={styles.label} htmlFor="delegate-repo">Repository</label>
+          {repoLocked ? (
+            <div className={styles.repoLocked}>{repoKey(fixedRepo)}</div>
+          ) : (
+            <>
+              <select
+                id="delegate-repo"
+                className={styles.select}
+                value={selected}
+                onChange={(e) => setSelected(e.target.value)}
+              >
+                {targets.map((t) => (
+                  <option key={repoKey(t)} value={repoKey(t)}>{repoKey(t)}</option>
+                ))}
+                <option value={OTHER_REPO}>Other repo…</option>
+              </select>
+              {usingCustom && (
+                <div className={styles.customRepo}>
+                  <input
+                    className={styles.input}
+                    value={customOwner}
+                    placeholder="owner"
+                    onChange={(e) => setCustomOwner(e.target.value)}
+                  />
+                  <span className={styles.slash}>/</span>
+                  <input
+                    className={styles.input}
+                    value={customName}
+                    placeholder="repo"
+                    onChange={(e) => setCustomName(e.target.value)}
+                  />
+                </div>
+              )}
+            </>
+          )}
+
+          <label className={styles.label} htmlFor="delegate-base">Base branch (optional)</label>
+          <input
+            id="delegate-base"
+            className={styles.input}
+            value={baseBranch}
+            placeholder="default branch"
+            onChange={(e) => setBaseBranch(e.target.value)}
+          />
+
+          {error && <div className={styles.error}>{error}</div>}
+        </div>
+
+        <div className={styles.footer}>
+          <button type="button" className={styles.secondary} onClick={onClose} disabled={busy}>
+            Cancel
+          </button>
+          <button type="button" className={styles.primary} onClick={() => void launch()} disabled={!canLaunch}>
+            <Icon icon={Sparkles} size={14} />
+            {busy ? 'Launching…' : 'Launch task'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/DelegateComposer.tsx
+++ b/src/renderer/src/components/DelegateComposer.tsx
@@ -71,6 +71,18 @@ export function DelegateComposer({
     promptRef.current?.focus()
   }, [])
 
+  // Escape closes the dialog (unless a launch is mid-flight), matching CommandPalette.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape' && !busy) {
+        e.preventDefault()
+        onClose()
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [onClose, busy])
+
   const repoLocked = fixedRepo !== undefined
   const usingCustom = !repoLocked && selected === OTHER_REPO
 
@@ -107,7 +119,7 @@ export function DelegateComposer({
 
   return (
     <div className={styles.backdrop} onClick={onClose}>
-      <div className={styles.panel} onClick={(e) => e.stopPropagation()} role="dialog" aria-label="Delegate to Copilot">
+      <div className={styles.panel} onClick={(e) => e.stopPropagation()} role="dialog" aria-modal="true" aria-label="Delegate to Copilot">
         <div className={styles.header}>
           <Icon icon={Sparkles} size={15} className={styles.headerIcon} />
           <span className={styles.headerTitle}>Delegate to Copilot</span>

--- a/src/renderer/src/components/NextAction.test.tsx
+++ b/src/renderer/src/components/NextAction.test.tsx
@@ -5,19 +5,19 @@ import { NextAction } from './NextAction'
 
 describe('NextAction', () => {
   it('shows the current next action', () => {
-    render(<NextAction value="Wire the retry backoff" onSave={vi.fn()} onDone={vi.fn()} />)
+    render(<NextAction value="Wire the retry backoff" onSave={vi.fn()} onDone={vi.fn()} onDelegate={vi.fn()} />)
     expect(screen.getByText('Wire the retry backoff')).toBeTruthy()
   })
 
   it('shows a placeholder when empty and disables Done', () => {
-    render(<NextAction value="" onSave={vi.fn()} onDone={vi.fn()} />)
+    render(<NextAction value="" onSave={vi.fn()} onDone={vi.fn()} onDelegate={vi.fn()} />)
     expect(screen.getByText('Set your next action…')).toBeTruthy()
     expect(screen.getByText('Done').closest('button')?.hasAttribute('disabled')).toBe(true)
   })
 
   it('saves an edited value on Enter', () => {
     const onSave = vi.fn()
-    render(<NextAction value="old" onSave={onSave} onDone={vi.fn()} />)
+    render(<NextAction value="old" onSave={onSave} onDone={vi.fn()} onDelegate={vi.fn()} />)
     fireEvent.click(screen.getByText('old'))
     const input = screen.getByPlaceholderText(/one next thing/)
     fireEvent.change(input, { target: { value: 'new action' } })
@@ -27,8 +27,18 @@ describe('NextAction', () => {
 
   it('calls onDone when Done is clicked', () => {
     const onDone = vi.fn()
-    render(<NextAction value="something" onSave={vi.fn()} onDone={onDone} />)
+    render(<NextAction value="something" onSave={vi.fn()} onDone={onDone} onDelegate={vi.fn()} />)
     fireEvent.click(screen.getByText('Done'))
     expect(onDone).toHaveBeenCalledOnce()
+  })
+
+  it('delegates the current value and disables Delegate when empty', () => {
+    const onDelegate = vi.fn()
+    const { rerender } = render(<NextAction value="" onSave={vi.fn()} onDone={vi.fn()} onDelegate={onDelegate} />)
+    expect(screen.getByText('Delegate').closest('button')?.hasAttribute('disabled')).toBe(true)
+
+    rerender(<NextAction value="Ship it" onSave={vi.fn()} onDone={vi.fn()} onDelegate={onDelegate} />)
+    fireEvent.click(screen.getByText('Delegate'))
+    expect(onDelegate).toHaveBeenCalledWith('Ship it')
   })
 })

--- a/src/renderer/src/components/NextAction.tsx
+++ b/src/renderer/src/components/NextAction.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
-import { Pencil, Check } from 'lucide-react'
+import { Pencil, Check, Sparkles } from 'lucide-react'
 import { Icon } from './Icon'
 import styles from './NextAction.module.css'
 
@@ -7,9 +7,11 @@ interface NextActionProps {
   value: string
   onSave: (text: string) => void
   onDone: () => void
+  /** Hand this next action to a cloud Copilot agent task. */
+  onDelegate: (prompt: string) => void
 }
 
-export function NextAction({ value, onSave, onDone }: NextActionProps): JSX.Element {
+export function NextAction({ value, onSave, onDone, onDelegate }: NextActionProps): JSX.Element {
   const [editing, setEditing] = useState(false)
   const [draft, setDraft] = useState(value)
   const inputRef = useRef<HTMLTextAreaElement>(null)
@@ -71,6 +73,16 @@ export function NextAction({ value, onSave, onDone }: NextActionProps): JSX.Elem
         <button type="button" className={styles.secondary} onClick={() => setEditing(true)}>
           <Icon icon={Pencil} size={14} />
           Edit
+        </button>
+        <button
+          type="button"
+          className={styles.secondary}
+          onClick={() => onDelegate(value)}
+          disabled={!hasValue}
+          title="Hand this to a Copilot agent task"
+        >
+          <Icon icon={Sparkles} size={14} />
+          Delegate
         </button>
         <button type="button" className={styles.primary} onClick={onDone} disabled={!hasValue}>
           <Icon icon={Check} size={14} />

--- a/src/renderer/src/components/ProjectRail.tsx
+++ b/src/renderer/src/components/ProjectRail.tsx
@@ -9,10 +9,12 @@ interface ProjectRailProps {
   projects: Project[]
   focusedId: number | null
   inboxCount: number
+  agentTaskCount: number
   collapsed: boolean
   onToggleCollapse: () => void
   onSelect: (id: number) => void
   onSelectInbox: () => void
+  onSelectAgentTasks: () => void
   onNewProject: () => void
 }
 
@@ -29,10 +31,12 @@ export function ProjectRail({
   projects,
   focusedId,
   inboxCount,
+  agentTaskCount,
   collapsed,
   onToggleCollapse,
   onSelect,
   onSelectInbox,
+  onSelectAgentTasks,
   onNewProject,
 }: ProjectRailProps): JSX.Element {
   const [parkedOpen, setParkedOpen] = useState(false)
@@ -63,6 +67,9 @@ export function ProjectRail({
           })}
         </div>
         <div className={styles.spacer} />
+        <button type="button" className={styles.collapsedItem} title="Agent tasks" aria-label="Agent tasks" onClick={onSelectAgentTasks}>
+          <Icon icon={Sparkles} size={16} />
+        </button>
         <button type="button" className={styles.collapsedItem} title="Inbox" aria-label="Inbox" onClick={onSelectInbox}>
           <Icon icon={Inbox} size={16} />
         </button>
@@ -119,6 +126,11 @@ export function ProjectRail({
       <div className={styles.spacer} />
 
       <div className={styles.footer}>
+        <button type="button" className={styles.item} onClick={onSelectAgentTasks}>
+          <Icon icon={Sparkles} size={15} />
+          <span className={styles.itemName}>Agent tasks</span>
+          {agentTaskCount > 0 && <span className={styles.badge}>{agentTaskCount}</span>}
+        </button>
         <button type="button" className={styles.item} onClick={onSelectInbox}>
           <Icon icon={Inbox} size={15} />
           <span className={styles.itemName}>Inbox</span>

--- a/src/renderer/src/components/ReentryDigest.test.tsx
+++ b/src/renderer/src/components/ReentryDigest.test.tsx
@@ -4,10 +4,10 @@ import { render, screen, fireEvent } from '@testing-library/react'
 import type { ReentryDigest as ReentryDigestType } from '@shared/ipc-channels'
 import { ReentryDigest } from './ReentryDigest'
 
-const openExternal = vi.fn()
+const openExternal = vi.fn(() => Promise.resolve())
 
 beforeEach(() => {
-  openExternal.mockReset()
+  openExternal.mockClear()
   ;(globalThis as unknown as { window: Window }).window.electron = {
     openExternal,
   } as unknown as Window['electron']

--- a/src/renderer/src/components/WorkingColumn.module.css
+++ b/src/renderer/src/components/WorkingColumn.module.css
@@ -273,12 +273,6 @@
   gap: 11px;
   padding: 9px 6px;
   border-bottom: 1px solid var(--border-muted);
-  background: none;
-  border-left: none;
-  border-right: none;
-  border-top: none;
-  cursor: pointer;
-  text-align: left;
   width: 100%;
 }
 

--- a/src/renderer/src/components/WorkingColumn.module.css
+++ b/src/renderer/src/components/WorkingColumn.module.css
@@ -147,12 +147,17 @@
 }
 
 .todoRow:hover .rowAction,
-.resourceRow:hover .rowAction {
+.resourceRow:hover .rowAction,
+.notifRow:hover .rowAction {
   opacity: 1;
 }
 
 .rowAction:hover {
   color: var(--danger);
+}
+
+.rowAction.delegate:hover {
+  color: var(--accent-text);
 }
 
 .divider {
@@ -279,6 +284,20 @@
 
 .notifRow:hover {
   background: var(--bg-subtle);
+}
+
+.notifContent {
+  flex: 1;
+  display: flex;
+  align-items: flex-start;
+  gap: 11px;
+  min-width: 0;
+  padding: 0;
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  text-align: left;
 }
 
 .notifIcon {

--- a/src/renderer/src/components/WorkingColumn.tsx
+++ b/src/renderer/src/components/WorkingColumn.tsx
@@ -15,8 +15,9 @@ import {
   CircleAlert,
   ExternalLink,
   Trash2,
+  Sparkles,
 } from 'lucide-react'
-import type { NotificationThread, NotificationType, ProjectDetail, ProjectLink, ProjectTodo } from '@shared/ipc-channels'
+import type { NotificationThread, NotificationType, ProjectDetail, ProjectLink, ProjectTodo, LaunchTarget } from '@shared/ipc-channels'
 import type { LucideIcon } from 'lucide-react'
 import { Icon } from './Icon'
 import { fire, openExternal } from '../ipc'
@@ -32,6 +33,8 @@ interface WorkingColumnProps {
   onSaveNotes: (notes: string) => void
   onCreateLink: (label: string, url: string) => void
   onDeleteLink: (link: ProjectLink) => void
+  /** Hand a todo or notification to a cloud Copilot agent task. */
+  onDelegate: (prompt: string, fixedRepo?: LaunchTarget) => void
 }
 
 function relativeTime(iso: string): string {
@@ -49,7 +52,8 @@ function TodosPanel({
   onCreateTodo,
   onToggleTodo,
   onDeleteTodo,
-}: Pick<WorkingColumnProps, 'detail' | 'onCreateTodo' | 'onToggleTodo' | 'onDeleteTodo'>): JSX.Element {
+  onDelegate,
+}: Pick<WorkingColumnProps, 'detail' | 'onCreateTodo' | 'onToggleTodo' | 'onDeleteTodo' | 'onDelegate'>): JSX.Element {
   const [text, setText] = useState('')
   const active = detail.todos.filter((t) => !t.done)
   const done = detail.todos.filter((t) => t.done)
@@ -77,6 +81,9 @@ function TodosPanel({
         <div key={t.id} className={styles.todoRow}>
           <button type="button" className={styles.checkbox} onClick={() => onToggleTodo(t)} aria-label="Mark done" />
           <span className={styles.todoText}>{t.text}</span>
+          <button type="button" className={styles.rowAction} onClick={() => onDelegate(t.text)} aria-label="Delegate to Copilot" title="Delegate to Copilot">
+            <Icon icon={Sparkles} size={13} />
+          </button>
           <button type="button" className={styles.rowAction} onClick={() => onDeleteTodo(t)} aria-label="Delete todo">
             <Icon icon={Trash2} size={13} />
           </button>
@@ -179,7 +186,7 @@ const NOTIF_ICON: Record<NotificationType, LucideIcon> = {
   CheckSuite: CircleAlert,
 }
 
-function NotificationsPanel({ projectId }: { projectId: number }): JSX.Element {
+function NotificationsPanel({ projectId, onDelegate }: { projectId: number; onDelegate: WorkingColumnProps['onDelegate'] }): JSX.Element {
   const [threads, setThreads] = useState<NotificationThread[]>([])
 
   useEffect(() => {
@@ -212,16 +219,27 @@ function NotificationsPanel({ projectId }: { projectId: number }): JSX.Element {
   return (
     <div className={styles.notifs}>
       {threads.map((t) => (
-        <button type="button" key={t.id} className={styles.notifRow} onClick={() => open(t)}>
-          <Icon icon={NOTIF_ICON[t.type] ?? Bell} size={16} className={styles.notifIcon} />
-          <div className={styles.notifBody}>
-            <div className={styles.notifTitle}>{t.title}</div>
-            <div className={styles.notifMeta}>
-              {t.repoOwner}/{t.repoName} · {relativeTime(t.updatedAt)}
+        <div key={t.id} className={styles.notifRow}>
+          <button type="button" className={styles.notifContent} onClick={() => open(t)}>
+            <Icon icon={NOTIF_ICON[t.type] ?? Bell} size={16} className={styles.notifIcon} />
+            <div className={styles.notifBody}>
+              <div className={styles.notifTitle}>{t.title}</div>
+              <div className={styles.notifMeta}>
+                {t.repoOwner}/{t.repoName} · {relativeTime(t.updatedAt)}
+              </div>
             </div>
-          </div>
+          </button>
+          <button
+            type="button"
+            className={`${styles.rowAction} ${styles.delegate}`}
+            onClick={() => onDelegate(t.title, { repoOwner: t.repoOwner, repoName: t.repoName })}
+            aria-label="Delegate to Copilot"
+            title="Delegate to Copilot"
+          >
+            <Icon icon={Sparkles} size={13} />
+          </button>
           {t.unread && <span className={styles.unreadDot} aria-hidden />}
-        </button>
+        </div>
       ))}
     </div>
   )
@@ -266,13 +284,14 @@ export function WorkingColumn(props: WorkingColumnProps): JSX.Element {
             onCreateTodo={props.onCreateTodo}
             onToggleTodo={props.onToggleTodo}
             onDeleteTodo={props.onDeleteTodo}
+            onDelegate={props.onDelegate}
           />
         )}
         {tab === 'notes' && <NotesPanel detail={props.detail} onSaveNotes={props.onSaveNotes} />}
         {tab === 'resources' && (
           <ResourcesPanel detail={props.detail} onCreateLink={props.onCreateLink} onDeleteLink={props.onDeleteLink} />
         )}
-        {tab === 'notifications' && <NotificationsPanel projectId={props.detail.id} />}
+        {tab === 'notifications' && <NotificationsPanel projectId={props.detail.id} onDelegate={props.onDelegate} />}
       </div>
     </div>
   )

--- a/src/renderer/src/pages/AgentTasksView.module.css
+++ b/src/renderer/src/pages/AgentTasksView.module.css
@@ -1,0 +1,130 @@
+.main {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.toolbar {
+  height: 46px;
+  flex: none;
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  padding: 0 24px;
+  border-bottom: 1px solid var(--border-muted);
+}
+
+.heading {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.sub {
+  font-size: 12px;
+  color: var(--text-3);
+}
+
+.content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px 24px 24px;
+}
+
+.empty {
+  padding: 32px 0;
+  text-align: center;
+  color: var(--text-3);
+  font-size: 13px;
+}
+
+.sectionLabel {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-3);
+  margin: 16px 0 6px;
+}
+
+.sectionLabel:first-child {
+  margin-top: 4px;
+}
+
+.row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 6px;
+  border-bottom: 1px solid var(--border-muted);
+}
+
+.status {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: none;
+}
+
+.toneAgent {
+  color: var(--accent-text);
+}
+
+.toneAttention {
+  color: var(--attention);
+}
+
+.toneQuiet {
+  color: var(--text-3);
+}
+
+.body {
+  flex: 1;
+  min-width: 0;
+}
+
+.title {
+  font-size: 13px;
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.meta {
+  font-size: 11.5px;
+  color: var(--text-3);
+  margin-top: 2px;
+}
+
+.assign {
+  height: 28px;
+  padding: 0 8px;
+  font-size: 12px;
+  color: var(--text-2);
+  background: var(--bg-inset);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+
+.rowAction {
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  color: var(--text-3);
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  flex: none;
+}
+
+.rowAction:hover {
+  background: var(--bg-subtle);
+  color: var(--text);
+}

--- a/src/renderer/src/pages/AgentTasksView.test.tsx
+++ b/src/renderer/src/pages/AgentTasksView.test.tsx
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import type { CopilotSession, Project } from '@shared/ipc-channels'
+import { AgentTasksView } from './AgentTasksView'
+
+const invoke = vi.fn()
+const onCopilotUpdated = vi.fn(() => () => {})
+
+beforeEach(() => {
+  invoke.mockReset()
+  onCopilotUpdated.mockClear()
+  ;(globalThis as unknown as { window: Window }).window.electron = {
+    ipc: { invoke },
+    openExternal: vi.fn(() => Promise.resolve()),
+    onCopilotUpdated,
+  } as unknown as Window['electron']
+})
+
+function session(overrides: Partial<CopilotSession>): CopilotSession {
+  return {
+    id: 'x', projectId: null, source: 'github', status: 'in_progress', title: 'A task',
+    htmlUrl: null, startedAt: '2026-07-02T00:00:00Z', updatedAt: '2026-07-02T00:00:00Z',
+    repoOwner: 'o', repoName: 'r', branch: null, linkedPrUrl: null, pinnedProjectId: null,
+    ...overrides,
+  }
+}
+
+const project: Project = {
+  id: 1, name: 'Alpha', notes: '', nextAction: '', status: 'active', sortOrder: 0,
+  createdAt: '', updatedAt: '', unreadCount: 0, activeTodoCount: 0, snoozeMode: null,
+  snoozeUntil: null, copilotStatus: null, lastFocusedAt: null, driftState: 'active',
+}
+
+function mockInvoke(sessions: CopilotSession[]): void {
+  invoke.mockImplementation((channel: string) => {
+    if (channel === 'copilot:unassigned') return Promise.resolve(sessions)
+    if (channel === 'projects:list') return Promise.resolve([project])
+    if (channel === 'copilot:assign') return Promise.resolve(undefined)
+    return Promise.resolve(undefined)
+  })
+}
+
+describe('AgentTasksView', () => {
+  it('groups active vs completed and shows an empty state', async () => {
+    mockInvoke([])
+    render(<AgentTasksView />)
+    expect(await screen.findByText(/No unassigned agent tasks/)).toBeTruthy()
+  })
+
+  it('lists active and completed sessions in sections', async () => {
+    mockInvoke([
+      session({ id: 'a', status: 'in_progress', title: 'Active one' }),
+      session({ id: 'b', status: 'completed', title: 'Done one' }),
+    ])
+    render(<AgentTasksView />)
+    expect(await screen.findByText('Active one')).toBeTruthy()
+    expect(screen.getByText('Done one')).toBeTruthy()
+    expect(screen.getByText('Active')).toBeTruthy()
+    expect(screen.getByText('Recently completed')).toBeTruthy()
+  })
+
+  it('assigns a session to a project', async () => {
+    mockInvoke([session({ id: 'a', title: 'Active one' })])
+    render(<AgentTasksView />)
+    await screen.findByText('Active one')
+
+    const select = screen.getByRole('combobox') as HTMLSelectElement
+    fireEvent.change(select, { target: { value: '1' } })
+
+    await waitFor(() => expect(invoke).toHaveBeenCalledWith('copilot:assign', 'a', 1))
+  })
+})

--- a/src/renderer/src/pages/AgentTasksView.tsx
+++ b/src/renderer/src/pages/AgentTasksView.tsx
@@ -1,0 +1,151 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { formatDistanceToNow, parseISO } from 'date-fns'
+import { Sparkles, GitPullRequest, PauseCircle, CheckCircle2, ExternalLink } from 'lucide-react'
+import type { CopilotSession, CopilotSessionStatus, Project } from '@shared/ipc-channels'
+import type { LucideIcon } from 'lucide-react'
+import { Icon } from '../components/Icon'
+import { openExternal } from '../ipc'
+import styles from './AgentTasksView.module.css'
+
+const STATUS_META: Record<CopilotSessionStatus, { label: string; icon: LucideIcon; tone: string }> = {
+  in_progress: { label: 'Working', icon: Sparkles, tone: styles.toneAgent },
+  waiting: { label: 'Needs you', icon: PauseCircle, tone: styles.toneAttention },
+  pr_ready: { label: 'PR ready', icon: GitPullRequest, tone: styles.toneAttention },
+  completed: { label: 'Done', icon: CheckCircle2, tone: styles.toneQuiet },
+}
+
+function relativeTime(iso: string): string {
+  try {
+    const parsed = parseISO(iso)
+    return Number.isNaN(parsed.getTime()) ? '' : formatDistanceToNow(parsed, { addSuffix: true })
+  } catch {
+    return ''
+  }
+}
+
+function SessionRow({
+  session,
+  projects,
+  onAssign,
+}: {
+  session: CopilotSession
+  projects: Project[]
+  onAssign: (sessionId: string, projectId: number) => void
+}): JSX.Element {
+  const meta = STATUS_META[session.status]
+  return (
+    <div className={styles.row}>
+      <span className={`${styles.status} ${meta.tone}`} title={meta.label}>
+        <Icon icon={meta.icon} size={15} />
+      </span>
+      <div className={styles.body}>
+        <div className={styles.title}>{session.title || 'Untitled task'}</div>
+        <div className={styles.meta}>
+          {session.repoOwner && session.repoName ? `${session.repoOwner}/${session.repoName} · ` : ''}
+          {meta.label} · {relativeTime(session.updatedAt)}
+        </div>
+      </div>
+      <select
+        className={styles.assign}
+        value=""
+        onChange={(e) => e.target.value && onAssign(session.id, Number(e.target.value))}
+      >
+        <option value="">Assign…</option>
+        {projects.map((p) => (
+          <option key={p.id} value={p.id}>{p.name}</option>
+        ))}
+      </select>
+      {session.htmlUrl && (
+        <button
+          type="button"
+          className={styles.rowAction}
+          onClick={() => openExternal(session.htmlUrl as string)}
+          aria-label="Open on GitHub"
+        >
+          <Icon icon={ExternalLink} size={14} />
+        </button>
+      )}
+    </div>
+  )
+}
+
+export function AgentTasksView(): JSX.Element {
+  const [sessions, setSessions] = useState<CopilotSession[]>([])
+  const [projects, setProjects] = useState<Project[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const mountedRef = useRef(true)
+
+  useEffect(() => {
+    mountedRef.current = true
+    return () => { mountedRef.current = false }
+  }, [])
+
+  const load = useCallback(async () => {
+    try {
+      const [unassigned, projectList] = await Promise.all([
+        window.electron.ipc.invoke('copilot:unassigned'),
+        window.electron.ipc.invoke('projects:list'),
+      ])
+      if (!mountedRef.current) return
+      setSessions(unassigned)
+      setProjects(projectList.filter((p) => p.status === 'active'))
+    } catch (err) {
+      console.error('[AgentTasks] Failed to load:', err)
+    } finally {
+      if (mountedRef.current) setIsLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void load()
+    const unsub = window.electron.onCopilotUpdated(() => { void load() })
+    return unsub
+  }, [load])
+
+  const handleAssign = useCallback(async (sessionId: string, projectId: number) => {
+    try {
+      await window.electron.ipc.invoke('copilot:assign', sessionId, projectId)
+      // Optimistically drop it from the list; the push event reconciles the rest.
+      setSessions((prev) => prev.filter((s) => s.id !== sessionId))
+    } catch (err) {
+      console.error('[AgentTasks] Assign failed:', err)
+    }
+  }, [])
+
+  const active = sessions.filter((s) => s.status !== 'completed')
+  const completed = sessions.filter((s) => s.status === 'completed')
+
+  return (
+    <main className={styles.main}>
+      <header className={styles.toolbar}>
+        <span className={styles.heading}>Agent tasks</span>
+        <span className={styles.sub}>Copilot sessions not tied to a project</span>
+      </header>
+
+      <div className={styles.content}>
+        {isLoading && <div className={styles.empty}>Loading…</div>}
+        {!isLoading && sessions.length === 0 && (
+          <div className={styles.empty}>No unassigned agent tasks. Everything Copilot is doing is tied to a project.</div>
+        )}
+
+        {active.length > 0 && (
+          <>
+            <div className={styles.sectionLabel}>Active</div>
+            {active.map((s) => (
+              <SessionRow key={s.id} session={s} projects={projects} onAssign={(id, pid) => void handleAssign(id, pid)} />
+            ))}
+          </>
+        )}
+
+        {completed.length > 0 && (
+          <>
+            <div className={styles.sectionLabel}>Recently completed</div>
+            {completed.map((s) => (
+              <SessionRow key={s.id} session={s} projects={projects} onAssign={(id, pid) => void handleAssign(id, pid)} />
+            ))}
+          </>
+        )}
+      </div>
+    </main>
+  )
+}

--- a/src/renderer/src/pages/AgentTasksView.tsx
+++ b/src/renderer/src/pages/AgentTasksView.tsx
@@ -48,6 +48,7 @@ function SessionRow({
       <select
         className={styles.assign}
         value=""
+        aria-label={`Assign "${session.title || 'Untitled task'}" to a project`}
         onChange={(e) => e.target.value && onAssign(session.id, Number(e.target.value))}
       >
         <option value="">Assign…</option>

--- a/src/renderer/src/pages/FocusPage.tsx
+++ b/src/renderer/src/pages/FocusPage.tsx
@@ -1,12 +1,13 @@
 import { useRef, useState } from 'react'
 import { MoreHorizontal, Moon, Trash2, Sun } from 'lucide-react'
-import type { Project, ProjectLink, ProjectTodo } from '@shared/ipc-channels'
+import type { LaunchTarget, Project, ProjectLink, ProjectTodo } from '@shared/ipc-channels'
 import { Icon } from '../components/Icon'
 import { ReentryDigest } from '../components/ReentryDigest'
 import { NextAction } from '../components/NextAction'
 import { WorkingColumn } from '../components/WorkingColumn'
+import { DelegateComposer } from '../components/DelegateComposer'
 import { ResurfaceStrip } from '../components/ResurfaceStrip'
-import { fire } from '../ipc'
+import { fire, openExternal } from '../ipc'
 import { useProjectDetail } from '../hooks/useProjectDetail'
 import { useDigest } from '../hooks/useDigest'
 import styles from './FocusPage.module.css'
@@ -38,6 +39,7 @@ export function FocusPage(props: FocusPageProps): JSX.Element {
   } = useProjectDetail(props.projectId, props.onProjectChanged)
   const { digest, dismiss } = useDigest(props.projectId)
   const [menuOpen, setMenuOpen] = useState(false)
+  const [delegate, setDelegate] = useState<{ prompt: string; fixedRepo?: LaunchTarget } | null>(null)
   const menuRef = useRef<HTMLDivElement>(null)
 
   if (isLoading || detail === null) {
@@ -123,7 +125,12 @@ export function FocusPage(props: FocusPageProps): JSX.Element {
         </div>
       </div>
 
-      <NextAction value={detail.nextAction} onSave={(text) => fire(updateProject({ nextAction: text }))} onDone={handleDone} />
+      <NextAction
+        value={detail.nextAction}
+        onSave={(text) => fire(updateProject({ nextAction: text }))}
+        onDone={handleDone}
+        onDelegate={(prompt) => setDelegate({ prompt })}
+      />
 
       <ResurfaceStrip
         drifting={props.drifting}
@@ -141,9 +148,26 @@ export function FocusPage(props: FocusPageProps): JSX.Element {
         onSaveNotes={(notes) => fire(updateProject({ notes }))}
         onCreateLink={(label, url) => fire(createLink(label, url))}
         onDeleteLink={handleDeleteLink}
+        onDelegate={(prompt, fixedRepo) => setDelegate({ prompt, fixedRepo })}
       />
 
       <div className={styles.tail} />
+
+      {delegate && (
+        <DelegateComposer
+          initialPrompt={delegate.prompt}
+          projectId={props.projectId}
+          fixedRepo={delegate.fixedRepo}
+          onClose={() => setDelegate(null)}
+          onLaunched={(session) => {
+            props.showUndo(
+              'Copilot is on it — I’ll fold the result into your digest.',
+              () => { if (session.htmlUrl) openExternal(session.htmlUrl) },
+              'Open'
+            )
+          }}
+        />
+      )}
     </main>
   )
 }

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -538,8 +538,9 @@ export type IpcChannels = {
 
   /**
    * Launches a cloud `gh agent-task` off the render thread and returns the
-   * optimistically-inserted session row (status 'in_progress'). Throws a typed
-   * error string ('GH_NOT_AUTHENTICATED' | 'LAUNCH_FAILED') on failure.
+   * optimistically-inserted session row (status 'in_progress'). On failure it
+   * rejects with an `Error` whose `message` is `'GH_NOT_AUTHENTICATED'` or
+   * starts with `'LAUNCH_FAILED: '` — renderer callers should read `err.message`.
    */
   'copilot:launch': {
     args: [payload: LaunchAgentTaskPayload]

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -56,6 +56,31 @@ export interface CopilotSession {
   repoName: string | null
   branch: string | null          // reserved for future use
   linkedPrUrl: string | null     // PR opened by Copilot for this task
+  /**
+   * Sticky project assignment set by launching from a project or manually
+   * assigning an unassigned session. When set (and the project is live), it
+   * resists re-resolution on the next `gh agent-task list` sync so a launched
+   * task doesn't jump to the Unassigned surface. Null = follow auto-resolution.
+   */
+  pinnedProjectId: number | null
+}
+
+/** Payload to launch a cloud `gh agent-task`. */
+export interface LaunchAgentTaskPayload {
+  /** The task description handed to Copilot. */
+  prompt: string
+  repoOwner: string
+  repoName: string
+  /** Base branch for the PR; defaults to the repo's default branch when omitted. */
+  baseBranch?: string
+  /** Originating project, pinned so the launched session stays co-located. Null = no project. */
+  projectId: number | null
+}
+
+/** A repo a project's agent task can target, resolved from repo rules + threads. */
+export interface LaunchTarget {
+  repoOwner: string
+  repoName: string
 }
 
 export interface Project {
@@ -509,6 +534,49 @@ export type IpcChannels = {
   'copilot:sync': {
     args: []
     result: void
+  }
+
+  /**
+   * Launches a cloud `gh agent-task` off the render thread and returns the
+   * optimistically-inserted session row (status 'in_progress'). Throws a typed
+   * error string ('GH_NOT_AUTHENTICATED' | 'LAUNCH_FAILED') on failure.
+   */
+  'copilot:launch': {
+    args: [payload: LaunchAgentTaskPayload]
+    result: CopilotSession
+  }
+
+  /**
+   * Returns unassigned Copilot sessions (project_id IS NULL) for the Agent Tasks
+   * surface: active-first then newest, capped, including recently-completed ones.
+   */
+  'copilot:unassigned': {
+    args: []
+    result: CopilotSession[]
+  }
+
+  /** Count of active (non-completed) unassigned sessions, for the rail badge. */
+  'copilot:unassigned-count': {
+    args: []
+    result: number
+  }
+
+  /**
+   * Pins an unassigned session to a live project (sticky across syncs).
+   * Throws if the project is missing or soft-deleted.
+   */
+  'copilot:assign': {
+    args: [sessionId: string, projectId: number]
+    result: void
+  }
+
+  /**
+   * Candidate repos a project's agent task can target, resolved from the
+   * project's repo rules and notification threads (distinct).
+   */
+  'copilot:launch-targets': {
+    args: [projectId: number]
+    result: LaunchTarget[]
   }
 
   // ── Focus: re-entry digest + drift ───────────────────────────────────────────


### PR DESCRIPTION
## What this is

MVP B of the "Focus" rebuild (part of #68, epic #71). Evolves the read-only Copilot integration into **launch + track**, built on top of MVP A's shared session model, rail status dot, and re-entry digest (PR #72). Scoped strictly to agent-session / launch / digest so it doesn't collide with MVP C.

**Shippable signal:** I delegate a boring task, walk away, and the digest tells me when it's done.

## What I did and why

MVP A already syncs `gh agent-task list`, drives the rail dot off `copilotStatus`, and folds sessions into the re-entry digest. So the "track" plumbing mostly existed - the new work is launch, sticky assignment, a status fix, and the unassigned surface.

### Launch
- `copilot:launch` shells out to `gh agent-task create -R owner/repo [-b base]` off the render thread, piping the prompt via `-F -` stdin (injection-proof, no ARG_MAX limit).
- A minimal **Delegate to Copilot** confirm composer, reachable from the next action, a todo, and a notification. Repo is auto-resolved from the project's repo rules + notification threads (or free-text when there's no match). It's a confirm popover, not pure one-click: a cloud launch spends premium requests and can't be cleanly undone read-only (there's no `gh agent-task cancel`, and closing the PR would be write-back beyond launch + unsubscribe).
- **Auth:** `gh agent-task` needs gh's keyring OAuth token; if `GH_TOKEN`/`GITHUB_TOKEN` are set it rejects them. The subprocess env strips just those two vars for the `agent-task` calls. No-op in the shipped app (those vars are normally unset), a fix when present.
- `create` prints the agent-session URL; I parse the session id + PR number and **optimistically insert** an `in_progress` row so the rail/digest light up before the next list sync. A background sync then reconciles the real title/status.

### Track
- New `pinned_project_id` column (migration 014): a launched/assigned session **stays on its project** across the re-resolving list sync. The sync UPSERT preserves a live pin, clears a dead one, and prefers it over auto-resolution. `insertLaunchedSession` resolves a live-or-null pin so a launch is never lost to an FK error or a row pointing at a vanished project.
- **`deriveStatus` fix:** a launch opens a draft PR immediately, and the old logic called any open PR `pr_ready` - so the rail/digest lied right after launch. Now the task lifecycle wins: `completed` + open PR → `pr_ready`; `completed` + merged/closed → `completed`; `failed`/`cancelled` → `completed`; `idle` → `waiting`; else `in_progress`.

### Unassigned surface
- `copilot:unassigned` / `:unassigned-count` / `:assign` plus a badged **Agent tasks** rail entry near Inbox, opening a list grouped active vs recently-completed, with assign-to-project (sticky, validates the target is live) and open-on-GitHub.

## How I verified it
- `bun run typecheck` + `bun run lint` clean.
- **169 tests pass** under `bun --bun vitest run` (the integration tests use `bun:sqlite`, so they need the bun runtime):
  - Pure unit: `parseAgentTaskCreateOutput` (URL shapes + errors), launch payload validation, `deriveStatus` (the full state x PR matrix).
  - DB integration (in-memory sqlite): pin stickiness across a re-sync, optimistic-insert-doesn't-clobber-synced-row, unassigned ordering + active count, assign survives sync + rejects missing/soft-deleted targets, delete + dead-pin hygiene, launch-targets union, and a **launched session folds into the digest**.
  - RTL: DelegateComposer pre-fill/launch/auth-error, AgentTasksView grouping + assign, NextAction delegate button.
- **Live end-to-end:** ran the real `launchAgentTask` against `robert-crandall/gh-notifier` - confirmed `agentTaskEnv()` strips `GH_TOKEN` for the child (parent had it set), `gh agent-task create -F -` stdin works, and the output parses to the session id + PR number. Closed the throwaway PRs (#73, #74).

## What I did NOT verify
- I didn't drive the full Electron GUI headless. The launch subprocess + DB + digest are verified via the live launch and integration tests; the composer/rail wiring is covered by RTL, not a running app window.
- I mapped the `state` vocabulary from observed tasks (`in_progress`/`idle`/`completed`); `deriveStatus` defaults unknown active states to `in_progress`, so it's robust to states I haven't seen. If `idle` ever means "done, PR ready" it'd show as `waiting` instead of `pr_ready` - worth watching real output.

## Incidental
Corrected two stale MVP A tests that blocked a clean `bun --bun vitest run`: a `ReentryDigest` mock returning `undefined` (→ unhandled `.catch`) and a `deleteProject` CASCADE test that still asserted hard-delete after MVP A moved to soft-delete.

## Out of scope
Embedded/local agent, streaming, permission cards, worktree (MVP D); project brain / resources (MVP C); any GitHub write-back beyond launch + the existing unsubscribe.

Process: plan and work each reviewed by GPT 5.5 (two rounds each) until green-lit.