### PR TITLE
MVP C follow-up: embedding retriever + adversarial eval (fix a rigged recall metric)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "focus",
       "dependencies": {
+        "@huggingface/transformers": "^4.2.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@octokit/rest": "^22.0.1",
         "better-sqlite3": "^12.9.0",
@@ -130,7 +131,7 @@
 
     "@emnapi/core": ["@emnapi/core@1.9.2", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA=="],
 
-    "@emnapi/runtime": ["@emnapi/runtime@1.9.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw=="],
+    "@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
 
     "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
 
@@ -202,6 +203,12 @@
 
     "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
 
+    "@huggingface/jinja": ["@huggingface/jinja@0.5.9", "", {}, "sha512-uWTG+l3VJRsl7EXxYizuL3P+cCPoc3cRqbWWRcQN0FhejRfbdq0RNhCmbY/YDtnTcz9icdLYuLDjsnz4d8JMuw=="],
+
+    "@huggingface/tokenizers": ["@huggingface/tokenizers@0.1.3", "", {}, "sha512-8rF/RRT10u+kn7YuUbUg0OF30K8rjTc78aHpxT+qJ1uWSqxT1MHi8+9ltwYfkFYJzT/oS+qw3JVfHtNMGAdqyA=="],
+
+    "@huggingface/transformers": ["@huggingface/transformers@4.2.0", "", { "dependencies": { "@huggingface/jinja": "^0.5.6", "@huggingface/tokenizers": "^0.1.3", "onnxruntime-node": "1.24.3", "onnxruntime-web": "1.26.0-dev.20260416-b7804b056c", "sharp": "^0.34.5" } }, "sha512-8BRCoBMH0XsWaEIamuR0LrJGAfftgHAfb2Vrffy0VKlSAE/MnUJ5/h/zTfEP3fDIft+nk7TqB8xXEyABGitBjQ=="],
+
     "@humanfs/core": ["@humanfs/core@0.19.2", "", { "dependencies": { "@humanfs/types": "^0.15.0" } }, "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA=="],
 
     "@humanfs/node": ["@humanfs/node@0.16.8", "", { "dependencies": { "@humanfs/core": "^0.19.2", "@humanfs/types": "^0.15.0", "@humanwhocodes/retry": "^0.4.0" } }, "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ=="],
@@ -211,6 +218,56 @@
     "@humanwhocodes/module-importer": ["@humanwhocodes/module-importer@1.0.1", "", {}, "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA=="],
 
     "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
+
+    "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
+
+    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
+
+    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.2.4" }, "os": "darwin", "cpu": "x64" }, "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw=="],
+
+    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g=="],
+
+    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg=="],
+
+    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.2.4", "", { "os": "linux", "cpu": "arm" }, "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A=="],
+
+    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw=="],
+
+    "@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.2.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA=="],
+
+    "@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.2.4", "", { "os": "linux", "cpu": "none" }, "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA=="],
+
+    "@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.2.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ=="],
+
+    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw=="],
+
+    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw=="],
+
+    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg=="],
+
+    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.2.4" }, "os": "linux", "cpu": "arm" }, "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw=="],
+
+    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg=="],
+
+    "@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.2.4" }, "os": "linux", "cpu": "ppc64" }, "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA=="],
+
+    "@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.2.4" }, "os": "linux", "cpu": "none" }, "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw=="],
+
+    "@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.2.4" }, "os": "linux", "cpu": "s390x" }, "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg=="],
+
+    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ=="],
+
+    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg=="],
+
+    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q=="],
+
+    "@img/sharp-wasm32": ["@img/sharp-wasm32@0.34.5", "", { "dependencies": { "@emnapi/runtime": "^1.7.0" }, "cpu": "none" }, "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw=="],
+
+    "@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.34.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g=="],
+
+    "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.34.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg=="],
+
+    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
 
     "@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
 
@@ -263,6 +320,24 @@
     "@oxc-project/types": ["@oxc-project/types@0.126.0", "", {}, "sha512-oGfVtjAgwQVVpfBrbtk4e1XDyWHRFta6BS3GWVzrF8xYBT2VGQAk39yJS/wFSMrZqoiCU4oghT3Ch0HaHGIHcQ=="],
 
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
+
+    "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
+
+    "@protobufjs/base64": ["@protobufjs/base64@1.1.2", "", {}, "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="],
+
+    "@protobufjs/codegen": ["@protobufjs/codegen@2.0.5", "", {}, "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g=="],
+
+    "@protobufjs/eventemitter": ["@protobufjs/eventemitter@1.1.1", "", {}, "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg=="],
+
+    "@protobufjs/fetch": ["@protobufjs/fetch@1.1.1", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.1" } }, "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw=="],
+
+    "@protobufjs/float": ["@protobufjs/float@1.0.2", "", {}, "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="],
+
+    "@protobufjs/path": ["@protobufjs/path@1.1.2", "", {}, "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="],
+
+    "@protobufjs/pool": ["@protobufjs/pool@1.1.0", "", {}, "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="],
+
+    "@protobufjs/utf8": ["@protobufjs/utf8@1.1.1", "", {}, "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg=="],
 
     "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-rc.16", "", { "os": "android", "cpu": "arm64" }, "sha512-rhY3k7Bsae9qQfOtph2Pm2jZEA+s8Gmjoz4hhmx70K9iMQ/ddeae+xhRQcM5IuVx5ry1+bGfkvMn7D6MJggVSA=="],
 
@@ -491,6 +566,8 @@
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
+
+    "adm-zip": ["adm-zip@0.5.18", "", {}, "sha512-ufJnssQGbxzLNS1Ho9bCtX4rQKCCvoVuDLHoJyc3F9dOGDB4BkWs2Ci0kv53lqocAEQ/Cbi+I2XCsNYGqVYqng=="],
 
     "agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
 
@@ -826,6 +903,8 @@
 
     "flat-cache": ["flat-cache@4.0.1", "", { "dependencies": { "flatted": "^3.2.9", "keyv": "^4.5.4" } }, "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw=="],
 
+    "flatbuffers": ["flatbuffers@25.9.23", "", {}, "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ=="],
+
     "flatted": ["flatted@3.4.2", "", {}, "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA=="],
 
     "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
@@ -873,6 +952,8 @@
     "got": ["got@11.8.6", "", { "dependencies": { "@sindresorhus/is": "^4.0.0", "@szmarczak/http-timer": "^4.0.5", "@types/cacheable-request": "^6.0.1", "@types/responselike": "^1.0.0", "cacheable-lookup": "^5.0.3", "cacheable-request": "^7.0.2", "decompress-response": "^6.0.0", "http2-wrapper": "^1.0.0-beta.5.2", "lowercase-keys": "^2.0.0", "p-cancelable": "^2.0.0", "responselike": "^2.0.0" } }, "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+
+    "guid-typescript": ["guid-typescript@1.0.9", "", {}, "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ=="],
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
@@ -1042,6 +1123,8 @@
 
     "log-symbols": ["log-symbols@4.1.0", "", { "dependencies": { "chalk": "^4.1.0", "is-unicode-supported": "^0.1.0" } }, "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg=="],
 
+    "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
+
     "loose-envify": ["loose-envify@1.4.0", "", { "dependencies": { "js-tokens": "^3.0.0 || ^4.0.0" }, "bin": { "loose-envify": "cli.js" } }, "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q=="],
 
     "lowercase-keys": ["lowercase-keys@2.0.0", "", {}, "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA=="],
@@ -1142,6 +1225,12 @@
 
     "onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
 
+    "onnxruntime-common": ["onnxruntime-common@1.24.3", "", {}, "sha512-GeuPZO6U/LBJXvwdaqHbuUmoXiEdeCjWi/EG7Y1HNnDwJYuk6WUbNXpF6luSUY8yASul3cmUlLGrCCL1ZgVXqA=="],
+
+    "onnxruntime-node": ["onnxruntime-node@1.24.3", "", { "dependencies": { "adm-zip": "^0.5.16", "global-agent": "^3.0.0", "onnxruntime-common": "1.24.3" }, "os": [ "linux", "win32", "darwin", ] }, "sha512-JH7+czbc8ALA819vlTgcV+Q214/+VjGeBHDjX81+ZCD0PCVCIFGFNtT0V4sXG/1JXypKPgScQcB3ij/hk3YnTg=="],
+
+    "onnxruntime-web": ["onnxruntime-web@1.26.0-dev.20260416-b7804b056c", "", { "dependencies": { "flatbuffers": "^25.1.24", "guid-typescript": "^1.0.9", "long": "^5.2.3", "onnxruntime-common": "1.24.0-dev.20251116-b39e144322", "platform": "^1.3.6", "protobufjs": "^7.2.4" } }, "sha512-MD6Ss4GSpQBo6zqoJzyT9LRbKYs7x/JVN23FT24EcEvlqF4VuzPOeH6X38orZPKHQDbprn7K+SBpu0/mj2CQiw=="],
+
     "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
 
     "ora": ["ora@5.4.1", "", { "dependencies": { "bl": "^4.1.0", "chalk": "^4.1.0", "cli-cursor": "^3.1.0", "cli-spinners": "^2.5.0", "is-interactive": "^1.0.0", "is-unicode-supported": "^0.1.0", "log-symbols": "^4.1.0", "strip-ansi": "^6.0.0", "wcwidth": "^1.0.1" } }, "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ=="],
@@ -1180,6 +1269,8 @@
 
     "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
+    "platform": ["platform@1.3.6", "", {}, "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg=="],
+
     "plist": ["plist@3.1.0", "", { "dependencies": { "@xmldom/xmldom": "^0.8.8", "base64-js": "^1.5.1", "xmlbuilder": "^15.1.1" } }, "sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ=="],
 
     "postcss": ["postcss@8.5.10", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ=="],
@@ -1199,6 +1290,8 @@
     "promise-inflight": ["promise-inflight@1.0.1", "", {}, "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g=="],
 
     "promise-retry": ["promise-retry@2.0.1", "", { "dependencies": { "err-code": "^2.0.2", "retry": "^0.12.0" } }, "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g=="],
+
+    "protobufjs": ["protobufjs@7.6.4", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.5", "@protobufjs/eventemitter": "^1.1.1", "@protobufjs/fetch": "^1.1.1", "@protobufjs/float": "^1.0.2", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.1", "@types/node": ">=13.7.0", "long": "^5.3.2" } }, "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw=="],
 
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
 
@@ -1279,6 +1372,8 @@
     "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
 
     "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
+
+    "sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
 
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
@@ -1518,6 +1613,8 @@
 
     "@modelcontextprotocol/sdk/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
+    "@rolldown/binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.9.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw=="],
+
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" }, "bundled": true }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
@@ -1593,6 +1690,8 @@
     "minipass-sized/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
 
     "minizlib/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
+
+    "onnxruntime-web/onnxruntime-common": ["onnxruntime-common@1.24.0-dev.20251116-b39e144322", "", {}, "sha512-BOoomdHYmNRL5r4iQ4bMvsl2t0/hzVQ3OM3PHD0gxeXu1PmggqBv3puZicEUVOA3AtHHYmqZtjMj9FOfGrATTw=="],
 
     "path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -42,6 +42,10 @@
       },
     },
   },
+  "trustedDependencies": [
+    "onnxruntime-node",
+    "protobufjs",
+  ],
   "packages": {
     "7zip-bin": ["7zip-bin@5.2.0", "", {}, "sha512-ukTPVhqG4jNzMro2qA9HSCSSVJN3aN7tlb+hfqYCt3ER0yWroeA2VR38MNrOHLQ/cVj+DaIMad0kFCtWWowh/A=="],
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "dist:dir": "bun run build && electron-builder --dir --mac",
     "db:copy-prod": "bash scripts/copy-prod-db.sh",
     "rebuild": "electron-rebuild -f -w better-sqlite3",
-    "setup": "bun install --ignore-scripts && bun pm trust onnxruntime-node protobufjs && bun run rebuild",
+    "setup": "bun install && bun run rebuild",
     "install-app": "bash scripts/install-app.sh"
   },
   "keywords": [],

--- a/package.json
+++ b/package.json
@@ -22,7 +22,12 @@
   "keywords": [],
   "author": "robert-crandall",
   "license": "MIT",
+  "trustedDependencies": [
+    "onnxruntime-node",
+    "protobufjs"
+  ],
   "dependencies": {
+    "@huggingface/transformers": "^4.2.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@octokit/rest": "^22.0.1",
     "better-sqlite3": "^12.9.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "dist:dir": "bun run build && electron-builder --dir --mac",
     "db:copy-prod": "bash scripts/copy-prod-db.sh",
     "rebuild": "electron-rebuild -f -w better-sqlite3",
-    "setup": "bun install --ignore-scripts && bun run rebuild",
+    "setup": "bun install --ignore-scripts && bun pm trust onnxruntime-node protobufjs && bun run rebuild",
     "install-app": "bash scripts/install-app.sh"
   },
   "keywords": [],

--- a/src/main/context/assemble.test.ts
+++ b/src/main/context/assemble.test.ts
@@ -103,35 +103,35 @@ describe('capCandidates', () => {
 // ── assemble ──────────────────────────────────────────────────────────────────
 
 describe('assemble', () => {
-  it('always returns the card plus a capped candidate set', () => {
+  it('always returns the card plus a capped candidate set', async () => {
     const corpus = [
       makeResource({ title: 'mesh latency', service: 'mesh', aliases: ['service mesh latency'] }),
       makeResource({ title: 'kafka lag', service: 'ingest' }),
     ]
-    const ctx = assemble('how is mesh latency?', emptyCard, corpus, { limit: 5 })
+    const ctx = await assemble('how is mesh latency?', emptyCard, corpus, { limit: 5 })
     expect(ctx.card).toBe(emptyCard)
     expect(ctx.candidates.length).toBeGreaterThanOrEqual(1)
     expect(ctx.candidates[0].resource.title).toBe('mesh latency')
     expect(ctx.candidates[0].healthy).toBe(true)
   })
 
-  it('never exceeds the hard cap even with a large corpus', () => {
+  it('never exceeds the hard cap even with a large corpus', async () => {
     const corpus = Array.from({ length: 30 }, (_, i) =>
       makeResource({ title: `latency dashboard ${i}`, service: 'svc' })
     )
-    const ctx = assemble('latency', emptyCard, corpus, { limit: 5, poolSize: 10 })
+    const ctx = await assemble('latency', emptyCard, corpus, { limit: 5, poolSize: 10 })
     expect(ctx.candidates.length).toBeLessThanOrEqual(5)
   })
 
-  it('marks suspect candidates as not healthy', () => {
+  it('marks suspect candidates as not healthy', async () => {
     const corpus = [makeResource({ title: 'mesh latency', service: 'mesh', suspect: true })]
-    const ctx = assemble('mesh latency', emptyCard, corpus, {})
+    const ctx = await assemble('mesh latency', emptyCard, corpus, {})
     expect(ctx.candidates[0].healthy).toBe(false)
   })
 
-  it('returns no candidates for an unmatched question (feeds negative handling)', () => {
+  it('returns no candidates for an unmatched question (feeds negative handling)', async () => {
     const corpus = [makeResource({ title: 'mesh latency', service: 'mesh' })]
-    const ctx = assemble('quarterly revenue', emptyCard, corpus, {})
+    const ctx = await assemble('quarterly revenue', emptyCard, corpus, {})
     expect(ctx.candidates).toEqual([])
   })
 })

--- a/src/main/context/assemble.ts
+++ b/src/main/context/assemble.ts
@@ -93,20 +93,20 @@ export function capCandidates(
 /**
  * Assembles the two-layer context for a question. Pure over its inputs — the DB
  * reads (card + corpus) happen in the caller (resolve.ts) so this stays testable
- * offline.
+ * offline. Async because the retriever may be embedding-backed.
  */
-export function assemble(
+export async function assemble(
   question: string,
   card: ProjectCard,
   corpus: Resource[],
   options: AssembleOptions = {}
-): AssembledContext {
+): Promise<AssembledContext> {
   const poolSize = options.poolSize ?? DEFAULT_POOL_SIZE
   const limit = options.limit ?? DEFAULT_LIMIT
   const healthyReserve = options.healthyReserve ?? DEFAULT_HEALTHY_RESERVE
   const retriever = options.retriever ?? lexicalRetriever
 
-  const pool = retriever.retrieve(question, corpus, poolSize)
+  const pool = await retriever.retrieve(question, corpus, poolSize)
   const capped = capCandidates(pool, limit, healthyReserve)
 
   return {

--- a/src/main/context/assemble.ts
+++ b/src/main/context/assemble.ts
@@ -38,8 +38,11 @@ export interface AssembleOptions {
   retriever?: Retriever
 }
 
-const DEFAULT_POOL_SIZE = 10
-const DEFAULT_LIMIT = 5
+const DEFAULT_POOL_SIZE = 15
+// The decider sees up to this many candidates. Kept generous (not 5) so a
+// correct-but-lower-ranked semantic match still reaches the LLM — the
+// adversarial eval had a right answer at rank 7 that a cap of 5 hid.
+const DEFAULT_LIMIT = 8
 const DEFAULT_HEALTHY_RESERVE = 2
 
 function isHealthy(resource: Resource): boolean {

--- a/src/main/context/assemble.ts
+++ b/src/main/context/assemble.ts
@@ -28,9 +28,9 @@ export interface AssembledContext {
 }
 
 export interface AssembleOptions {
-  /** How many candidates to retrieve before capping. Default 10. */
+  /** How many candidates to retrieve before capping. Default 15. */
   poolSize?: number
-  /** Hard cap on candidates injected into the decision stage. Default 5. */
+  /** Hard cap on candidates injected into the decision stage. Default 8. */
   limit?: number
   /** Minimum healthy candidates to guarantee in the final set when available. Default 2. */
   healthyReserve?: number

--- a/src/main/context/embed-retriever.test.ts
+++ b/src/main/context/embed-retriever.test.ts
@@ -80,6 +80,16 @@ describe('createEmbeddingRetriever (hybrid, fake embedder)', () => {
     expect(res[0].resource.service).toBe('authzd')
   })
 
+  it('detects a hyphenated structured value typed exactly (orders-db)', async () => {
+    // tokenize() would split "orders-db" into order/db; the raw-string check must
+    // still fire the structured tie-break for the exact hyphenated service.
+    const ordersDb = makeResource({ title: 'DB one', aliases: ['login'], service: 'orders-db' })
+    const other = makeResource({ title: 'DB two', aliases: ['login'], service: 'billing-db' })
+    const retriever = createEmbeddingRetriever(topicEmbedder())
+    const res = await retriever.retrieve('login errors on orders-db', [ordersDb, other], 2)
+    expect(res[0].resource.service).toBe('orders-db')
+  })
+
   it('returns nothing when nothing is semantically close (feeds honest none)', async () => {
     const authn = makeResource({ title: 'Auth errors', aliases: ['login'], service: 'authnd' })
     const retriever = createEmbeddingRetriever(topicEmbedder())

--- a/src/main/context/embed-retriever.test.ts
+++ b/src/main/context/embed-retriever.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest'
+import type { Resource } from '../../shared/ipc-channels'
+import type { Embedder } from './embed'
+import { createEmbeddingRetriever, createDefaultRetriever, resourceDocument } from './retrieve'
+
+let nextId = 1
+function makeResource(partial: Partial<Resource> & { title: string }): Resource {
+  return {
+    id: nextId++,
+    projectId: 1,
+    title: partial.title,
+    kind: partial.kind ?? 'dashboard',
+    source: partial.source ?? 'generic',
+    service: partial.service ?? '',
+    env: partial.env ?? '',
+    tags: partial.tags ?? {},
+    url: null,
+    description: partial.description ?? '',
+    aliases: partial.aliases ?? [],
+    provenance: 'manual',
+    confidence: 0.5,
+    lastUsed: null,
+    lastVerified: null,
+    failureCount: 0,
+    suspect: false,
+    pinnedGroup: null,
+    mcpServer: null,
+    toolName: null,
+    toolArgs: null,
+    externalRef: null,
+    validationState: 'unverified',
+    lastErrorCode: null,
+    lastErrorMessage: null,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  }
+}
+
+// A deterministic fake embedder: routes text to a one-hot topic vector so tests
+// are offline and stable (no model download). Cosine of matching topic = 1.
+function topicEmbedder(): Embedder {
+  const vec = (t: string): number[] => {
+    if (/login|account|auth/i.test(t)) return [1, 0, 0]
+    if (/ship|carrier|label/i.test(t)) return [0, 1, 0]
+    return [0, 0, 1]
+  }
+  return { embed: async (texts) => texts.map(vec) }
+}
+
+describe('resourceDocument', () => {
+  it('includes title, aliases, description, service, env', () => {
+    const doc = resourceDocument(
+      makeResource({ title: 'Auth errors', aliases: ['login errors'], description: 'd', service: 'authnd', env: 'prod' })
+    )
+    expect(doc).toContain('Auth errors')
+    expect(doc).toContain('login errors')
+    expect(doc).toContain('authnd')
+    expect(doc).toContain('prod')
+  })
+})
+
+describe('createEmbeddingRetriever (hybrid, fake embedder)', () => {
+  it('ranks the semantically-closest record first despite zero lexical overlap', async () => {
+    const authn = makeResource({ title: 'Authentication service errors', aliases: ['login errors', 'sign in failures'], service: 'authnd' })
+    const shipping = makeResource({ title: 'Shipping label delay', aliases: ['carrier handoff'], service: 'shipping' })
+    const retriever = createEmbeddingRetriever(topicEmbedder())
+    // Query shares NO words with the authn record, but is topically "account/login".
+    const res = await retriever.retrieve('why is my account locked?', [authn, shipping], 5)
+    expect(res[0].resource.id).toBe(authn.id)
+    // The unrelated shipping doc (cosine 0) is filtered out.
+    expect(res.map((r) => r.resource.id)).not.toContain(shipping.id)
+  })
+
+  it('uses the structured bonus to break a near-sibling tie', async () => {
+    // Both are "auth" topic (same cosine); the exact service token decides.
+    const authnd = makeResource({ title: 'Authn errors', aliases: ['login errors'], service: 'authnd' })
+    const authzd = makeResource({ title: 'Authz errors', aliases: ['login errors'], service: 'authzd' })
+    const retriever = createEmbeddingRetriever(topicEmbedder())
+    const res = await retriever.retrieve('login errors for authzd', [authnd, authzd], 2)
+    expect(res[0].resource.service).toBe('authzd')
+  })
+
+  it('returns nothing when nothing is semantically close (feeds honest none)', async () => {
+    const authn = makeResource({ title: 'Auth errors', aliases: ['login'], service: 'authnd' })
+    const retriever = createEmbeddingRetriever(topicEmbedder())
+    // "carrier handoff" is the shipping topic; the only record is auth -> cosine 0.
+    const res = await retriever.retrieve('carrier handoff time', [authn], 5)
+    expect(res).toEqual([])
+  })
+
+  it('re-embeds only changed records (cache by id + updatedAt)', async () => {
+    let embedCalls = 0
+    const counting: Embedder = {
+      embed: async (texts) => {
+        embedCalls++
+        return texts.map(() => [1, 0, 0])
+      },
+    }
+    const r = makeResource({ title: 'Auth', service: 'authnd' })
+    const retriever = createEmbeddingRetriever(counting)
+    await retriever.retrieve('login', [r], 5) // embeds query + corpus
+    const afterFirst = embedCalls
+    await retriever.retrieve('login again', [r], 5) // corpus cached -> only query embed
+    // The corpus wasn't re-embedded, so total calls grew by exactly 1 (the query).
+    expect(embedCalls).toBe(afterFirst + 1)
+  })
+})
+
+describe('createDefaultRetriever (embedding with lexical fallback)', () => {
+  it('falls back to lexical scoring when the embedder throws', async () => {
+    const throwing: Embedder = {
+      embed: async () => {
+        throw new Error('no model')
+      },
+    }
+    const mesh = makeResource({ title: 'Service mesh latency', service: 'mesh', aliases: ['mesh latency'] })
+    const retriever = createDefaultRetriever(throwing)
+    // Lexically overlapping query still resolves via the fallback.
+    const res = await retriever.retrieve('mesh latency', [mesh], 5)
+    expect(res[0]?.resource.id).toBe(mesh.id)
+  })
+})

--- a/src/main/context/embed-retriever.test.ts
+++ b/src/main/context/embed-retriever.test.ts
@@ -88,7 +88,7 @@ describe('createEmbeddingRetriever (hybrid, fake embedder)', () => {
     expect(res).toEqual([])
   })
 
-  it('re-embeds only changed records (cache by id + updatedAt)', async () => {
+  it('re-embeds only changed content (cache keyed by document, not updatedAt)', async () => {
     let embedCalls = 0
     const counting: Embedder = {
       embed: async (texts) => {
@@ -100,8 +100,9 @@ describe('createEmbeddingRetriever (hybrid, fake embedder)', () => {
     const retriever = createEmbeddingRetriever(counting)
     await retriever.retrieve('login', [r], 5) // embeds query + corpus
     const afterFirst = embedCalls
-    await retriever.retrieve('login again', [r], 5) // corpus cached -> only query embed
-    // The corpus wasn't re-embedded, so total calls grew by exactly 1 (the query).
+    // A health/usage bump moves updatedAt but not the document text -> no re-embed.
+    const bumped = { ...r, updatedAt: '2027-02-02T00:00:00.000Z' }
+    await retriever.retrieve('login again', [bumped], 5) // corpus cached -> only query embed
     expect(embedCalls).toBe(afterFirst + 1)
   })
 })

--- a/src/main/context/embed.ts
+++ b/src/main/context/embed.ts
@@ -1,0 +1,52 @@
+import type { FeatureExtractionPipeline } from '@huggingface/transformers'
+
+/**
+ * Local text embedder for semantic retrieval. Wraps transformers.js running a
+ * small sentence-transformer (all-MiniLM-L6-v2, 384-dim, mean-pooled + L2
+ * normalized). Fully local: the model downloads once to the transformers.js
+ * cache and then runs offline. Off the render thread (main process only).
+ *
+ * The model is loaded lazily on first use and reused. Any load/inference failure
+ * is surfaced to the caller so the retriever can fall back to lexical scoring.
+ */
+
+export interface Embedder {
+  /** Embeds each text into an L2-normalized vector. Throws on load/inference failure. */
+  embed(texts: string[]): Promise<number[][]>
+}
+
+const MODEL_ID = 'Xenova/all-MiniLM-L6-v2'
+
+export interface EmbedderOptions {
+  /** Writable dir for the downloaded model cache (required in a packaged app). */
+  cacheDir?: string
+}
+
+/** Creates a lazily-initialized local embedder. */
+export function createLocalEmbedder(options: EmbedderOptions = {}): Embedder {
+  let pipelinePromise: Promise<FeatureExtractionPipeline> | null = null
+
+  async function getPipeline(): Promise<FeatureExtractionPipeline> {
+    if (pipelinePromise === null) {
+      // Import lazily so merely importing this module doesn't pull the runtime in.
+      pipelinePromise = import('@huggingface/transformers').then(({ pipeline, env }) => {
+        // Point the model cache at a writable location (a packaged app bundle is
+        // read-only, so the default node_modules cache would fail).
+        if (options.cacheDir !== undefined) env.cacheDir = options.cacheDir
+        return pipeline('feature-extraction', MODEL_ID)
+      })
+    }
+    return pipelinePromise
+  }
+
+  return {
+    async embed(texts: string[]): Promise<number[][]> {
+      if (texts.length === 0) return []
+      const extractor = await getPipeline()
+      const output = await extractor(texts, { pooling: 'mean', normalize: true })
+      // output is a Tensor of shape [texts.length, dims]; tolist() gives number[][].
+      const rows = output.tolist() as number[][]
+      return rows
+    },
+  }
+}

--- a/src/main/context/embed.ts
+++ b/src/main/context/embed.ts
@@ -35,6 +35,10 @@ export function createLocalEmbedder(options: EmbedderOptions = {}): Embedder {
         if (options.cacheDir !== undefined) env.cacheDir = options.cacheDir
         return pipeline('feature-extraction', MODEL_ID)
       })
+      // Don't cache a transient load failure forever — reset so later calls retry.
+      pipelinePromise.catch(() => {
+        pipelinePromise = null
+      })
     }
     return pipelinePromise
   }

--- a/src/main/context/embed.ts
+++ b/src/main/context/embed.ts
@@ -49,8 +49,11 @@ export function createLocalEmbedder(options: EmbedderOptions = {}): Embedder {
       const extractor = await getPipeline()
       const output = await extractor(texts, { pooling: 'mean', normalize: true })
       // output is a Tensor of shape [texts.length, dims]; tolist() gives number[][].
-      const rows = output.tolist() as number[][]
-      return rows
+      const rows: unknown = output.tolist()
+      if (!Array.isArray(rows) || rows.length !== texts.length || !rows.every((r) => Array.isArray(r))) {
+        throw new Error(`unexpected embedding output shape for ${texts.length} texts`)
+      }
+      return rows as number[][]
     },
   }
 }

--- a/src/main/context/embed.ts
+++ b/src/main/context/embed.ts
@@ -50,8 +50,15 @@ export function createLocalEmbedder(options: EmbedderOptions = {}): Embedder {
       const output = await extractor(texts, { pooling: 'mean', normalize: true })
       // output is a Tensor of shape [texts.length, dims]; tolist() gives number[][].
       const rows: unknown = output.tolist()
-      if (!Array.isArray(rows) || rows.length !== texts.length || !rows.every((r) => Array.isArray(r))) {
-        throw new Error(`unexpected embedding output shape for ${texts.length} texts`)
+      if (
+        !Array.isArray(rows) ||
+        rows.length !== texts.length ||
+        !rows.every(
+          (r) =>
+            Array.isArray(r) && r.length > 0 && r.every((n) => typeof n === 'number' && Number.isFinite(n))
+        )
+      ) {
+        throw new Error(`unexpected embedding output shape/values for ${texts.length} texts`)
       }
       return rows as number[][]
     },

--- a/src/main/context/eval/eval.test.ts
+++ b/src/main/context/eval/eval.test.ts
@@ -47,6 +47,10 @@ describe('resolver retrieval eval (offline, synthetic)', () => {
     // The adversarial questions are genuinely lexically disjoint: lexical
     // retrieval falls well short of Gate 0's 100% top-3 bar. This assertion
     // guards against the eval quietly becoming lexically-aligned (a false pass).
+    if (adversarial.topKRecall >= 0.9) {
+      // If lexical unexpectedly does well, the set probably re-aligned — surface it.
+      console.error('adversarial set no longer disjoint for lexical; hits:', JSON.stringify(adversarial, null, 2))
+    }
     expect(adversarial.topKRecall).toBeLessThan(0.9)
   })
 })

--- a/src/main/context/eval/eval.test.ts
+++ b/src/main/context/eval/eval.test.ts
@@ -31,8 +31,8 @@ describe('resolver retrieval eval (offline, synthetic)', () => {
   })
 
   it('lexical clears 100% top-3 recall on the ALIGNED set (Gate 0 bar)', () => {
-    if (aligned.top3Recall < 1) console.error('aligned top-3 misses:', JSON.stringify(aligned.misses, null, 2))
-    expect(aligned.top3Recall).toBe(1)
+    if (aligned.topKRecall < 1) console.error('aligned top-3 misses:', JSON.stringify(aligned.misses, null, 2))
+    expect(aligned.topKRecall).toBe(1)
   })
 
   it('lexical clears >= 80% top-1 recall on the ALIGNED set', () => {
@@ -47,7 +47,7 @@ describe('resolver retrieval eval (offline, synthetic)', () => {
     // The adversarial questions are genuinely lexically disjoint: lexical
     // retrieval falls well short of Gate 0's 100% top-3 bar. This assertion
     // guards against the eval quietly becoming lexically-aligned (a false pass).
-    expect(adversarial.top3Recall).toBeLessThan(0.9)
+    expect(adversarial.topKRecall).toBeLessThan(0.9)
   })
 })
 

--- a/src/main/context/eval/eval.test.ts
+++ b/src/main/context/eval/eval.test.ts
@@ -1,36 +1,62 @@
-import { describe, it, expect } from 'vitest'
-import { runRetrievalEval, loadCorpus, loadQuestions } from './harness'
+import { describe, it, expect, beforeAll } from 'vitest'
+import { runRetrievalEval, loadCorpus, loadQuestions, loadAdversarialQuestions, toResourceFixtures } from './harness'
+import { lexicalRetriever, type ScoredCandidate } from '../retrieve'
+import type { RetrievalReport } from './harness'
 
 /**
- * Offline retrieval-recall gate. Carries Gate 0's rubric for the deterministic
- * half: top-3 recall on fuzzy questions must be perfect on the synthetic corpus,
- * top-1 recall must clear 80%, and ambiguous questions must surface >= 2
- * plausible candidates so the decision stage can clarify. The LLM half
- * (right-source@1, negatives, live pull) is the manual `--live` run.
+ * Offline retrieval gates (deterministic, no network).
+ *
+ * The ALIGNED set shares vocabulary with the records (aliases bridge the fuzzy
+ * language), and the lexical retriever clears Gate 0's bar on it. The ADVERSARIAL
+ * set is deliberately lexically DISJOINT from the records — it exists to keep us
+ * honest: lexical retrieval does NOT clear the bar there, which is exactly why
+ * the resolver ships the embedding retriever in production (proven separately in
+ * the network-dependent retriever-eval, since a local model can't run in CI).
  */
 
 describe('resolver retrieval eval (offline, synthetic)', () => {
-  const report = runRetrievalEval()
+  let aligned: RetrievalReport
+  let adversarial: RetrievalReport
+
+  beforeAll(async () => {
+    aligned = await runRetrievalEval(lexicalRetriever)
+    adversarial = await runRetrievalEval(lexicalRetriever, 3, loadAdversarialQuestions())
+  })
 
   it('has a corpus and question set of the expected shape', () => {
     expect(loadCorpus().length).toBeGreaterThanOrEqual(20)
     expect(loadQuestions().length).toBeGreaterThanOrEqual(21)
-    expect(report.fuzzyTotal).toBeGreaterThanOrEqual(18)
+    expect(loadAdversarialQuestions().length).toBeGreaterThanOrEqual(10)
+    expect(aligned.fuzzyTotal).toBeGreaterThanOrEqual(18)
   })
 
-  it('clears 100% top-3 recall on fuzzy questions (Gate 0 bar)', () => {
-    if (report.top3Recall < 1) {
-      // Surface the misses so a regression is diagnosable.
-      console.error('top-3 misses:', JSON.stringify(report.misses, null, 2))
-    }
-    expect(report.top3Recall).toBe(1)
+  it('lexical clears 100% top-3 recall on the ALIGNED set (Gate 0 bar)', () => {
+    if (aligned.top3Recall < 1) console.error('aligned top-3 misses:', JSON.stringify(aligned.misses, null, 2))
+    expect(aligned.top3Recall).toBe(1)
   })
 
-  it('clears >= 80% top-1 recall on fuzzy questions', () => {
-    expect(report.top1Recall).toBeGreaterThanOrEqual(0.8)
+  it('lexical clears >= 80% top-1 recall on the ALIGNED set', () => {
+    expect(aligned.top1Recall).toBeGreaterThanOrEqual(0.8)
   })
 
   it('surfaces >= 2 plausible candidates for every ambiguous question', () => {
-    expect(report.ambiguousSurfaced).toBe(report.ambiguousTotal)
+    expect(aligned.ambiguousSurfaced).toBe(aligned.ambiguousTotal)
+  })
+
+  it('lexical does NOT clear the bar on the ADVERSARIAL set (why we ship embeddings)', () => {
+    // The adversarial questions are genuinely lexically disjoint: lexical
+    // retrieval falls well short of Gate 0's 100% top-3 bar. This assertion
+    // guards against the eval quietly becoming lexically-aligned (a false pass).
+    expect(adversarial.top3Recall).toBeLessThan(0.9)
+  })
+})
+
+describe('Retriever interface is async', () => {
+  it('lexicalRetriever.retrieve returns a Promise', async () => {
+    const { resources } = toResourceFixtures(loadCorpus())
+    const result = lexicalRetriever.retrieve('checkout latency', resources, 3)
+    expect(result).toBeInstanceOf(Promise)
+    const candidates: ScoredCandidate[] = await result
+    expect(Array.isArray(candidates)).toBe(true)
   })
 })

--- a/src/main/context/eval/harness.ts
+++ b/src/main/context/eval/harness.ts
@@ -107,9 +107,12 @@ export interface RetrievalReport {
 }
 
 /** Runs the retrieval-stage eval and returns recall metrics. */
-export function runRetrievalEval(retriever: Retriever = lexicalRetriever, k = 3): RetrievalReport {
+export async function runRetrievalEval(
+  retriever: Retriever = lexicalRetriever,
+  k = 3,
+  questions: EvalQuestion[] = loadQuestions()
+): Promise<RetrievalReport> {
   const { resources, stringIdByNumericId } = toResourceFixtures(loadCorpus())
-  const questions = loadQuestions()
 
   let fuzzyTotal = 0
   let top1Hits = 0
@@ -119,7 +122,7 @@ export function runRetrievalEval(retriever: Retriever = lexicalRetriever, k = 3)
   const misses: RetrievalReport['misses'] = []
 
   for (const question of questions) {
-    const results = retriever.retrieve(question.q, resources, Math.max(k, 5))
+    const results = await retriever.retrieve(question.q, resources, Math.max(k, 5))
     const rankedIds = results.map((r) => stringIdByNumericId.get(r.resource.id) ?? '')
 
     if (question.category === 'fuzzy' && question.expectedId !== null) {
@@ -148,4 +151,10 @@ export function runRetrievalEval(retriever: Retriever = lexicalRetriever, k = 3)
     ambiguousSurfaced,
     misses,
   }
+}
+
+/** Loads the adversarial (lexically-disjoint) question set. */
+export function loadAdversarialQuestions(): EvalQuestion[] {
+  const raw = readFileSync(join(__dirname, 'questions.adversarial.json'), 'utf8')
+  return (JSON.parse(raw) as QuestionsFile).questions
 }

--- a/src/main/context/eval/harness.ts
+++ b/src/main/context/eval/harness.ts
@@ -95,11 +95,14 @@ export function toResourceFixtures(records: EvalRecord[]): {
 }
 
 export interface RetrievalReport {
+  /** The k used for the recall@k metric (top-k membership). */
+  k: number
   fuzzyTotal: number
   top1Hits: number
-  top3Hits: number
+  topKHits: number
   top1Recall: number
-  top3Recall: number
+  /** Fraction of fuzzy questions whose expected source appears in the top `k`. */
+  topKRecall: number
   ambiguousTotal: number
   ambiguousSurfaced: number
   /** Per-question detail for debugging failures. */
@@ -116,7 +119,7 @@ export async function runRetrievalEval(
 
   let fuzzyTotal = 0
   let top1Hits = 0
-  let top3Hits = 0
+  let topKHits = 0
   let ambiguousTotal = 0
   let ambiguousSurfaced = 0
   const misses: RetrievalReport['misses'] = []
@@ -129,7 +132,7 @@ export async function runRetrievalEval(
       fuzzyTotal++
       if (rankedIds[0] === question.expectedId) top1Hits++
       if (rankedIds.slice(0, k).includes(question.expectedId)) {
-        top3Hits++
+        topKHits++
       } else {
         misses.push({ q: question.q, expectedId: question.expectedId, got: rankedIds.slice(0, k) })
       }
@@ -142,11 +145,12 @@ export async function runRetrievalEval(
   }
 
   return {
+    k,
     fuzzyTotal,
     top1Hits,
-    top3Hits,
+    topKHits,
     top1Recall: fuzzyTotal === 0 ? 0 : top1Hits / fuzzyTotal,
-    top3Recall: fuzzyTotal === 0 ? 0 : top3Hits / fuzzyTotal,
+    topKRecall: fuzzyTotal === 0 ? 0 : topKHits / fuzzyTotal,
     ambiguousTotal,
     ambiguousSurfaced,
     misses,

--- a/src/main/context/eval/live-eval.ts
+++ b/src/main/context/eval/live-eval.ts
@@ -56,7 +56,7 @@ async function main(): Promise<void> {
     while (idx < questions.length) {
       const i = idx++
       const question = questions[i]
-      const { candidates } = assemble(question.q, emptyCard, resources)
+      const { candidates } = await assemble(question.q, emptyCard, resources)
       if (candidates.length === 0) {
         outcomes[i] = { q: question.q, category: question.category, expectedId: question.expectedId, verdict: 'none', citedId: null, cited: false }
         process.stdout.write(`. `)

--- a/src/main/context/eval/live-eval.ts
+++ b/src/main/context/eval/live-eval.ts
@@ -18,6 +18,8 @@ import { buildDecidePrompt } from '../prompt'
 import { parseAndValidateDecision } from '../verdict-contract'
 import { createCopilotDecideRunner } from '../copilot-run'
 import { createMcpRunner } from '../mcp-client'
+import { createDefaultRetriever } from '../retrieve'
+import { createLocalEmbedder } from '../embed'
 import type { ProjectCard } from '../../../shared/ipc-channels'
 
 const emptyCard: ProjectCard = {
@@ -46,6 +48,10 @@ async function main(): Promise<void> {
   const questions = loadQuestions()
   const home = isolatedHome()
   const decideRunner = createCopilotDecideRunner({ isolatedHome: home, cwd: home, timeoutMs: 60_000 })
+  // Use the PRODUCTION retriever (embedding + structured bonus) so this validates
+  // the real pipeline — including whether the LLM still says "none" on negatives
+  // when embeddings surface weak candidates.
+  const retriever = createDefaultRetriever(createLocalEmbedder())
 
   const outcomes: Outcome[] = []
 
@@ -56,7 +62,7 @@ async function main(): Promise<void> {
     while (idx < questions.length) {
       const i = idx++
       const question = questions[i]
-      const { candidates } = await assemble(question.q, emptyCard, resources)
+      const { candidates } = await assemble(question.q, emptyCard, resources, { retriever })
       if (candidates.length === 0) {
         outcomes[i] = { q: question.q, category: question.category, expectedId: question.expectedId, verdict: 'none', citedId: null, cited: false }
         process.stdout.write(`. `)

--- a/src/main/context/eval/questions.adversarial.json
+++ b/src/main/context/eval/questions.adversarial.json
@@ -1,0 +1,17 @@
+{
+  "_comment": "ADVERSARIAL eval: questions deliberately phrased to share as little vocabulary as possible with the target record's title/aliases/description/service. This tests whether lexical+structured retrieval is genuinely sufficient, or whether semantic embeddings are needed to bridge lexically-disjoint phrasing (the exact case Gate 0's embeddings solved). expectedId references corpus.synthetic.json ids.",
+  "questions": [
+    { "q": "are we serving responses out of memory or hitting the datastore every time?", "expectedId": "cache-hit-rate-dash", "category": "fuzzy" },
+    { "q": "why can't people get into their accounts?", "expectedId": "authnd-errors-dash", "category": "fuzzy" },
+    { "q": "are shoppers' purchases getting rejected at the register?", "expectedId": "payments-decline-dash", "category": "fuzzy" },
+    { "q": "how long until an order is ready to hand off to the carrier?", "expectedId": "shipping-delay-dash", "category": "fuzzy" },
+    { "q": "are the standby copies of the database falling behind the leader?", "expectedId": "db-replica-lag-query", "category": "fuzzy" },
+    { "q": "are outbound alerts stuck waiting to go out?", "expectedId": "notifications-queue-dash", "category": "fuzzy" },
+    { "q": "how much reliability headroom is left this month?", "expectedId": "slo-overview-dash", "category": "fuzzy" },
+    { "q": "is the streaming pipeline keeping up with everything coming in?", "expectedId": "ingest-lag-dash", "category": "fuzzy" },
+    { "q": "how long do visitors wait at the entrypoint before a service answers?", "expectedId": "edgeproxy-latency-dash", "category": "fuzzy" },
+    { "q": "what's our monthly bill from the cloud provider?", "expectedId": "cost-explorer-link", "category": "fuzzy" },
+    { "q": "who picks up the phone when something breaks?", "expectedId": "oncall-runbook-doc", "category": "fuzzy" },
+    { "q": "are product pages taking too long to render?", "expectedId": "catalog-latency-dash", "category": "fuzzy" }
+  ]
+}

--- a/src/main/context/eval/retriever-eval.ts
+++ b/src/main/context/eval/retriever-eval.ts
@@ -31,7 +31,7 @@ async function main(): Promise<void> {
     const at3 = await runRetrievalEval(r, 3, qs)
     const at8 = await runRetrievalEval(r, 8, qs)
     console.log(
-      `${label.padEnd(26)} recall@3 ${(at3.top3Recall * 100).toFixed(1).padStart(5)}%   recall@8 ${(at8.top3Recall * 100).toFixed(1).padStart(5)}%   (n=${at3.fuzzyTotal})`
+      `${label.padEnd(26)} recall@3 ${(at3.topKRecall * 100).toFixed(1).padStart(5)}%   recall@8 ${(at8.topKRecall * 100).toFixed(1).padStart(5)}%   (n=${at3.fuzzyTotal})`
     )
   }
   await report('lexical   / aligned', lexicalRetriever, aligned)

--- a/src/main/context/eval/retriever-eval.ts
+++ b/src/main/context/eval/retriever-eval.ts
@@ -1,0 +1,45 @@
+/**
+ * Manual retriever eval — NOT part of CI (needs a local embedding model to load,
+ * which downloads once and can't run offline in CI). Compares the lexical vs the
+ * real embedding retriever on the ALIGNED and ADVERSARIAL (lexically-disjoint)
+ * synthetic question sets, and reports top-1 / top-3 recall.
+ *
+ * Run: bun --bun run src/main/context/eval/retriever-eval.ts
+ */
+import { runRetrievalEval, loadQuestions, loadAdversarialQuestions } from './harness'
+import { lexicalRetriever, createDefaultRetriever } from '../retrieve'
+import { createLocalEmbedder } from '../embed'
+
+async function main(): Promise<void> {
+  // createDefaultRetriever is the production retriever (hybrid embedding + structured
+  // bonus, with a lexical fallback) — the same thing the app wires in resolve-deps.
+  const embedding = createDefaultRetriever(createLocalEmbedder())
+  const aligned = loadQuestions()
+  const adversarial = loadAdversarialQuestions()
+
+  const line = (label: string, r: { top1Recall: number; top3Recall: number; fuzzyTotal: number }): string =>
+    `${label.padEnd(26)} top1 ${(r.top1Recall * 100).toFixed(1).padStart(5)}%   top3 ${(r.top3Recall * 100).toFixed(1).padStart(5)}%   (n=${r.fuzzyTotal})`
+
+  console.log('Loading embedding model (downloads once)...')
+  const t0 = Date.now()
+  await embedding.retrieve('warmup', [], 1)
+  console.log(`model ready in ${((Date.now() - t0) / 1000).toFixed(1)}s\n`)
+
+  console.log('=== RETRIEVER EVAL (synthetic) ===')
+  console.log(line('lexical   / aligned', await runRetrievalEval(lexicalRetriever, 3, aligned)))
+  console.log(line('embedding / aligned', await runRetrievalEval(embedding, 3, aligned)))
+  console.log('')
+  console.log(line('lexical   / adversarial', await runRetrievalEval(lexicalRetriever, 3, adversarial)))
+  const embAdv = await runRetrievalEval(embedding, 3, adversarial)
+  console.log(line('embedding / adversarial', embAdv))
+  console.log(`\nembedding adversarial misses (hard/ambiguous phrasings; the LLM stage answers none/clarify, and the alias-capture loop closes these over time):`)
+  for (const m of embAdv.misses) console.log(`  - "${m.q}" -> expected ${m.expectedId}, got [${m.got.join(', ') || '(nothing)'}]`)
+}
+
+void main().then(
+  () => process.exit(0),
+  (err) => {
+    console.error(err)
+    process.exit(1)
+  }
+)

--- a/src/main/context/eval/retriever-eval.ts
+++ b/src/main/context/eval/retriever-eval.ts
@@ -6,7 +6,7 @@
  *
  * Run: bun --bun run src/main/context/eval/retriever-eval.ts
  */
-import { runRetrievalEval, loadQuestions, loadAdversarialQuestions } from './harness'
+import { runRetrievalEval, loadQuestions, loadAdversarialQuestions, loadCorpus, toResourceFixtures } from './harness'
 import { lexicalRetriever, createDefaultRetriever } from '../retrieve'
 import { createLocalEmbedder } from '../embed'
 
@@ -19,7 +19,10 @@ async function main(): Promise<void> {
 
   console.log('Loading embedding model (downloads once)...')
   const t0 = Date.now()
-  await embedding.retrieve('warmup', [], 1)
+  // Warm up against a non-empty corpus so the model actually loads now (an empty
+  // corpus short-circuits before embedding), making the timing meaningful.
+  const { resources } = toResourceFixtures(loadCorpus())
+  await embedding.retrieve('warmup', resources.slice(0, 1), 1)
   console.log(`model ready in ${((Date.now() - t0) / 1000).toFixed(1)}s\n`)
 
   console.log('=== RETRIEVER EVAL (synthetic) ===')

--- a/src/main/context/eval/retriever-eval.ts
+++ b/src/main/context/eval/retriever-eval.ts
@@ -17,23 +17,29 @@ async function main(): Promise<void> {
   const aligned = loadQuestions()
   const adversarial = loadAdversarialQuestions()
 
-  const line = (label: string, r: { top1Recall: number; top3Recall: number; fuzzyTotal: number }): string =>
-    `${label.padEnd(26)} top1 ${(r.top1Recall * 100).toFixed(1).padStart(5)}%   top3 ${(r.top3Recall * 100).toFixed(1).padStart(5)}%   (n=${r.fuzzyTotal})`
-
   console.log('Loading embedding model (downloads once)...')
   const t0 = Date.now()
   await embedding.retrieve('warmup', [], 1)
   console.log(`model ready in ${((Date.now() - t0) / 1000).toFixed(1)}s\n`)
 
   console.log('=== RETRIEVER EVAL (synthetic) ===')
-  console.log(line('lexical   / aligned', await runRetrievalEval(lexicalRetriever, 3, aligned)))
-  console.log(line('embedding / aligned', await runRetrievalEval(embedding, 3, aligned)))
+  console.log('recall@3 (strict top-3) and recall@8 (what the decider actually sees, cap=8):\n')
+  const report = async (label: string, r: typeof lexicalRetriever, qs = aligned): Promise<void> => {
+    const at3 = await runRetrievalEval(r, 3, qs)
+    const at8 = await runRetrievalEval(r, 8, qs)
+    console.log(
+      `${label.padEnd(26)} recall@3 ${(at3.top3Recall * 100).toFixed(1).padStart(5)}%   recall@8 ${(at8.top3Recall * 100).toFixed(1).padStart(5)}%   (n=${at3.fuzzyTotal})`
+    )
+  }
+  await report('lexical   / aligned', lexicalRetriever, aligned)
+  await report('embedding / aligned', embedding, aligned)
   console.log('')
-  console.log(line('lexical   / adversarial', await runRetrievalEval(lexicalRetriever, 3, adversarial)))
-  const embAdv = await runRetrievalEval(embedding, 3, adversarial)
-  console.log(line('embedding / adversarial', embAdv))
-  console.log(`\nembedding adversarial misses (hard/ambiguous phrasings; the LLM stage answers none/clarify, and the alias-capture loop closes these over time):`)
-  for (const m of embAdv.misses) console.log(`  - "${m.q}" -> expected ${m.expectedId}, got [${m.got.join(', ') || '(nothing)'}]`)
+  await report('lexical   / adversarial', lexicalRetriever, adversarial)
+  await report('embedding / adversarial', embedding, adversarial)
+
+  const embAdv8 = await runRetrievalEval(embedding, 8, adversarial)
+  console.log(`\nembedding adversarial misses at cap=8 (the decider never sees these; alias-capture-by-use closes them over time):`)
+  for (const m of embAdv8.misses) console.log(`  - "${m.q}" -> expected ${m.expectedId}, got [${m.got.join(', ') || '(nothing)'}]`)
 }
 
 void main().then(

--- a/src/main/context/resolve-deps.ts
+++ b/src/main/context/resolve-deps.ts
@@ -27,7 +27,11 @@ export function ensureIsolatedCopilotHome(baseDir: string): string {
 
 export function createResolveDeps(baseDir: string, model?: string): ResolveDeps {
   const home = ensureIsolatedCopilotHome(baseDir)
-  const embedder = createLocalEmbedder({ cacheDir: join(baseDir, 'model-cache') })
+  const cacheDir = join(baseDir, 'model-cache')
+  // Ensure the model cache dir exists — otherwise the embedder can fail to load
+  // and silently fall back to lexical retrieval in production.
+  mkdirSync(cacheDir, { recursive: true })
+  const embedder = createLocalEmbedder({ cacheDir })
   return {
     decideRunner: createCopilotDecideRunner({ isolatedHome: home, cwd: home, model }),
     mcpRunner: createMcpRunner(),

--- a/src/main/context/resolve-deps.ts
+++ b/src/main/context/resolve-deps.ts
@@ -2,6 +2,8 @@ import { mkdirSync, writeFileSync } from 'fs'
 import { join } from 'path'
 import { createCopilotDecideRunner } from './copilot-run'
 import { createMcpRunner } from './mcp-client'
+import { createDefaultRetriever } from './retrieve'
+import { createLocalEmbedder } from './embed'
 import type { ResolveDeps } from './resolve'
 
 /**
@@ -9,6 +11,10 @@ import type { ResolveDeps } from './resolve'
  * an app-owned Copilot HOME containing an empty MCP config, so the decide
  * subprocess loads none of the user's global MCP servers and has no tools. The
  * app-owned MCP read (mcp-client) is what actually talks to wired servers.
+ *
+ * Retrieval uses the hybrid embedding retriever (semantic recall for
+ * lexically-disjoint questions) with a transparent lexical fallback if the local
+ * model can't load.
  */
 
 /** Creates an isolated Copilot home with an empty MCP config; returns its path. */
@@ -21,8 +27,10 @@ export function ensureIsolatedCopilotHome(baseDir: string): string {
 
 export function createResolveDeps(baseDir: string, model?: string): ResolveDeps {
   const home = ensureIsolatedCopilotHome(baseDir)
+  const embedder = createLocalEmbedder({ cacheDir: join(baseDir, 'model-cache') })
   return {
     decideRunner: createCopilotDecideRunner({ isolatedHome: home, cwd: home, model }),
     mcpRunner: createMcpRunner(),
+    assembleOptions: { retriever: createDefaultRetriever(embedder) },
   }
 }

--- a/src/main/context/resolve.ts
+++ b/src/main/context/resolve.ts
@@ -72,7 +72,7 @@ export async function resolveQuestion(
 
   const card = getProjectCard(projectId)
   const corpus = listResources(projectId)
-  const { candidates } = assemble(trimmed, card, corpus, deps.assembleOptions)
+  const { candidates } = await assemble(trimmed, card, corpus, deps.assembleOptions)
 
   // No candidates at all -> honestly, no source saved.
   if (candidates.length === 0) {

--- a/src/main/context/retrieve.test.ts
+++ b/src/main/context/retrieve.test.ts
@@ -96,51 +96,51 @@ describe('scoreResource', () => {
 // ── retriever: recall + ranking ───────────────────────────────────────────────
 
 describe('lexicalRetriever', () => {
-  it('bridges fuzzy language via aliases (top-1)', () => {
+  it('bridges fuzzy language via aliases (top-1)', async () => {
     const corpus = [
       makeResource({ title: 'Service mesh p99 dashboard', service: 'mesh', aliases: ['mesh latency', 'service mesh latency'] }),
       makeResource({ title: 'Kafka consumer lag', service: 'ingest' }),
       makeResource({ title: 'Postgres connections', service: 'db' }),
     ]
-    const [top] = lexicalRetriever.retrieve('how is the service mesh latency?', corpus, 3)
+    const [top] = await lexicalRetriever.retrieve('how is the service mesh latency?', corpus, 3)
     expect(top.resource.title).toBe('Service mesh p99 dashboard')
   })
 
-  it('disambiguates near-name siblings via structured service match (Gate 0 note #3)', () => {
+  it('disambiguates near-name siblings via structured service match (Gate 0 note #3)', async () => {
     // authnd vs authzd: one letter apart. The exact service match must win.
     const authnd = makeResource({ title: 'Auth service errors', service: 'authnd', aliases: ['auth errors'] })
     const authzd = makeResource({ title: 'Authz service errors', service: 'authzd', aliases: ['authz errors'] })
     const corpus = [authnd, authzd]
 
-    const forAuthzd = lexicalRetriever.retrieve('errors for authzd', corpus, 2)
+    const forAuthzd = await lexicalRetriever.retrieve('errors for authzd', corpus, 2)
     expect(forAuthzd[0].resource.service).toBe('authzd')
 
-    const forAuthnd = lexicalRetriever.retrieve('errors for authnd', corpus, 2)
+    const forAuthnd = await lexicalRetriever.retrieve('errors for authnd', corpus, 2)
     expect(forAuthnd[0].resource.service).toBe('authnd')
   })
 
-  it('tolerates a typo via edit distance without beating an exact sibling', () => {
+  it('tolerates a typo via edit distance without beating an exact sibling', async () => {
     const authnd = makeResource({ title: 'Authn errors', service: 'authnd' })
     const authzd = makeResource({ title: 'Authz errors', service: 'authzd' })
     const corpus = [authnd, authzd]
     // "authznd" is edit distance 1 from authzd's title token but the question also
     // structurally names authzd — exact structured match must dominate.
-    const res = lexicalRetriever.retrieve('authzd errors', corpus, 2)
+    const res = await lexicalRetriever.retrieve('authzd errors', corpus, 2)
     expect(res[0].resource.service).toBe('authzd')
   })
 
-  it('returns nothing for a question with no overlap (feeds negative handling)', () => {
+  it('returns nothing for a question with no overlap (feeds negative handling)', async () => {
     const corpus = [makeResource({ title: 'Mesh latency', service: 'mesh' })]
-    expect(lexicalRetriever.retrieve('quarterly revenue forecast', corpus, 5)).toEqual([])
+    expect(await lexicalRetriever.retrieve('quarterly revenue forecast', corpus, 5)).toEqual([])
   })
 
-  it('respects the limit and is deterministic on ties', () => {
+  it('respects the limit and is deterministic on ties', async () => {
     const corpus = [
       makeResource({ title: 'latency one', service: 'svc' }),
       makeResource({ title: 'latency two', service: 'svc' }),
       makeResource({ title: 'latency three', service: 'svc' }),
     ]
-    const res = lexicalRetriever.retrieve('latency', corpus, 2)
+    const res = await lexicalRetriever.retrieve('latency', corpus, 2)
     expect(res).toHaveLength(2)
     // stable tie-break by id
     expect(res[0].resource.id).toBeLessThan(res[1].resource.id)

--- a/src/main/context/retrieve.ts
+++ b/src/main/context/retrieve.ts
@@ -273,10 +273,11 @@ export function createEmbeddingRetriever(embedder: Embedder): Retriever {
     })
     if (missingIdx.length > 0) {
       const vecs = await embedder.embed(missingIdx.map((i) => docs[i]))
-      missingIdx.forEach((i, j) => {
-        if (cache.size >= MAX_CACHE) cache.clear() // simple bound; re-embeds next time
-        cache.set(docs[i], vecs[j])
-      })
+      // Bound the cache. If this batch would overflow, drop the OLD entries first
+      // (never mid-batch — that would evict vectors just computed for this corpus
+      // and leave current resources with no vector, wrongly filtering them out).
+      if (cache.size + missingIdx.length > MAX_CACHE) cache.clear()
+      missingIdx.forEach((i, j) => cache.set(docs[i], vecs[j]))
     }
     const byId = new Map<number, number[]>()
     corpus.forEach((r, i) => {

--- a/src/main/context/retrieve.ts
+++ b/src/main/context/retrieve.ts
@@ -362,7 +362,7 @@ export function createEmbeddingRetriever(embedder: Embedder): Retriever {
           return { resource, score: cosine + bonus }
         })
         // Drop only genuine noise; the LLM decides "none" over what survives.
-        .filter((c) => c.score > EMBED_MIN_SCORE)
+        .filter((c) => c.score >= EMBED_MIN_SCORE)
 
       scored.sort((a, b) => b.score - a.score || a.resource.id - b.resource.id)
       return scored.slice(0, Math.max(0, limit))

--- a/src/main/context/retrieve.ts
+++ b/src/main/context/retrieve.ts
@@ -276,11 +276,13 @@ function dot(a: number[], b: number[]): number {
 }
 
 /**
- * Cosine floor: drop only genuine noise so weak-but-real matches still reach the
- * decider. It must stay low — the two-stage design relies on the LLM (not this
+ * Minimum COMBINED score (cosine + structured bonus) for a candidate to survive.
+ * It's deliberately low — the two-stage design relies on the LLM (not this
  * floor) to reject candidates and answer "none". Set from the adversarial eval:
- * a correct-but-weak match (authnd) scored ~0.16, so a 0.2 floor wrongly
- * filtered it. The LLM rejects genuine negatives (verified in the live eval).
+ * a correct-but-weak match (authnd) scored ~0.16 cosine, so a higher floor
+ * wrongly filtered it. Note it applies to the combined score, so an exact
+ * structured match can (intentionally) rescue a resource the user named
+ * explicitly even when its cosine is modest.
  */
 const EMBED_MIN_SCORE = 0.1
 

--- a/src/main/context/retrieve.ts
+++ b/src/main/context/retrieve.ts
@@ -173,15 +173,25 @@ function bonusFromStructValues(questionTokens: string[], structValues: Set<strin
   return bonus
 }
 
+/** Escapes a string for literal use inside a RegExp. */
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
 /**
- * Boolean structured hit-check (Gate 0 note #3: authnd vs authzd). A question
- * token that IS one of the resource's structured values (service/env/tag) is a
- * hit. Decoupled from the lexical weight constant so the embedding retriever's
+ * Boolean structured hit-check (Gate 0 note #3: authnd vs authzd). True when a
+ * structured value (service/env/tag) appears as a whole token in the raw
+ * question — matched against the raw string, NOT tokenize(), so hyphenated
+ * values like "orders-db" or "us-east" are detected when typed exactly.
+ * Decoupled from the lexical weight constant so the embedding retriever's
  * tie-break is unaffected if EXACT_STRUCT_BONUS is ever re-tuned. Pure.
  */
-export function hasStructuredMatch(questionTokens: string[], resource: Resource): boolean {
-  const structValues = resourceStructValues(resource)
-  return questionTokens.some((qt) => structValues.has(qt))
+export function hasStructuredMatch(question: string, resource: Resource): boolean {
+  const q = question.toLowerCase()
+  for (const value of resourceStructValues(resource)) {
+    if (new RegExp(`(^|[^a-z0-9])${escapeRegExp(value)}([^a-z0-9]|$)`).test(q)) return true
+  }
+  return false
 }
 
 /** Pure relevance score of a resource for a set of question tokens. No health penalty. */
@@ -313,14 +323,13 @@ export function createEmbeddingRetriever(embedder: Embedder): Retriever {
         throw new Error('embedder returned no vector for the query')
       }
       const corpusVecs = await embedCorpus(corpus)
-      const questionTokens = tokenize(question)
 
       const scored = corpus
         .map((resource) => {
           const vec = corpusVecs.get(resource.id)
           if (vec === undefined) return { resource, score: 0 }
           const cosine = dot(queryVec, vec)
-          const bonus = hasStructuredMatch(questionTokens, resource) ? EMBED_STRUCT_BONUS : 0
+          const bonus = hasStructuredMatch(question, resource) ? EMBED_STRUCT_BONUS : 0
           return { resource, score: cosine + bonus }
         })
         // Drop only genuine noise; the LLM decides "none" over what survives.

--- a/src/main/context/retrieve.ts
+++ b/src/main/context/retrieve.ts
@@ -343,12 +343,12 @@ export function createEmbeddingRetriever(embedder: Embedder): Retriever {
     async retrieve(question: string, corpus: Resource[], limit: number): Promise<ScoredCandidate[]> {
       if (corpus.length === 0 || limit <= 0) return [] // no embedding work for no-op calls
       const queryVecs = await embedder.embed([question])
-      const queryVec = queryVecs[0]
-      // Fail fast (rather than a later unclear error) if the embedder didn't
-      // return a query vector; createDefaultRetriever falls back to lexical.
-      if (queryVec === undefined) {
-        throw new Error('embedder returned no vector for the query')
+      // Assert exactly one vector for the single-text request so a buggy embedder
+      // fails fast (to the lexical fallback) instead of masking a contract break.
+      if (queryVecs.length !== 1) {
+        throw new Error(`embedder returned ${queryVecs.length} vectors for a single query`)
       }
+      const queryVec = queryVecs[0]
       const corpusVecs = await embedCorpus(corpus)
 
       const scored = corpus

--- a/src/main/context/retrieve.ts
+++ b/src/main/context/retrieve.ts
@@ -180,10 +180,14 @@ function bonusFromStructValues(questionTokens: string[], structValues: Set<strin
  * both the lexical and embedding retrievers so near-name siblings never confuse
  * the semantic layer either. Pure.
  */
-export function structuredMatchBonus(questionTokens: string[], resource: Resource): number {
-  // Only needs the structured values — avoid the full field tokenization, which
-  // matters in the embedding retriever's per-resource-per-query hot path.
-  return bonusFromStructValues(questionTokens, resourceStructValues(resource))
+/**
+ * Boolean structured hit-check, decoupled from the lexical weight constant. The
+ * embedding retriever uses this for its tie-break so it is unaffected if
+ * EXACT_STRUCT_BONUS is ever re-tuned (or zeroed) for lexical scoring. Pure.
+ */
+export function hasStructuredMatch(questionTokens: string[], resource: Resource): boolean {
+  const structValues = resourceStructValues(resource)
+  return questionTokens.some((qt) => structValues.has(qt))
 }
 
 /** Pure relevance score of a resource for a set of question tokens. No health penalty. */
@@ -284,6 +288,12 @@ export function createEmbeddingRetriever(embedder: Embedder): Retriever {
     })
     if (missingIdx.length > 0) {
       const vecs = await embedder.embed(missingIdx.map((i) => docs[i]))
+      // Fail fast if the embedder didn't return exactly one vector per document —
+      // otherwise a short/misordered result would silently cache invalid vectors
+      // (score 0 -> wrongly filtered). createDefaultRetriever falls back to lexical.
+      if (vecs.length !== missingIdx.length) {
+        throw new Error(`embedder returned ${vecs.length} vectors for ${missingIdx.length} documents`)
+      }
       // Bound the cache with a simple whole-cache clear when the incoming batch
       // would overflow. Done BEFORE inserting (never mid-batch) so it can't evict
       // vectors just computed for the current corpus and wrongly filter them out.
@@ -310,7 +320,7 @@ export function createEmbeddingRetriever(embedder: Embedder): Retriever {
           const vec = corpusVecs.get(resource.id)
           if (vec === undefined) return { resource, score: 0 }
           const cosine = dot(queryVec, vec)
-          const bonus = structuredMatchBonus(questionTokens, resource) > 0 ? EMBED_STRUCT_BONUS : 0
+          const bonus = hasStructuredMatch(questionTokens, resource) ? EMBED_STRUCT_BONUS : 0
           return { resource, score: cosine + bonus }
         })
         // Drop only genuine noise; the LLM decides "none" over what survives.

--- a/src/main/context/retrieve.ts
+++ b/src/main/context/retrieve.ts
@@ -236,9 +236,14 @@ export function resourceDocument(resource: Resource): string {
 }
 
 function dot(a: number[], b: number[]): number {
+  // Fail fast on a dimension mismatch (model change / corrupted cache / partial
+  // output) rather than silently scoring on a truncated prefix. The default
+  // retriever catches this and falls back to lexical.
+  if (a.length !== b.length) {
+    throw new Error(`embedding dimension mismatch: ${a.length} vs ${b.length}`)
+  }
   let s = 0
-  const n = Math.min(a.length, b.length)
-  for (let i = 0; i < n; i++) s += a[i] * b[i]
+  for (let i = 0; i < a.length; i++) s += a[i] * b[i]
   return s
 }
 
@@ -279,9 +284,9 @@ export function createEmbeddingRetriever(embedder: Embedder): Retriever {
     })
     if (missingIdx.length > 0) {
       const vecs = await embedder.embed(missingIdx.map((i) => docs[i]))
-      // Bound the cache. If this batch would overflow, drop the OLD entries first
-      // (never mid-batch — that would evict vectors just computed for this corpus
-      // and leave current resources with no vector, wrongly filtering them out).
+      // Bound the cache with a simple whole-cache clear when the incoming batch
+      // would overflow. Done BEFORE inserting (never mid-batch) so it can't evict
+      // vectors just computed for the current corpus and wrongly filter them out.
       if (cache.size + missingIdx.length > MAX_CACHE) cache.clear()
       missingIdx.forEach((i, j) => cache.set(docs[i], vecs[j]))
     }

--- a/src/main/context/retrieve.ts
+++ b/src/main/context/retrieve.ts
@@ -253,7 +253,7 @@ const EMBED_STRUCT_BONUS = 0.15
 /**
  * Creates a hybrid embedding retriever: semantic cosine similarity + the
  * structured exact-match bonus. Corpus embeddings are cached in-memory keyed by
- * resource id + updatedAt, so only new/changed records are re-embedded.
+ * the embedded document text, so only new/changed content is re-embedded.
  */
 export function createEmbeddingRetriever(embedder: Embedder): Retriever {
   // Cache keyed by the embedded DOCUMENT text, so health/usage bumps (which move

--- a/src/main/context/retrieve.ts
+++ b/src/main/context/retrieve.ts
@@ -234,6 +234,15 @@ function dot(a: number[], b: number[]): number {
 }
 
 /**
+ * Cosine floor: drop only genuine noise so weak-but-real matches still reach the
+ * decider. It must stay low — the two-stage design relies on the LLM (not this
+ * floor) to reject candidates and answer "none". Set from the adversarial eval:
+ * a correct-but-weak match (authnd) scored ~0.16, so a 0.2 floor wrongly
+ * filtered it. The LLM rejects genuine negatives (verified in the live eval).
+ */
+const EMBED_MIN_SCORE = 0.1
+
+/**
  * How much a single structured exact-match nudges the (cosine-based) score.
  * Cosine is roughly [-1, 1]; this keeps embeddings primary while letting an
  * exact service/env/tag match break near-name-sibling ties (authnd vs authzd),
@@ -247,20 +256,30 @@ const EMBED_STRUCT_BONUS = 0.15
  * resource id + updatedAt, so only new/changed records are re-embedded.
  */
 export function createEmbeddingRetriever(embedder: Embedder): Retriever {
+  // Cache keyed by the embedded DOCUMENT text, so health/usage bumps (which move
+  // updatedAt but not content) don't force re-embedding, and identical content
+  // dedups. Bounded so it can't grow without limit.
   const cache = new Map<string, number[]>()
-  const cacheKey = (r: Resource): string => `${r.id}:${r.updatedAt}`
+  const MAX_CACHE = 5000
 
   async function embedCorpus(corpus: Resource[]): Promise<Map<number, number[]>> {
-    const missing = corpus.filter((r) => !cache.has(cacheKey(r)))
-    if (missing.length > 0) {
-      const vecs = await embedder.embed(missing.map(resourceDocument))
-      missing.forEach((r, i) => cache.set(cacheKey(r), vecs[i]))
+    const docs = corpus.map((r) => resourceDocument(r))
+    const missingIdx: number[] = []
+    docs.forEach((doc, i) => {
+      if (!cache.has(doc)) missingIdx.push(i)
+    })
+    if (missingIdx.length > 0) {
+      const vecs = await embedder.embed(missingIdx.map((i) => docs[i]))
+      missingIdx.forEach((i, j) => {
+        if (cache.size >= MAX_CACHE) cache.clear() // simple bound; re-embeds next time
+        cache.set(docs[i], vecs[j])
+      })
     }
     const byId = new Map<number, number[]>()
-    for (const r of corpus) {
-      const v = cache.get(cacheKey(r))
+    corpus.forEach((r, i) => {
+      const v = cache.get(docs[i])
       if (v) byId.set(r.id, v)
-    }
+    })
     return byId
   }
 
@@ -279,9 +298,8 @@ export function createEmbeddingRetriever(embedder: Embedder): Retriever {
           const bonus = structuredMatchBonus(questionTokens, resource) > 0 ? EMBED_STRUCT_BONUS : 0
           return { resource, score: cosine + bonus }
         })
-        // Drop weak/negative matches so an unrelated question yields no candidates
-        // (feeds the resolver's honest "no source saved").
-        .filter((c) => c.score > 0.2)
+        // Drop only genuine noise; the LLM decides "none" over what survives.
+        .filter((c) => c.score > EMBED_MIN_SCORE)
 
       scored.sort((a, b) => b.score - a.score || a.resource.id - b.resource.id)
       return scored.slice(0, Math.max(0, limit))

--- a/src/main/context/retrieve.ts
+++ b/src/main/context/retrieve.ts
@@ -1,4 +1,5 @@
 import type { Resource } from '../../shared/ipc-channels'
+import type { Embedder } from './embed'
 
 /**
  * Two-stage resolver, stage one: retrieval. This produces a *pure relevance*
@@ -23,7 +24,7 @@ export interface ScoredCandidate {
 
 export interface Retriever {
   /** Returns up to `limit` candidates ranked by descending relevance. Ties broken by id (stable). */
-  retrieve(question: string, corpus: Resource[], limit: number): ScoredCandidate[]
+  retrieve(question: string, corpus: Resource[], limit: number): Promise<ScoredCandidate[]>
 }
 
 // ── Tokenization ──────────────────────────────────────────────────────────────
@@ -159,6 +160,22 @@ function fieldHits(questionTokens: string[], fieldTokens: string[]): number {
   return score
 }
 
+/**
+ * Structured exact-match bonus for a resource: a question token that IS one of
+ * the resource's structured values (service/env/tag) decisively boosts it. This
+ * is the disambiguation from Gate 0 note #3 (authnd vs authzd) and is shared by
+ * both the lexical and embedding retrievers so near-name siblings never confuse
+ * the semantic layer either. Pure.
+ */
+export function structuredMatchBonus(questionTokens: string[], resource: Resource): number {
+  const structValues = resourceTokens(resource).structValues
+  let bonus = 0
+  for (const qt of questionTokens) {
+    if (structValues.has(qt)) bonus += EXACT_STRUCT_BONUS
+  }
+  return bonus
+}
+
 /** Pure relevance score of a resource for a set of question tokens. No health penalty. */
 export function scoreResource(questionTokens: string[], resource: Resource): number {
   if (questionTokens.length === 0) return 0
@@ -175,23 +192,122 @@ export function scoreResource(questionTokens: string[], resource: Resource): num
 
   // Structured exact-match dominance: a question token that IS a structured
   // value (service/env/tag) decisively boosts this record over near siblings.
-  for (const qt of questionTokens) {
-    if (ft.structValues.has(qt)) score += EXACT_STRUCT_BONUS
-  }
+  score += structuredMatchBonus(questionTokens, resource)
 
   return score
+}
+
+/** Synchronous lexical ranking (shared internals; the async retriever wraps this). */
+export function rankLexical(question: string, corpus: Resource[], limit: number): ScoredCandidate[] {
+  const questionTokens = tokenize(question)
+  const scored = corpus
+    .map((resource) => ({ resource, score: scoreResource(questionTokens, resource) }))
+    .filter((c) => c.score > 0)
+  // Descending score; stable tie-break by id so results are deterministic.
+  scored.sort((a, b) => b.score - a.score || a.resource.id - b.resource.id)
+  return scored.slice(0, Math.max(0, limit))
 }
 
 // ── The lexical retriever ─────────────────────────────────────────────────────
 
 export const lexicalRetriever: Retriever = {
-  retrieve(question: string, corpus: Resource[], limit: number): ScoredCandidate[] {
-    const questionTokens = tokenize(question)
-    const scored = corpus
-      .map((resource) => ({ resource, score: scoreResource(questionTokens, resource) }))
-      .filter((c) => c.score > 0)
-    // Descending score; stable tie-break by id so results are deterministic.
-    scored.sort((a, b) => b.score - a.score || a.resource.id - b.resource.id)
-    return scored.slice(0, Math.max(0, limit))
+  retrieve(question: string, corpus: Resource[], limit: number): Promise<ScoredCandidate[]> {
+    return Promise.resolve(rankLexical(question, corpus, limit))
   },
+}
+
+// ── Embedding retriever (semantic recall for lexically-disjoint phrasing) ──────
+
+/** The text embedded per resource: everything a question might semantically match. */
+export function resourceDocument(resource: Resource): string {
+  const tagValues = Object.values(resource.tags).join(' ')
+  return [resource.title, resource.aliases.join(' '), resource.description, resource.service, resource.env, tagValues]
+    .filter((p) => p.trim().length > 0)
+    .join('. ')
+}
+
+function dot(a: number[], b: number[]): number {
+  let s = 0
+  const n = Math.min(a.length, b.length)
+  for (let i = 0; i < n; i++) s += a[i] * b[i]
+  return s
+}
+
+/**
+ * How much a single structured exact-match nudges the (cosine-based) score.
+ * Cosine is roughly [-1, 1]; this keeps embeddings primary while letting an
+ * exact service/env/tag match break near-name-sibling ties (authnd vs authzd),
+ * which pure embeddings alone confuse (Gate 0 note #3).
+ */
+const EMBED_STRUCT_BONUS = 0.15
+
+/**
+ * Creates a hybrid embedding retriever: semantic cosine similarity + the
+ * structured exact-match bonus. Corpus embeddings are cached in-memory keyed by
+ * resource id + updatedAt, so only new/changed records are re-embedded.
+ */
+export function createEmbeddingRetriever(embedder: Embedder): Retriever {
+  const cache = new Map<string, number[]>()
+  const cacheKey = (r: Resource): string => `${r.id}:${r.updatedAt}`
+
+  async function embedCorpus(corpus: Resource[]): Promise<Map<number, number[]>> {
+    const missing = corpus.filter((r) => !cache.has(cacheKey(r)))
+    if (missing.length > 0) {
+      const vecs = await embedder.embed(missing.map(resourceDocument))
+      missing.forEach((r, i) => cache.set(cacheKey(r), vecs[i]))
+    }
+    const byId = new Map<number, number[]>()
+    for (const r of corpus) {
+      const v = cache.get(cacheKey(r))
+      if (v) byId.set(r.id, v)
+    }
+    return byId
+  }
+
+  return {
+    async retrieve(question: string, corpus: Resource[], limit: number): Promise<ScoredCandidate[]> {
+      if (corpus.length === 0) return []
+      const [queryVec] = await embedder.embed([question])
+      const corpusVecs = await embedCorpus(corpus)
+      const questionTokens = tokenize(question)
+
+      const scored = corpus
+        .map((resource) => {
+          const vec = corpusVecs.get(resource.id)
+          if (vec === undefined) return { resource, score: 0 }
+          const cosine = dot(queryVec, vec)
+          const bonus = structuredMatchBonus(questionTokens, resource) > 0 ? EMBED_STRUCT_BONUS : 0
+          return { resource, score: cosine + bonus }
+        })
+        // Drop weak/negative matches so an unrelated question yields no candidates
+        // (feeds the resolver's honest "no source saved").
+        .filter((c) => c.score > 0.2)
+
+      scored.sort((a, b) => b.score - a.score || a.resource.id - b.resource.id)
+      return scored.slice(0, Math.max(0, limit))
+    },
+  }
+}
+
+/**
+ * The production retriever: the hybrid embedding retriever (semantic cosine +
+ * structured tie-break) with a transparent lexical fallback if the embedding
+ * model can't load or an embed fails (offline, missing runtime). Pure lexical
+ * ranking is deliberately NOT fused in — on lexically-disjoint questions its
+ * coincidental token matches add noise that drags the right semantic result
+ * down (measured: fusion scored lower on the adversarial eval than embeddings
+ * alone). The structured bonus already recovers exact service/env/tag matches.
+ */
+export function createDefaultRetriever(embedder: Embedder): Retriever {
+  const embedding = createEmbeddingRetriever(embedder)
+  return {
+    async retrieve(question: string, corpus: Resource[], limit: number): Promise<ScoredCandidate[]> {
+      try {
+        return await embedding.retrieve(question, corpus, limit)
+      } catch (err) {
+        console.error('[retrieve] embedding retriever failed; falling back to lexical:', err)
+        return rankLexical(question, corpus, limit)
+      }
+    },
+  }
 }

--- a/src/main/context/retrieve.ts
+++ b/src/main/context/retrieve.ts
@@ -381,12 +381,18 @@ export function createEmbeddingRetriever(embedder: Embedder): Retriever {
  */
 export function createDefaultRetriever(embedder: Embedder): Retriever {
   const embedding = createEmbeddingRetriever(embedder)
+  let warnedFailure = false
   return {
     async retrieve(question: string, corpus: Resource[], limit: number): Promise<ScoredCandidate[]> {
       try {
         return await embedding.retrieve(question, corpus, limit)
       } catch (err) {
-        console.error('[retrieve] embedding retriever failed; falling back to lexical:', err)
+        // Log once per retriever instance so a persistently-unavailable model
+        // (offline first run / missing runtime) doesn't spam on every resolve.
+        if (!warnedFailure) {
+          warnedFailure = true
+          console.error('[retrieve] embedding retriever failed; falling back to lexical:', err)
+        }
         return rankLexical(question, corpus, limit)
       }
     },

--- a/src/main/context/retrieve.ts
+++ b/src/main/context/retrieve.ts
@@ -174,16 +174,10 @@ function bonusFromStructValues(questionTokens: string[], structValues: Set<strin
 }
 
 /**
- * Structured exact-match bonus for a resource: a question token that IS one of
- * the resource's structured values (service/env/tag) decisively boosts it. This
- * is the disambiguation from Gate 0 note #3 (authnd vs authzd) and is shared by
- * both the lexical and embedding retrievers so near-name siblings never confuse
- * the semantic layer either. Pure.
- */
-/**
- * Boolean structured hit-check, decoupled from the lexical weight constant. The
- * embedding retriever uses this for its tie-break so it is unaffected if
- * EXACT_STRUCT_BONUS is ever re-tuned (or zeroed) for lexical scoring. Pure.
+ * Boolean structured hit-check (Gate 0 note #3: authnd vs authzd). A question
+ * token that IS one of the resource's structured values (service/env/tag) is a
+ * hit. Decoupled from the lexical weight constant so the embedding retriever's
+ * tie-break is unaffected if EXACT_STRUCT_BONUS is ever re-tuned. Pure.
  */
 export function hasStructuredMatch(questionTokens: string[], resource: Resource): boolean {
   const structValues = resourceStructValues(resource)
@@ -311,7 +305,13 @@ export function createEmbeddingRetriever(embedder: Embedder): Retriever {
   return {
     async retrieve(question: string, corpus: Resource[], limit: number): Promise<ScoredCandidate[]> {
       if (corpus.length === 0) return []
-      const [queryVec] = await embedder.embed([question])
+      const queryVecs = await embedder.embed([question])
+      const queryVec = queryVecs[0]
+      // Fail fast (rather than a later unclear error) if the embedder didn't
+      // return a query vector; createDefaultRetriever falls back to lexical.
+      if (queryVec === undefined) {
+        throw new Error('embedder returned no vector for the query')
+      }
       const corpusVecs = await embedCorpus(corpus)
       const questionTokens = tokenize(question)
 

--- a/src/main/context/retrieve.ts
+++ b/src/main/context/retrieve.ts
@@ -173,9 +173,24 @@ function bonusFromStructValues(questionTokens: string[], structValues: Set<strin
   return bonus
 }
 
-/** Escapes a string for literal use inside a RegExp. */
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+/** True for a lowercased ASCII alphanumeric char (used for word boundaries). */
+function isAlnum(ch: string): boolean {
+  if (ch.length === 0) return false
+  const c = ch.charCodeAt(0)
+  return (c >= 48 && c <= 57) || (c >= 97 && c <= 122)
+}
+
+/** Whole-token containment (alnum boundaries) without RegExp compilation. */
+function containsToken(haystack: string, token: string): boolean {
+  let from = 0
+  for (;;) {
+    const idx = haystack.indexOf(token, from)
+    if (idx === -1) return false
+    const before = idx === 0 ? '' : haystack[idx - 1]
+    const after = idx + token.length >= haystack.length ? '' : haystack[idx + token.length]
+    if (!isAlnum(before) && !isAlnum(after)) return true
+    from = idx + 1
+  }
 }
 
 /**
@@ -189,7 +204,7 @@ function escapeRegExp(value: string): string {
 export function hasStructuredMatch(question: string, resource: Resource): boolean {
   const q = question.toLowerCase()
   for (const value of resourceStructValues(resource)) {
-    if (new RegExp(`(^|[^a-z0-9])${escapeRegExp(value)}([^a-z0-9]|$)`).test(q)) return true
+    if (containsToken(q, value)) return true
   }
   return false
 }
@@ -321,7 +336,7 @@ export function createEmbeddingRetriever(embedder: Embedder): Retriever {
 
   return {
     async retrieve(question: string, corpus: Resource[], limit: number): Promise<ScoredCandidate[]> {
-      if (corpus.length === 0) return []
+      if (corpus.length === 0 || limit <= 0) return [] // no embedding work for no-op calls
       const queryVecs = await embedder.embed([question])
       const queryVec = queryVecs[0]
       // Fail fast (rather than a later unclear error) if the embedder didn't

--- a/src/main/context/retrieve.ts
+++ b/src/main/context/retrieve.ts
@@ -160,6 +160,15 @@ function fieldHits(questionTokens: string[], fieldTokens: string[]): number {
   return score
 }
 
+/** Adds the exact-match bonus for question tokens that hit a precomputed struct-value set. */
+function bonusFromStructValues(questionTokens: string[], structValues: Set<string>): number {
+  let bonus = 0
+  for (const qt of questionTokens) {
+    if (structValues.has(qt)) bonus += EXACT_STRUCT_BONUS
+  }
+  return bonus
+}
+
 /**
  * Structured exact-match bonus for a resource: a question token that IS one of
  * the resource's structured values (service/env/tag) decisively boosts it. This
@@ -168,12 +177,7 @@ function fieldHits(questionTokens: string[], fieldTokens: string[]): number {
  * the semantic layer either. Pure.
  */
 export function structuredMatchBonus(questionTokens: string[], resource: Resource): number {
-  const structValues = resourceTokens(resource).structValues
-  let bonus = 0
-  for (const qt of questionTokens) {
-    if (structValues.has(qt)) bonus += EXACT_STRUCT_BONUS
-  }
-  return bonus
+  return bonusFromStructValues(questionTokens, resourceTokens(resource).structValues)
 }
 
 /** Pure relevance score of a resource for a set of question tokens. No health penalty. */
@@ -190,9 +194,8 @@ export function scoreResource(questionTokens: string[], resource: Resource): num
     fieldHits(questionTokens, ft.description) * WEIGHTS.description +
     fieldHits(questionTokens, ft.source) * WEIGHTS.source
 
-  // Structured exact-match dominance: a question token that IS a structured
-  // value (service/env/tag) decisively boosts this record over near siblings.
-  score += structuredMatchBonus(questionTokens, resource)
+  // Structured exact-match dominance, reusing the already-computed struct values.
+  score += bonusFromStructValues(questionTokens, ft.structValues)
 
   return score
 }

--- a/src/main/context/retrieve.ts
+++ b/src/main/context/retrieve.ts
@@ -290,6 +290,8 @@ export function createEmbeddingRetriever(embedder: Embedder): Retriever {
     docs.forEach((doc, i) => {
       if (!cache.has(doc)) missingIdx.push(i)
     })
+    // Vectors for docs embedded this call but not persisted (oversized batch).
+    const fresh = new Map<string, number[]>()
     if (missingIdx.length > 0) {
       const vecs = await embedder.embed(missingIdx.map((i) => docs[i]))
       // Fail fast if the embedder didn't return exactly one vector per document —
@@ -298,15 +300,20 @@ export function createEmbeddingRetriever(embedder: Embedder): Retriever {
       if (vecs.length !== missingIdx.length) {
         throw new Error(`embedder returned ${vecs.length} vectors for ${missingIdx.length} documents`)
       }
-      // Bound the cache with a simple whole-cache clear when the incoming batch
-      // would overflow. Done BEFORE inserting (never mid-batch) so it can't evict
-      // vectors just computed for the current corpus and wrongly filter them out.
-      if (cache.size + missingIdx.length > MAX_CACHE) cache.clear()
-      missingIdx.forEach((i, j) => cache.set(docs[i], vecs[j]))
+      // Only persist to the bounded cache when the batch itself fits; a batch
+      // larger than MAX_CACHE is used transiently for this query and not cached,
+      // so the persistent cache stays strictly bounded. Clear old entries first
+      // (never mid-batch) when a fitting batch would overflow.
+      const persist = missingIdx.length <= MAX_CACHE
+      if (persist && cache.size + missingIdx.length > MAX_CACHE) cache.clear()
+      missingIdx.forEach((i, j) => {
+        if (persist) cache.set(docs[i], vecs[j])
+        else fresh.set(docs[i], vecs[j])
+      })
     }
     const byId = new Map<number, number[]>()
     corpus.forEach((r, i) => {
-      const v = cache.get(docs[i])
+      const v = cache.get(docs[i]) ?? fresh.get(docs[i])
       if (v) byId.set(r.id, v)
     })
     return byId

--- a/src/main/context/retrieve.ts
+++ b/src/main/context/retrieve.ts
@@ -117,14 +117,18 @@ interface FieldTokens {
   structValues: Set<string>
 }
 
-/** Precompute a resource's tokenized fields. Pure; exported for tests. */
-export function resourceTokens(resource: Resource): FieldTokens {
-  const tagValues = Object.values(resource.tags)
-  const structValues = new Set<string>(
-    [resource.service, resource.env, ...tagValues]
+/** The lowercased structured values (service/env/tag) for exact-match matching. Cheap. */
+export function resourceStructValues(resource: Resource): Set<string> {
+  return new Set<string>(
+    [resource.service, resource.env, ...Object.values(resource.tags)]
       .map((v) => v.toLowerCase().trim())
       .filter((v) => v.length > 0)
   )
+}
+
+/** Precompute a resource's tokenized fields. Pure; exported for tests. */
+export function resourceTokens(resource: Resource): FieldTokens {
+  const tagValues = Object.values(resource.tags)
   return {
     title: tokenize(resource.title),
     aliases: resource.aliases.flatMap(tokenize),
@@ -133,7 +137,7 @@ export function resourceTokens(resource: Resource): FieldTokens {
     tags: tagValues.flatMap(tokenize),
     description: tokenize(resource.description),
     source: tokenize(resource.source),
-    structValues,
+    structValues: resourceStructValues(resource),
   }
 }
 
@@ -177,7 +181,9 @@ function bonusFromStructValues(questionTokens: string[], structValues: Set<strin
  * the semantic layer either. Pure.
  */
 export function structuredMatchBonus(questionTokens: string[], resource: Resource): number {
-  return bonusFromStructValues(questionTokens, resourceTokens(resource).structValues)
+  // Only needs the structured values — avoid the full field tokenization, which
+  // matters in the embedding retriever's per-resource-per-query hot path.
+  return bonusFromStructValues(questionTokens, resourceStructValues(resource))
 }
 
 /** Pure relevance score of a resource for a set of question tokens. No health penalty. */

--- a/src/main/context/retrieve.ts
+++ b/src/main/context/retrieve.ts
@@ -252,7 +252,12 @@ export const lexicalRetriever: Retriever = {
 
 /** The text embedded per resource: everything a question might semantically match. */
 export function resourceDocument(resource: Resource): string {
-  const tagValues = Object.values(resource.tags).join(' ')
+  // Sort tags by key so the embedded text (and thus the cache key) is stable
+  // regardless of JSON round-trip key ordering.
+  const tagValues = Object.entries(resource.tags)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([, v]) => v)
+    .join(' ')
   return [resource.title, resource.aliases.join(' '), resource.description, resource.service, resource.env, tagValues]
     .filter((p) => p.trim().length > 0)
     .join('. ')


### PR DESCRIPTION
Follow-up to #76 (MVP C). Fixes an integrity problem I shipped in that PR, caught in review.

## The problem: my eval was rigged

MVP C's synthetic eval reported **100% top-3 retrieval recall** and I used that to justify shipping a lexical-only retriever with "embeddings as a deferred upgrade." That was a false pass: the eval questions were **lexically aligned** — they shared vocabulary with the records' aliases, so simple token matching always won. Gate 0's real recall came from **semantic embeddings bridging lexically-DISJOINT phrasing** (e.g. "in-memory store" → redis), which my eval never tested.

I built an adversarial (deliberately lexically-disjoint) question set and measured honestly:

| retriever | aligned recall@3 | adversarial recall@3 | adversarial recall@8 |
|---|---|---|---|
| lexical (shipped in #76) | 100% | **58%** | 67% |
| embedding (this PR) | 100% | **92%** | **100%** |

Lexical whiffed completely on things like "why can't people get into their accounts?" → nothing. So lexical-only genuinely does not deliver the semantic recall the feature needs.

## The fix

- **Adversarial eval** (`questions.adversarial.json`) + a CI gate asserting lexical does *not* clear the bar on it — so the eval can never silently re-align into a false pass again.
- **Async `Retriever` interface** (assemble/resolve await) so retrieval can be embedding-backed.
- **Local embedder** (`embed.ts`): transformers.js `Xenova/all-MiniLM-L6-v2`, mean-pooled + L2-normalized, lazily loaded via dynamic `import()`, with a writable model-cache dir for the packaged app.
- **Hybrid embedding retriever**: cosine similarity + a small structured exact-match bonus so near-name siblings (authnd vs authzd) don't confuse the semantic layer (Gate 0 note #3). Corpus embeddings cached by document content (health/usage bumps don't force re-embeds), bounded.
- **Production wiring**: `createDefaultRetriever` = embedding with a transparent **lexical fallback** if the model can't load (offline / missing runtime). Unit + integration tests keep the deterministic lexical default (offline, no model download); the real-model quality is a manual `retriever-eval` + the live eval.
- I tried **RRF fusion** (lexical + embedding) and it scored *worse* on adversarial (lexical's coincidental matches inject noise on disjoint queries), so production deliberately uses pure embedding + structured bonus, not fusion. Documented in the code.

## How I verified it (and what a first review corrected)

An independent (GPT-5.5) review caught that my initial embedding cut still **filtered/capped the correct doc out before the LLM** — a 0.2 cosine floor dropped a correct-but-weak match (authnd at 0.164) and a cap of 5 hid a rank-7 correct doc. So "the LLM closes the gap" was a rationalization. Fixed:
- Floor 0.2 → **0.1** (the LLM, not the floor, decides "none").
- Decider candidate cap 5 → **8** (pool 10 → 15).

After those fixes:
- **Embedding adversarial recall@8 = 100%** — the decider now sees the right source for every adversarial question. Aligned stays 100%.
- **Live eval with the production embedding retriever** (real `copilot -p`): negatives **4/4 = 100%** (zero hallucinations — the LLM correctly rejects the weak candidates a low floor surfaces), right-source@1 20/21 (the one "miss" is a safe *clarify*), citations 100%, app-owned live-value pull works.
- 297 Vitest tests pass; typecheck + lint + build clean.
- `setup` now installs onnxruntime's native binaries (`trustedDependencies`) so production doesn't silently stay on the lexical fallback.

## Honest gaps

- **onnxruntime under a running Electron app** is not verified in-sandbox (I can't launch the app here). It works under bun/tests, the build bundles it, and onnxruntime-node is **N-API v6 (ABI-stable)** so it should load without a rebuild — but if it doesn't, the retriever falls back to lexical rather than crashing.
- The embedding model **downloads once** (~23MB) on first resolve. First-run latency + a writable cache dir are handled; offline first-run falls back to lexical until the model is cached.
- New dep weight: `@huggingface/transformers` + onnxruntime (main-process only, dynamic import, externalized like the MCP SDK).