### PR TITLE
MVP C: MCP "Connect a tool" UI + backend contracts for live values

### DIFF
--- a/db/migrations/016_project_mcp_servers_soft_delete.sql
+++ b/db/migrations/016_project_mcp_servers_soft_delete.sql
@@ -1,0 +1,9 @@
+-- Migration: 016_project_mcp_servers_soft_delete.sql
+-- MVP C: soft-delete for wired MCP servers so a "Disconnect a tool" delete is
+-- losslessly undoable (undo over confirmation) without nulling the resource
+-- links that point at the server. Mirrors the soft-delete pattern already used
+-- for resources.
+--
+-- deleted_at stores an ISO 8601 UTC string when soft-deleted, NULL when live.
+
+ALTER TABLE project_mcp_servers ADD COLUMN deleted_at TEXT;

--- a/src/main/context/mcp-client.test.ts
+++ b/src/main/context/mcp-client.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { join } from 'path'
-import { extractToolText, interpretCallResult, createMcpRunner, listMcpTools } from './mcp-client'
+import { extractToolText, interpretCallResult, createMcpRunner, listMcpTools, sanitizeMcpJson } from './mcp-client'
 import type { McpStdioConfig } from '../../shared/ipc-channels'
 
 // ── Pure interpretation ───────────────────────────────────────────────────────
@@ -112,4 +112,21 @@ describe('listMcpTools (honest connection probe)', () => {
     expect(r.ok).toBe(false)
     if (!r.ok) expect(r.error).not.toContain(secret)
   }, 12_000)
+})
+
+describe('sanitizeMcpJson', () => {
+  it('scrubs configured secret values from both string leaves AND object keys', () => {
+    const env = { TOKEN: 'supersecrettoken12345' }
+    const schema = {
+      supersecrettoken12345: 'inside a key',
+      description: 'value has supersecrettoken12345 in it',
+      nested: { arr: ['supersecrettoken12345'] },
+    }
+    const out = sanitizeMcpJson(schema, env)
+    expect(JSON.stringify(out)).not.toContain('supersecrettoken12345')
+  })
+  it('passes through non-secret content unchanged in shape', () => {
+    const out = sanitizeMcpJson({ type: 'object', n: 5, ok: true }, {})
+    expect(out).toEqual({ type: 'object', n: 5, ok: true })
+  })
 })

--- a/src/main/context/mcp-client.test.ts
+++ b/src/main/context/mcp-client.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { join } from 'path'
-import { extractToolText, interpretCallResult, createMcpRunner } from './mcp-client'
+import { extractToolText, interpretCallResult, createMcpRunner, listMcpTools } from './mcp-client'
 import type { McpStdioConfig } from '../../shared/ipc-channels'
 
 // ── Pure interpretation ───────────────────────────────────────────────────────
@@ -82,5 +82,34 @@ describe('createMcpRunner (app-owned read, end-to-end)', () => {
     const r = await runner.run({ command: 'definitely-not-a-real-binary-xyz', args: [], env: {} }, 'echo', {})
     expect(r.ok).toBe(false)
     expect(r.failure).toBe('connector_down')
+  }, 12_000)
+})
+
+describe('listMcpTools (honest connection probe)', () => {
+  it('starts the server and discovers its tools', async () => {
+    const r = await listMcpTools(echoServer(), { timeoutMs: 15_000 })
+    expect(r.ok).toBe(true)
+    if (r.ok) {
+      const names = r.tools.map((t) => t.name)
+      expect(names).toContain('echo')
+      expect(names).toContain('empty')
+      expect(names).toContain('fail')
+    }
+  }, 20_000)
+
+  it('returns a sanitized error for a bad command (no crash)', async () => {
+    const r = await listMcpTools({ command: 'definitely-not-a-real-binary-xyz', args: [], env: {} }, { timeoutMs: 8_000 })
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(typeof r.error).toBe('string')
+  }, 12_000)
+
+  it('redacts a configured secret value from the error message', async () => {
+    const secret = 'supersecrettoken12345'
+    const r = await listMcpTools(
+      { command: 'definitely-not-a-real-binary-xyz', args: [], env: { TOKEN: secret } },
+      { timeoutMs: 8_000 }
+    )
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.error).not.toContain(secret)
   }, 12_000)
 })

--- a/src/main/context/mcp-client.ts
+++ b/src/main/context/mcp-client.ts
@@ -176,16 +176,19 @@ export function sanitizeMcpText(message: string, env: Record<string, string>): s
   return out.length > 300 ? `${out.slice(0, 299)}…` : out
 }
 
-/** Recursively scrubs configured secret values from every string leaf of a JSON
- * value (e.g. a tool inputSchema, whose description/default/examples are
- * server-controlled). Depth-capped so a pathological schema can't blow the stack. */
+/** Recursively scrubs configured secret values from every string leaf AND object
+ * KEY of a JSON value (e.g. a tool inputSchema, whose property names, description,
+ * default, examples are all server-controlled). Depth-capped so a pathological
+ * schema can't blow the stack. */
 export function sanitizeMcpJson(value: unknown, env: Record<string, string>, depth = 0): unknown {
   if (depth > 24) return undefined
   if (typeof value === 'string') return sanitizeMcpText(value, env)
   if (Array.isArray(value)) return value.map((v) => sanitizeMcpJson(v, env, depth + 1))
   if (value !== null && typeof value === 'object') {
     const out: Record<string, unknown> = {}
-    for (const [k, v] of Object.entries(value as Record<string, unknown>)) out[k] = sanitizeMcpJson(v, env, depth + 1)
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      out[sanitizeMcpText(k, env)] = sanitizeMcpJson(v, env, depth + 1)
+    }
     return out
   }
   return value

--- a/src/main/context/mcp-client.ts
+++ b/src/main/context/mcp-client.ts
@@ -1,6 +1,6 @@
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
-import type { McpStdioConfig } from '../../shared/ipc-channels'
+import type { McpStdioConfig, McpToolInfo, McpToolsResult } from '../../shared/ipc-channels'
 
 /**
  * The app-owned MCP read (two-stage resolver, stage three: RUN). After the
@@ -151,5 +151,96 @@ export function createMcpRunner(options: McpRunnerOptions = {}): McpRunner {
         }
       }
     },
+  }
+}
+
+/**
+ * Best-effort scrub of any configured secret VALUE from an MCP-server-controlled
+ * string (a startup error, a tool description) before it crosses to the renderer,
+ * plus a length cap. This is defense-in-depth, not a hard boundary: it can't
+ * catch a secret the server transforms/encodes.
+ *
+ * Trust model: the hard guarantee is that STORED config secret values are never
+ * sent to the renderer via the config surfaces (see McpServerSummary). A wired
+ * server's runtime OUTPUT (live values, tool metadata) is the user's own tool
+ * answering the user — surfaced by design. `liveValue` is intentionally NOT
+ * scrubbed (it is the feature); diagnostic/metadata strings get this scrub as
+ * hygiene. command/args are not secrets per the config contract.
+ */
+export function sanitizeMcpText(message: string, env: Record<string, string>): string {
+  let out = message
+  for (const value of Object.values(env)) {
+    // Only redact non-trivial values to avoid mangling the message on short envs.
+    if (value.length >= 4) out = out.split(value).join('[redacted]')
+  }
+  return out.length > 300 ? `${out.slice(0, 299)}…` : out
+}
+
+/** Recursively scrubs configured secret values from every string leaf of a JSON
+ * value (e.g. a tool inputSchema, whose description/default/examples are
+ * server-controlled). Depth-capped so a pathological schema can't blow the stack. */
+export function sanitizeMcpJson(value: unknown, env: Record<string, string>, depth = 0): unknown {
+  if (depth > 24) return undefined
+  if (typeof value === 'string') return sanitizeMcpText(value, env)
+  if (Array.isArray(value)) return value.map((v) => sanitizeMcpJson(v, env, depth + 1))
+  if (value !== null && typeof value === 'object') {
+    const out: Record<string, unknown> = {}
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) out[k] = sanitizeMcpJson(v, env, depth + 1)
+    return out
+  }
+  return value
+}
+
+/**
+ * Honest connection probe: starts the (user/app-approved) stdio server and lists
+ * its tools. A success proves the server process starts and answers a listTools
+ * handshake — NOT that a real read (or its auth) will succeed. No tool is run.
+ */
+export async function listMcpTools(
+  server: McpStdioConfig,
+  options: McpRunnerOptions = {}
+): Promise<McpToolsResult> {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_MCP_TIMEOUT_MS
+  const env: Record<string, string> = {}
+  if (typeof process.env.PATH === 'string') env.PATH = process.env.PATH
+  for (const [k, v] of Object.entries(server.env)) env[k] = v
+
+  const transport = new StdioClientTransport({ command: server.command, args: server.args, env })
+  const client = new Client({ name: 'gh-projects-resolver', version: '1.0.0' }, { capabilities: {} })
+
+  try {
+    return await withTimeout<McpToolsResult>(
+      (async (): Promise<McpToolsResult> => {
+        await client.connect(transport)
+        const res = (await client.listTools()) as { tools?: unknown }
+        const list = Array.isArray(res.tools) ? res.tools : []
+        const tools: McpToolInfo[] = list.map((t): McpToolInfo => {
+          const tool = t as { name?: unknown; description?: unknown; inputSchema?: unknown }
+          return {
+            name: typeof tool.name === 'string' ? tool.name : '',
+            // Scrub configured secrets from the server-controlled description.
+            description: typeof tool.description === 'string' ? sanitizeMcpText(tool.description, server.env) : undefined,
+            inputSchema: tool.inputSchema !== undefined ? sanitizeMcpJson(tool.inputSchema, server.env) : undefined,
+          }
+        })
+        return { ok: true, tools: tools.filter((t) => t.name.length > 0) }
+      })(),
+      timeoutMs,
+      (): McpToolsResult => ({ ok: false, error: `Timed out after ${timeoutMs}ms` })
+    )
+  } catch (err) {
+    const raw = err instanceof Error ? err.message : String(err)
+    return { ok: false, error: sanitizeMcpText(raw, server.env) }
+  } finally {
+    try {
+      await client.close()
+    } catch {
+      /* best-effort */
+    }
+    try {
+      await transport.close()
+    } catch {
+      /* best-effort */
+    }
   }
 }

--- a/src/main/context/mcp-config.test.ts
+++ b/src/main/context/mcp-config.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { validateMcpServerInput, newMcpServerId } from './mcp-config'
+import { validateMcpServerInput, validateMcpServerPatch, validateToolName, validateToolArgs, newMcpServerId } from './mcp-config'
 
 describe('validateMcpServerInput', () => {
   it('accepts a well-formed config and normalizes it', () => {
@@ -48,5 +48,112 @@ describe('validateMcpServerInput', () => {
   it('mints unique ids', () => {
     expect(newMcpServerId()).not.toBe(newMcpServerId())
     expect(newMcpServerId().startsWith('mcp-')).toBe(true)
+  })
+})
+
+describe('validateMcpServerPatch', () => {
+  it('normalizes label/command/args when present', () => {
+    const r = validateMcpServerPatch({ label: '  L  ', command: '  c  ', args: ['a'] })
+    expect(r.ok).toBe(true)
+    if (r.ok) expect(r.value).toMatchObject({ label: 'L', command: 'c', args: ['a'], envSet: {}, envDelete: [] })
+  })
+
+  it('leaves omitted fields undefined (preserve on merge)', () => {
+    const r = validateMcpServerPatch({})
+    expect(r.ok).toBe(true)
+    if (r.ok) {
+      expect(r.value.label).toBeUndefined()
+      expect(r.value.command).toBeUndefined()
+      expect(r.value.args).toBeUndefined()
+      expect(r.value.envSet).toEqual({})
+      expect(r.value.envDelete).toEqual([])
+    }
+  })
+
+  it('rejects empty label/command when explicitly provided', () => {
+    expect(validateMcpServerPatch({ label: '  ' }).ok).toBe(false)
+    expect(validateMcpServerPatch({ command: '' }).ok).toBe(false)
+  })
+
+  it('rejects a key present in both envSet and envDelete', () => {
+    const r = validateMcpServerPatch({ envSet: { A: '1' }, envDelete: ['A'] })
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.error).toMatch(/both envSet and envDelete/)
+  })
+
+  it('rejects invalid env keys and non-string values', () => {
+    expect(validateMcpServerPatch({ envSet: { 'A=B': 'x' } }).ok).toBe(false)
+    expect(validateMcpServerPatch({ envSet: { '': 'x' } }).ok).toBe(false)
+    expect(validateMcpServerPatch({ envSet: { A: 2 as unknown as string } }).ok).toBe(false)
+  })
+
+  it('keeps an empty-string value distinct from a delete', () => {
+    const r = validateMcpServerPatch({ envSet: { A: '' }, envDelete: ['B'] })
+    expect(r.ok).toBe(true)
+    if (r.ok) {
+      expect(r.value.envSet).toEqual({ A: '' })
+      expect(r.value.envDelete).toEqual(['B'])
+    }
+  })
+})
+
+describe('validateToolName', () => {
+  it('accepts + trims a non-empty name', () => {
+    const r = validateToolName('  query  ')
+    expect(r.ok).toBe(true)
+    if (r.ok) expect(r.value).toBe('query')
+  })
+  it('rejects empty/non-string', () => {
+    expect(validateToolName('   ').ok).toBe(false)
+    expect(validateToolName(5).ok).toBe(false)
+    expect(validateToolName(null).ok).toBe(false)
+  })
+})
+
+describe('validateToolArgs', () => {
+  it('accepts a plain JSON object', () => {
+    const r = validateToolArgs({ metric: 'p99', tags: ['a'] })
+    expect(r.ok).toBe(true)
+    if (r.ok) expect(r.value).toEqual({ metric: 'p99', tags: ['a'] })
+  })
+  it('rejects arrays, null, and primitives', () => {
+    expect(validateToolArgs([]).ok).toBe(false)
+    expect(validateToolArgs(null).ok).toBe(false)
+    expect(validateToolArgs('x').ok).toBe(false)
+  })
+  it('rejects non-JSON-serializable values (BigInt)', () => {
+    expect(validateToolArgs({ n: 1n as unknown }).ok).toBe(false)
+  })
+  it('rejects oversized args', () => {
+    expect(validateToolArgs({ blob: 'x'.repeat(20_000) }).ok).toBe(false)
+  })
+})
+
+describe('validateMcpServerInput env-key validation', () => {
+  it('rejects an env key containing = or NUL', () => {
+    expect(validateMcpServerInput('X', { command: 'x', env: { 'A=B': 'v' } }).ok).toBe(false)
+    expect(validateMcpServerInput('X', { command: 'x', env: { 'A\u0000': 'v' } }).ok).toBe(false)
+  })
+  it('still accepts normal env keys', () => {
+    expect(validateMcpServerInput('X', { command: 'x', env: { DD_API_KEY: 'v' } }).ok).toBe(true)
+  })
+})
+
+describe('validateToolArgs strictness', () => {
+  it('rejects a class instance / Date at the top level', () => {
+    expect(validateToolArgs(new Date()).ok).toBe(false)
+  })
+  it('rejects a nested function or undefined (no silent drop)', () => {
+    expect(validateToolArgs({ fn: () => 1 } as unknown).ok).toBe(false)
+    expect(validateToolArgs({ u: undefined }).ok).toBe(false)
+  })
+  it('accepts nested plain JSON', () => {
+    const r = validateToolArgs({ a: { b: [1, 'x', true, null] } })
+    expect(r.ok).toBe(true)
+  })
+  it('rejects a cyclic object without stack-overflowing', () => {
+    const cyclic: Record<string, unknown> = {}
+    cyclic.self = cyclic
+    expect(validateToolArgs(cyclic).ok).toBe(false)
   })
 })

--- a/src/main/context/mcp-config.ts
+++ b/src/main/context/mcp-config.ts
@@ -108,6 +108,9 @@ export function validateMcpServerPatch(patch: McpServerPatch): McpPatchValidatio
     if (!Array.isArray(patch.envDelete) || !patch.envDelete.every((k): k is string => typeof k === 'string')) {
       return { ok: false, error: 'envDelete must be an array of strings' }
     }
+    for (const key of patch.envDelete) {
+      if (!isValidEnvKey(key)) return { ok: false, error: `Invalid env key: ${JSON.stringify(key)}` }
+    }
     out.envDelete = patch.envDelete
   }
 

--- a/src/main/context/mcp-config.ts
+++ b/src/main/context/mcp-config.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'crypto'
-import type { McpServerInput, McpStdioConfig } from '../../shared/ipc-channels'
+import type { McpServerInput, McpServerPatch, McpStdioConfig } from '../../shared/ipc-channels'
 
 /**
  * Per-project MCP config helpers. The stored config feeds the APP-OWNED MCP
@@ -44,8 +44,140 @@ export function validateMcpServerInput(label: unknown, config: unknown): McpConf
     env = Object.fromEntries(
       Object.entries(c.env as Record<string, unknown>).filter((e): e is [string, string] => typeof e[1] === 'string')
     )
+    // Validate keys (consistency with the edit-patch path): a bad env key would
+    // corrupt the child's environment.
+    for (const key of Object.keys(env)) {
+      if (!isValidEnvKey(key)) return { ok: false, error: `Invalid env key: ${JSON.stringify(key)}` }
+    }
   }
 
   const normalized: McpStdioConfig = { command, args, env }
   return { ok: true, value: { label: trimmedLabel, config: normalized } }
+}
+
+// ── Edit-patch + wiring validation (all main-owned; the renderer is decoration) ──
+
+/** An env var key is a non-empty string with no `=` or NUL (would corrupt the env). */
+function isValidEnvKey(key: string): boolean {
+  return key.length > 0 && !key.includes('=') && !key.includes('\0')
+}
+
+export type McpPatchValidation =
+  | { ok: true; value: { label?: string; command?: string; args?: string[]; envSet: Record<string, string>; envDelete: string[] } }
+  | { ok: false; error: string }
+
+/**
+ * Validates + normalizes an MCP server edit patch. Env is one-way: `envSet`
+ * adds/replaces, `envDelete` removes; a key can't appear in both. Omitted env
+ * keys are preserved by the caller (the renderer never sees or re-sends secrets).
+ */
+export function validateMcpServerPatch(patch: McpServerPatch): McpPatchValidation {
+  const out: { label?: string; command?: string; args?: string[]; envSet: Record<string, string>; envDelete: string[] } = {
+    envSet: {},
+    envDelete: [],
+  }
+
+  if (patch.label !== undefined) {
+    const label = patch.label.trim()
+    if (label.length === 0) return { ok: false, error: 'MCP server needs a label' }
+    out.label = label
+  }
+  if (patch.command !== undefined) {
+    const command = patch.command.trim()
+    if (command.length === 0) return { ok: false, error: 'MCP config needs a command' }
+    out.command = command
+  }
+  if (patch.args !== undefined) {
+    if (!Array.isArray(patch.args) || !patch.args.every((a): a is string => typeof a === 'string')) {
+      return { ok: false, error: 'MCP args must be an array of strings' }
+    }
+    out.args = patch.args
+  }
+
+  if (patch.envSet !== undefined) {
+    if (patch.envSet === null || typeof patch.envSet !== 'object' || Array.isArray(patch.envSet)) {
+      return { ok: false, error: 'envSet must be an object of strings' }
+    }
+    for (const [k, v] of Object.entries(patch.envSet)) {
+      if (!isValidEnvKey(k)) return { ok: false, error: `Invalid env key: ${JSON.stringify(k)}` }
+      if (typeof v !== 'string') return { ok: false, error: `env value for ${k} must be a string` }
+      out.envSet[k] = v
+    }
+  }
+  if (patch.envDelete !== undefined) {
+    if (!Array.isArray(patch.envDelete) || !patch.envDelete.every((k): k is string => typeof k === 'string')) {
+      return { ok: false, error: 'envDelete must be an array of strings' }
+    }
+    out.envDelete = patch.envDelete
+  }
+
+  // A key in both is ambiguous (set-then-delete) — reject rather than guess.
+  const setKeys = new Set(Object.keys(out.envSet))
+  const overlap = out.envDelete.filter((k) => setKeys.has(k))
+  if (overlap.length > 0) {
+    return { ok: false, error: `env keys in both envSet and envDelete: ${overlap.join(', ')}` }
+  }
+
+  return { ok: true, value: out }
+}
+
+/** Validates a tool name for wiring: a non-empty trimmed string. */
+export function validateToolName(name: unknown): { ok: true; value: string } | { ok: false; error: string } {
+  const trimmed = typeof name === 'string' ? name.trim() : ''
+  if (trimmed.length === 0) return { ok: false, error: 'A tool name is required' }
+  return { ok: true, value: trimmed }
+}
+
+const MAX_TOOL_ARGS_BYTES = 16_384
+
+/** True for a value that is faithfully representable as JSON (no data loss). */
+function isJsonValue(v: unknown, seen: WeakSet<object> = new WeakSet()): boolean {
+  if (v === null) return true
+  const t = typeof v
+  if (t === 'string' || t === 'boolean') return true
+  if (t === 'number') return Number.isFinite(v)
+  if (t === 'object') {
+    // Reject cycles (reachable via a direct IPC structured-clone payload) before
+    // recursing, so validation can't stack-overflow.
+    if (seen.has(v as object)) return false
+    seen.add(v as object)
+    if (Array.isArray(v)) return v.every((x) => isJsonValue(x, seen))
+    // Reject class instances / Date / Map etc. — only plain objects are allowed.
+    const proto = Object.getPrototypeOf(v)
+    if (proto !== Object.prototype && proto !== null) return false
+    return Object.values(v as Record<string, unknown>).every((x) => isJsonValue(x, seen))
+  }
+  // function / undefined / symbol / bigint
+  return false
+}
+
+/**
+ * Validates tool args: a PLAIN JSON object with only JSON-representable values,
+ * within a size cap. Rejects (rather than silently drops) functions, undefined,
+ * BigInt, class instances, and cycles, so a malformed IPC payload can't persist
+ * mangled args or crash the read.
+ */
+export function validateToolArgs(
+  args: unknown
+): { ok: true; value: Record<string, unknown> } | { ok: false; error: string } {
+  if (args === null || typeof args !== 'object' || Array.isArray(args)) {
+    return { ok: false, error: 'Tool args must be a JSON object' }
+  }
+  const proto = Object.getPrototypeOf(args)
+  if (proto !== Object.prototype && proto !== null) {
+    return { ok: false, error: 'Tool args must be a plain JSON object' }
+  }
+  if (!isJsonValue(args)) {
+    return { ok: false, error: 'Tool args must contain only JSON values' }
+  }
+  let serialized: string
+  try {
+    serialized = JSON.stringify(args)
+  } catch {
+    return { ok: false, error: 'Tool args must be JSON-serializable' }
+  }
+  if (serialized.length > MAX_TOOL_ARGS_BYTES) {
+    return { ok: false, error: 'Tool args are too large' }
+  }
+  return { ok: true, value: args as Record<string, unknown> }
 }

--- a/src/main/context/registry.integration.test.ts
+++ b/src/main/context/registry.integration.test.ts
@@ -23,9 +23,14 @@ import {
   getProjectCard,
   upsertProjectCard,
   listMcpServers,
+  listMcpServerSummaries,
   getMcpServer,
   upsertMcpServer,
+  updateMcpServer,
   deleteMcpServer,
+  restoreMcpServer,
+  connectResourceToServer,
+  disconnectResource,
 } from './registry'
 
 // ── Setup ─────────────────────────────────────────────────────────────────────
@@ -307,7 +312,7 @@ describe('MCP servers', () => {
     expect(getMcpServer('dd-1')).toBeNull()
   })
 
-  it('deleting a server clears referencing resources and is project-scoped', () => {
+  it('soft-deletes (preserving resource links), is project-scoped, and restores losslessly', () => {
     const a = seedProject('A')
     const b = seedProject('B')
     upsertMcpServer(a, 'srv', { label: 'S', config: { command: 'x', args: [], env: {} } })
@@ -317,10 +322,17 @@ describe('MCP servers', () => {
     deleteMcpServer(b, 'srv')
     expect(getMcpServer('srv')).not.toBeNull()
 
-    // Correct project: server gone AND the resource's dangling reference cleared.
+    // Correct project: the server reads as gone (so resolves degrade to no live
+    // value), but the resource link is PRESERVED so the delete is undoable.
     deleteMcpServer(a, 'srv')
     expect(getMcpServer('srv')).toBeNull()
-    expect(getResource(r.id)?.mcpServer).toBeNull()
+    expect(listMcpServers(a)).toHaveLength(0)
+    expect(getResource(r.id)?.mcpServer).toBe('srv')
+
+    // Restore brings the server back with the link intact — lossless undo.
+    restoreMcpServer(a, 'srv')
+    expect(getMcpServer('srv')).not.toBeNull()
+    expect(getResource(r.id)?.mcpServer).toBe('srv')
   })
 
   it('rejects a cross-project upsert of an existing server id', () => {
@@ -330,6 +342,73 @@ describe('MCP servers', () => {
     expect(() => upsertMcpServer(b, 'shared-id', { label: 'B', config: { command: 'y', args: [], env: {} } })).toThrow(
       /another project/
     )
+  })
+})
+
+describe('MCP server summaries + patch merge + wiring', () => {
+  it('summaries redact env values but keep the key names', () => {
+    const pid = seedProject()
+    upsertMcpServer(pid, 's', {
+      label: 'S',
+      config: { command: 'dd', args: ['--stdio'], env: { DD_KEY: 'secret', DD_APP: 'secret2' } },
+    })
+    const [summary] = listMcpServerSummaries(pid)
+    expect(summary).toMatchObject({ id: 's', label: 'S', command: 'dd', args: ['--stdio'] })
+    expect(summary.envKeys.sort()).toEqual(['DD_APP', 'DD_KEY'])
+    // The serialized summary must not contain any secret value.
+    expect(JSON.stringify(summary)).not.toContain('secret')
+  })
+
+  it('updateMcpServer merges env one-way (set/replace, delete, preserve)', () => {
+    const pid = seedProject()
+    upsertMcpServer(pid, 's', {
+      label: 'S',
+      config: { command: 'c', args: [], env: { KEEP: 'k', REPLACE: 'old', DROP: 'd' } },
+    })
+    updateMcpServer(pid, 's', {
+      label: 'S2',
+      envSet: { REPLACE: 'new', ADDED: 'a' },
+      envDelete: ['DROP'],
+    })
+    const server = getMcpServer('s')
+    expect(server?.label).toBe('S2')
+    expect(server?.config.env).toEqual({ KEEP: 'k', REPLACE: 'new', ADDED: 'a' })
+  })
+
+  it('updateMcpServer preserves command/args when omitted', () => {
+    const pid = seedProject()
+    upsertMcpServer(pid, 's', { label: 'S', config: { command: 'c', args: ['--x'], env: {} } })
+    updateMcpServer(pid, 's', { label: 'S2', envSet: {}, envDelete: [] })
+    const server = getMcpServer('s')
+    expect(server?.config.command).toBe('c')
+    expect(server?.config.args).toEqual(['--x'])
+  })
+
+  it('connectResourceToServer wires a resource and rejects a cross-project server', () => {
+    const a = seedProject('A')
+    const b = seedProject('B')
+    upsertMcpServer(a, 'srv-a', { label: 'A', config: { command: 'x', args: [], env: {} } })
+    upsertMcpServer(b, 'srv-b', { label: 'B', config: { command: 'x', args: [], env: {} } })
+    const r = createResource(a, { title: 'Checkout' })
+
+    const wired = connectResourceToServer(r.id, 'srv-a', 'query', { metric: 'p99' })
+    expect(wired.mcpServer).toBe('srv-a')
+    expect(wired.toolName).toBe('query')
+    expect(wired.toolArgs).toEqual({ metric: 'p99' })
+
+    expect(() => connectResourceToServer(r.id, 'srv-b', 'query', {})).toThrow(/another project/)
+    expect(() => connectResourceToServer(r.id, 'missing', 'query', {})).toThrow(/not found/)
+  })
+
+  it('disconnectResource clears the wiring', () => {
+    const pid = seedProject()
+    upsertMcpServer(pid, 'srv', { label: 'S', config: { command: 'x', args: [], env: {} } })
+    const r = createResource(pid, { title: 'Checkout' })
+    connectResourceToServer(r.id, 'srv', 'query', {})
+    const cleared = disconnectResource(r.id)
+    expect(cleared.mcpServer).toBeNull()
+    expect(cleared.toolName).toBeNull()
+    expect(cleared.toolArgs).toBeNull()
   })
 })
 

--- a/src/main/context/registry.ts
+++ b/src/main/context/registry.ts
@@ -610,7 +610,7 @@ export function updateMcpServer(
 export function deleteMcpServer(projectId: number, id: string): void {
   getDb()
     .prepare(
-      "UPDATE project_mcp_servers SET deleted_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now') WHERE id = ? AND project_id = ? AND deleted_at IS NULL"
+      "UPDATE project_mcp_servers SET deleted_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now'), updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now') WHERE id = ? AND project_id = ? AND deleted_at IS NULL"
     )
     .run(id, projectId)
 }
@@ -618,7 +618,9 @@ export function deleteMcpServer(projectId: number, id: string): void {
 /** Restores a soft-deleted MCP server (undo). Resource links were preserved. */
 export function restoreMcpServer(projectId: number, id: string): void {
   getDb()
-    .prepare('UPDATE project_mcp_servers SET deleted_at = NULL WHERE id = ? AND project_id = ?')
+    .prepare(
+      "UPDATE project_mcp_servers SET deleted_at = NULL, updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now') WHERE id = ? AND project_id = ?"
+    )
     .run(id, projectId)
 }
 

--- a/src/main/context/registry.ts
+++ b/src/main/context/registry.ts
@@ -1,6 +1,7 @@
 import type {
   McpServerConfig,
   McpServerInput,
+  McpServerSummary,
   McpStdioConfig,
   ProjectCard,
   ProjectCardPatch,
@@ -65,6 +66,7 @@ interface McpServerRow {
   config_json: string
   created_at: string
   updated_at: string
+  deleted_at: string | null
 }
 
 // ── JSON helpers (defensive: a malformed column never crashes a read) ──────────
@@ -202,6 +204,25 @@ export function toMcpServer(row: McpServerRow): McpServerConfig {
     projectId: row.project_id,
     label: row.label,
     config: parseStdioConfig(row.config_json),
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  }
+}
+
+/**
+ * Redacted view for the RENDERER: env VALUES are stripped, only key names remain.
+ * This is the only MCP-server shape that should ever cross an IPC result to the
+ * renderer. The full config (with secrets) never leaves the main process.
+ */
+export function toMcpServerSummary(row: McpServerRow): McpServerSummary {
+  const config = parseStdioConfig(row.config_json)
+  return {
+    id: row.id,
+    projectId: row.project_id,
+    label: row.label,
+    command: config.command,
+    args: config.args,
+    envKeys: Object.keys(config.env),
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   }
@@ -467,19 +488,50 @@ export function upsertProjectCard(projectId: number, patch: ProjectCardPatch): P
   return toProjectCard(row)
 }
 
+/** Redacts a full config into a renderer-safe summary (drops env values). */
+export function mcpConfigToSummary(server: McpServerConfig): McpServerSummary {
+  return {
+    id: server.id,
+    projectId: server.projectId,
+    label: server.label,
+    command: server.config.command,
+    args: server.config.args,
+    envKeys: Object.keys(server.config.env),
+    createdAt: server.createdAt,
+    updatedAt: server.updatedAt,
+  }
+}
+
 // ── Per-project MCP servers ───────────────────────────────────────────────────
 
+/** Full (secret-bearing) configs for LIVE (non-deleted) servers. Main-only. */
 export function listMcpServers(projectId: number): McpServerConfig[] {
   const rows = getDb()
-    .prepare('SELECT * FROM project_mcp_servers WHERE project_id = ? ORDER BY created_at ASC, id ASC')
+    .prepare(
+      'SELECT * FROM project_mcp_servers WHERE project_id = ? AND deleted_at IS NULL ORDER BY created_at ASC, id ASC'
+    )
     .all(projectId) as McpServerRow[]
   return rows.map(toMcpServer)
 }
 
-/** Returns a single MCP server config by id, or null. */
+/** REDACTED summaries for the renderer (no secret values). Live servers only. */
+export function listMcpServerSummaries(projectId: number): McpServerSummary[] {
+  const rows = getDb()
+    .prepare(
+      'SELECT * FROM project_mcp_servers WHERE project_id = ? AND deleted_at IS NULL ORDER BY created_at ASC, id ASC'
+    )
+    .all(projectId) as McpServerRow[]
+  return rows.map(toMcpServerSummary)
+}
+
+/**
+ * Returns a single LIVE MCP server config by id, or null. A soft-deleted server
+ * reads as null so the resolver treats a deleted connection as "no live value"
+ * (never an outage) and re-wiring/undo is clean.
+ */
 export function getMcpServer(id: string): McpServerConfig | null {
   const row = getDb()
-    .prepare('SELECT * FROM project_mcp_servers WHERE id = ?')
+    .prepare('SELECT * FROM project_mcp_servers WHERE id = ? AND deleted_at IS NULL')
     .get(id) as McpServerRow | undefined
   return row ? toMcpServer(row) : null
 }
@@ -512,17 +564,88 @@ export function upsertMcpServer(projectId: number, id: string, input: McpServerI
 }
 
 /**
- * Deletes a wired MCP server, scoped to its project (fail-closed boundary), and
- * clears any resources in that project that referenced it so resolves don't fail
- * as connector_down after an intentional delete.
+ * Applies an explicit edit patch to a LIVE server, merging env one-way: keys in
+ * `envSet` are added/replaced, keys in `envDelete` are removed, and any other
+ * existing env key is preserved. The renderer never has to hold or re-send a
+ * stored secret to keep it. Returns the full (main-only) updated config.
+ */
+export function updateMcpServer(
+  projectId: number,
+  id: string,
+  patch: { label?: string; command?: string; args?: string[]; envSet: Record<string, string>; envDelete: string[] }
+): McpServerConfig {
+  const db = getDb()
+  const current = db
+    .prepare('SELECT * FROM project_mcp_servers WHERE id = ? AND project_id = ? AND deleted_at IS NULL')
+    .get(id, projectId) as McpServerRow | undefined
+  if (!current) throw new Error('MCP server not found')
+
+  const existing = parseStdioConfig(current.config_json)
+  const env: Record<string, string> = { ...existing.env }
+  for (const key of patch.envDelete) delete env[key]
+  for (const [k, v] of Object.entries(patch.envSet)) env[k] = v
+
+  const merged: McpStdioConfig = {
+    command: patch.command ?? existing.command,
+    args: patch.args ?? existing.args,
+    env,
+  }
+  const row = db
+    .prepare(
+      `UPDATE project_mcp_servers SET
+         label = ?, config_json = ?, updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+       WHERE id = ? AND project_id = ? AND deleted_at IS NULL
+       RETURNING *`
+    )
+    .get(patch.label ?? current.label, JSON.stringify(merged), id, projectId) as McpServerRow
+  return toMcpServer(row)
+}
+
+/**
+ * Soft-deletes a wired MCP server, scoped to its project (fail-closed boundary).
+ * Resource links are PRESERVED (never nulled) so the delete is losslessly
+ * undoable; a resource pointing at a soft-deleted server simply resolves as
+ * "no live value" until the server is restored.
  */
 export function deleteMcpServer(projectId: number, id: string): void {
-  const db = getDb()
-  const run = db.transaction(() => {
-    db.prepare(
-      "UPDATE resources SET mcp_server = NULL, updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now') WHERE project_id = ? AND mcp_server = ?"
-    ).run(projectId, id)
-    db.prepare('DELETE FROM project_mcp_servers WHERE id = ? AND project_id = ?').run(id, projectId)
-  })
-  run()
+  getDb()
+    .prepare(
+      "UPDATE project_mcp_servers SET deleted_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now') WHERE id = ? AND project_id = ? AND deleted_at IS NULL"
+    )
+    .run(id, projectId)
+}
+
+/** Restores a soft-deleted MCP server (undo). Resource links were preserved. */
+export function restoreMcpServer(projectId: number, id: string): void {
+  getDb()
+    .prepare('UPDATE project_mcp_servers SET deleted_at = NULL WHERE id = ? AND project_id = ?')
+    .run(id, projectId)
+}
+
+/**
+ * Wires a resource to a configured server tool so a resolve can pull a live
+ * value. Validates the whole graph in main: the resource must exist, the server
+ * must exist + be live + belong to the SAME project as the resource.
+ */
+export function connectResourceToServer(
+  resourceId: number,
+  serverId: string,
+  toolName: string,
+  toolArgs: Record<string, unknown>
+): Resource {
+  const resource = getResource(resourceId)
+  if (!resource) throw new Error(`Resource not found: ${resourceId}`)
+  const server = getMcpServer(serverId)
+  if (!server) throw new Error('MCP server not found')
+  if (server.projectId !== resource.projectId) {
+    throw new Error('MCP server belongs to another project')
+  }
+  return updateResource(resourceId, { mcpServer: serverId, toolName, toolArgs })
+}
+
+/** Clears a resource's live wiring (mcpServer/toolName/toolArgs). */
+export function disconnectResource(resourceId: number): Resource {
+  const resource = getResource(resourceId)
+  if (!resource) throw new Error(`Resource not found: ${resourceId}`)
+  return updateResource(resourceId, { mcpServer: null, toolName: null, toolArgs: null })
 }

--- a/src/main/context/resolve.integration.test.ts
+++ b/src/main/context/resolve.integration.test.ts
@@ -230,10 +230,13 @@ describe('resolveQuestion', () => {
       'checkout latency',
       deps(decideRunnerReturning('{"verdict":"confident","citedCandidateId":"c1"}'), mcpNeverCalled)
     )
-    // Boundary violation is treated as a config/infra issue, not a live value.
+    // Boundary violation: no live value, and (per the failureClass fix) this is a
+    // config/boundary state, not an infra outage — so failureClass is null. The
+    // security guarantee (the cross-project server is never run) holds because
+    // mcpNeverCalled would throw if invoked.
     expect(res.verdict).toBe('source_available_no_live_value')
     expect(res.liveValue).toBeNull()
-    expect(res.failureClass).toBe('connector_down')
+    expect(res.failureClass).toBeNull()
   })
 
   it('treats an empty/whitespace mcpServer or toolName as no live source', async () => {

--- a/src/main/context/resolve.ts
+++ b/src/main/context/resolve.ts
@@ -3,7 +3,7 @@ import { assemble, type AssembleOptions, type AssembledCandidate } from './assem
 import { buildDecidePrompt } from './prompt'
 import { parseAndValidateDecision } from './verdict-contract'
 import type { DecideRunner } from './copilot-run'
-import type { McpRunner } from './mcp-client'
+import { sanitizeMcpText, type McpRunner } from './mcp-client'
 import {
   getProjectCard,
   listResources,
@@ -241,8 +241,9 @@ async function runCitedSource(
 
   const server = getMcpServer(mcpServerId)
   if (server === null || server.projectId !== projectId) {
-    // The wiring is gone or points outside this project (config/boundary issue),
-    // not the source itself — do NOT mark suspect.
+    // The wiring is gone/soft-deleted or points outside this project — a
+    // config/boundary state, NOT an infra outage. So failureClass is null (not
+    // connector_down) and the source is not marked suspect.
     markResourceUsed(resource.id, false)
     const result: ResolveResult = {
       verdict: 'source_available_no_live_value',
@@ -251,7 +252,7 @@ async function runCitedSource(
       liveValue: null,
       clarifyQuestion: null,
       candidates: [],
-      failureClass: 'connector_down',
+      failureClass: null,
       retrievalMode,
     }
     recordResolution({
@@ -261,7 +262,7 @@ async function runCitedSource(
       verdict: 'source_available_no_live_value',
       citedResourceId: resource.id,
       answer: result.answer,
-      failureClass: 'connector_down',
+      failureClass: null,
     })
     return result
   }
@@ -294,9 +295,12 @@ async function runCitedSource(
 
   // The read failed. Classify bad-source vs bad-infra.
   const failure = read.failure ?? 'connector_down'
+  // Scrub any configured secret the server may have echoed into the reason before
+  // it's persisted to last_error_message and shown in the suspect tooltip.
+  const reason = read.reason !== null ? sanitizeMcpText(read.reason, server.config.env) : null
   if (failure === 'query_invalid' || failure === 'no_data') {
     // The SOURCE itself is bad -> mark suspect + down-rank going forward.
-    markResourceSuspect(resource.id, failure === 'no_data' ? 'no_data' : 'invalid', failure, read.reason)
+    markResourceSuspect(resource.id, failure === 'no_data' ? 'no_data' : 'invalid', failure, reason)
   }
   // Infra failures (auth_missing/connector_down/timeout) do NOT mark the source suspect.
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -32,14 +32,16 @@ import { getDb } from './db'
 import {
   listResources, createResource, updateResource, deleteResource, restoreResource,
   getProjectCard, upsertProjectCard,
-  listMcpServers, upsertMcpServer, deleteMcpServer,
+  listMcpServerSummaries, upsertMcpServer, updateMcpServer, deleteMcpServer, restoreMcpServer,
+  getMcpServer, mcpConfigToSummary, connectResourceToServer, disconnectResource,
 } from './context/registry'
 import { groupResources } from './context/group'
 import { proposeFromUrl } from './context/capture'
-import { validateMcpServerInput, newMcpServerId } from './context/mcp-config'
+import { validateMcpServerInput, validateMcpServerPatch, validateToolName, validateToolArgs, newMcpServerId } from './context/mcp-config'
+import { listMcpTools } from './context/mcp-client'
 import { resolveQuestion } from './context/resolve'
 import { createResolveDeps } from './context/resolve-deps'
-import type { ProjectPatch, ProjectTodoPatch, ProjectLinkPatch, SnoozeMode, SyncIntervalMinutes, MaxSyncDays, CreateRoutingRulePayload, LaunchAgentTaskPayload, ResourceInput, ResourcePatch, ProjectCardPatch, McpServerInput } from '../shared/ipc-channels'
+import type { ProjectPatch, ProjectTodoPatch, ProjectLinkPatch, SnoozeMode, SyncIntervalMinutes, MaxSyncDays, CreateRoutingRulePayload, LaunchAgentTaskPayload, ResourceInput, ResourcePatch, ProjectCardPatch, McpServerInput, McpServerPatch, McpConnectInput } from '../shared/ipc-channels'
 import { SYNC_INTERVAL_OPTIONS, MAX_SYNC_DAYS_OPTIONS } from '../shared/ipc-channels'
 
 /** Broadcasts a push event to all renderer windows. */
@@ -47,6 +49,20 @@ function broadcast(channel: 'notifications:updated' | 'copilot:updated' | 'proje
   BrowserWindow.getAllWindows().forEach((win) => {
     win.webContents.send(channel)
   })
+}
+
+/**
+ * Strips the live-wiring fields from a generic resource create/update payload.
+ * Wiring a resource to an MCP tool must go through the validated
+ * resources:mcp-connect seam (same-project + tool/args checks), never the generic
+ * resource IPC — so the renderer cannot persist unvalidated wiring.
+ */
+function stripMcpWiring<T extends { mcpServer?: unknown; toolName?: unknown; toolArgs?: unknown }>(input: T): T {
+  const clone = { ...input }
+  delete clone.mcpServer
+  delete clone.toolName
+  delete clone.toolArgs
+  return clone
 }
 
 /** Emits projects:updated on a low-frequency tick so drift/cooldown transitions
@@ -336,12 +352,14 @@ app.whenReady().then(async () => {
   ipcMain.handle('resources:groups', (_event, projectId: number) => groupResources(listResources(projectId)))
   ipcMain.handle('resources:capture-proposal', (_event, url: string) => proposeFromUrl(url))
   ipcMain.handle('resources:create', (_event, projectId: number, input: ResourceInput) => {
-    const resource = createResource(projectId, input)
+    // Wiring a resource to a live tool is NOT allowed through the generic create;
+    // it must go through the validated resources:mcp-connect seam.
+    const resource = createResource(projectId, stripMcpWiring(input))
     broadcast('resources:updated')
     return resource
   })
   ipcMain.handle('resources:update', (_event, id: number, patch: ResourcePatch) => {
-    const resource = updateResource(id, patch)
+    const resource = updateResource(id, stripMcpWiring(patch))
     broadcast('resources:updated')
     return resource
   })
@@ -363,17 +381,51 @@ app.whenReady().then(async () => {
   ipcMain.handle('resources:card-upsert', (_event, projectId: number, patch: ProjectCardPatch) =>
     upsertProjectCard(projectId, patch)
   )
-  ipcMain.handle('resources:mcp-list', (_event, projectId: number) => listMcpServers(projectId))
-  ipcMain.handle('resources:mcp-upsert', (_event, projectId: number, id: string | null, input: McpServerInput) => {
+  ipcMain.handle('resources:mcp-list', (_event, projectId: number) => listMcpServerSummaries(projectId))
+  ipcMain.handle('resources:mcp-create', (_event, projectId: number, input: McpServerInput) => {
     const validation = validateMcpServerInput(input.label, input.config)
     if (!validation.ok) throw new Error(validation.error)
-    const server = upsertMcpServer(projectId, id ?? newMcpServerId(), validation.value)
+    const server = upsertMcpServer(projectId, newMcpServerId(), validation.value)
     broadcast('resources:updated')
-    return server
+    return mcpConfigToSummary(server)
+  })
+  ipcMain.handle('resources:mcp-update', (_event, projectId: number, id: string, patch: McpServerPatch) => {
+    const validation = validateMcpServerPatch(patch)
+    if (!validation.ok) throw new Error(validation.error)
+    const server = updateMcpServer(projectId, id, validation.value)
+    broadcast('resources:updated')
+    return mcpConfigToSummary(server)
   })
   ipcMain.handle('resources:mcp-delete', (_event, projectId: number, id: string) => {
     deleteMcpServer(projectId, id)
     broadcast('resources:updated')
+  })
+  ipcMain.handle('resources:mcp-restore', (_event, projectId: number, id: string) => {
+    restoreMcpServer(projectId, id)
+    broadcast('resources:updated')
+  })
+  ipcMain.handle('resources:mcp-list-tools', async (_event, projectId: number, id: string) => {
+    // Scope to the project + only live servers; the full (secret) config never
+    // leaves main — only the discovered tool metadata is returned.
+    const server = getMcpServer(id)
+    if (server === null || server.projectId !== projectId) {
+      return { ok: false, error: 'MCP server not found' }
+    }
+    return listMcpTools(server.config)
+  })
+  ipcMain.handle('resources:mcp-connect', (_event, resourceId: number, input: McpConnectInput) => {
+    const toolName = validateToolName(input.toolName)
+    if (!toolName.ok) throw new Error(toolName.error)
+    const toolArgs = validateToolArgs(input.toolArgs)
+    if (!toolArgs.ok) throw new Error(toolArgs.error)
+    const resource = connectResourceToServer(resourceId, input.serverId, toolName.value, toolArgs.value)
+    broadcast('resources:updated')
+    return resource
+  })
+  ipcMain.handle('resources:mcp-disconnect', (_event, resourceId: number) => {
+    const resource = disconnectResource(resourceId)
+    broadcast('resources:updated')
+    return resource
   })
 
   startNotificationSync()

--- a/src/renderer/src/components/McpTools.module.css
+++ b/src/renderer/src/components/McpTools.module.css
@@ -1,0 +1,385 @@
+.section {
+  margin-top: 14px;
+  border-top: 1px solid var(--border-muted);
+  padding-top: 12px;
+}
+
+.sectionHead {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+
+.sectionTitle {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-3);
+}
+
+.addServer,
+.addEnv {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 12px;
+  color: var(--accent-text);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 2px 4px;
+  border-radius: var(--radius);
+}
+
+.addServer:hover,
+.addEnv:hover {
+  background: var(--bg-subtle);
+}
+
+.sectionEmpty {
+  font-size: 12px;
+  color: var(--text-3);
+  padding: 4px 0 8px;
+  line-height: 1.5;
+}
+
+/* ── Server rows ── */
+.serverRow {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 0;
+  border-bottom: 1px solid var(--border-muted);
+}
+
+.serverInfo {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  min-width: 0;
+  flex: 1;
+}
+
+.serverLabel {
+  font-size: 13px;
+  color: var(--text);
+  font-weight: 500;
+}
+
+.serverCmd {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-3);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.serverEnv {
+  font-size: 11px;
+  color: var(--text-3);
+}
+
+.serverActions {
+  display: flex;
+  gap: 2px;
+}
+
+.iconBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  border: none;
+  background: none;
+  color: var(--text-3);
+  cursor: pointer;
+  border-radius: var(--radius);
+  transition: var(--transition);
+}
+
+.iconBtn:hover {
+  background: var(--bg-subtle);
+  color: var(--text);
+}
+
+.probeOk,
+.probeErr {
+  flex-basis: 100%;
+  font-size: 11px;
+  padding: 2px 0;
+}
+
+.probeOk {
+  color: var(--text-2);
+}
+
+.probeErr {
+  color: var(--danger);
+  font-family: var(--font-mono);
+  word-break: break-word;
+}
+
+.spin {
+  animation: mcpspin 0.8s linear infinite;
+}
+
+@keyframes mcpspin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* ── Forms ── */
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 10px;
+  background: var(--bg-inset);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  margin-bottom: 8px;
+  width: 100%;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.fieldLabel {
+  font-size: 11px;
+  color: var(--text-2);
+  font-weight: 500;
+}
+
+.hint {
+  font-weight: 400;
+  color: var(--text-3);
+}
+
+.input,
+.textarea {
+  background: var(--bg-window);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text);
+  font-size: 13px;
+  padding: 6px 8px;
+  width: 100%;
+  font-family: inherit;
+}
+
+.textarea {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  resize: vertical;
+}
+
+.input:focus,
+.textarea:focus {
+  outline: none;
+  border-color: var(--accent-border);
+}
+
+.envChips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 4px;
+}
+
+.envChip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  background: var(--bg-subtle);
+  border: 1px solid var(--border-muted);
+  border-radius: var(--radius);
+  padding: 2px 4px 2px 7px;
+  color: var(--text-2);
+}
+
+.envSet {
+  color: var(--text-3);
+}
+
+.envRow {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+}
+
+.envKey {
+  composes: input;
+  flex: 1;
+  font-family: var(--font-mono);
+  font-size: 12px;
+}
+
+.envValue {
+  composes: input;
+  flex: 1;
+}
+
+.chipX {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  background: none;
+  color: var(--text-3);
+  cursor: pointer;
+  padding: 2px;
+  border-radius: var(--radius);
+}
+
+.chipX:hover {
+  color: var(--danger);
+}
+
+.error {
+  font-size: 12px;
+  color: var(--danger);
+  background: var(--bg-inset);
+  border: 1px solid var(--danger);
+  border-radius: var(--radius);
+  padding: 6px 8px;
+}
+
+.formActions {
+  display: flex;
+  gap: 8px;
+}
+
+.primary {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  background: var(--accent);
+  color: var(--accent-fg);
+  border: 1px solid var(--accent-border);
+  border-radius: var(--radius);
+  font-size: 13px;
+  font-weight: 500;
+  padding: 6px 12px;
+  cursor: pointer;
+}
+
+.primary:hover {
+  background: var(--accent-hover);
+}
+
+.primary:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.secondary {
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text-2);
+  font-size: 13px;
+  padding: 6px 12px;
+  cursor: pointer;
+}
+
+.secondary:hover {
+  background: var(--bg-subtle);
+}
+
+/* ── Connect dialog ── */
+.dialogBackdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(1, 4, 9, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 40;
+}
+
+.dialog {
+  width: 420px;
+  max-width: calc(100vw - 40px);
+  max-height: calc(100vh - 80px);
+  overflow-y: auto;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  box-shadow: 0 8px 24px rgba(1, 4, 9, 0.5);
+}
+
+.dialogHead {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.dialogTitle {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.dialogResource {
+  font-size: 12px;
+  color: var(--text-2);
+  padding: 6px 8px;
+  background: var(--bg-inset);
+  border-radius: var(--radius);
+}
+
+.discoverRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.linkBtn {
+  background: none;
+  border: none;
+  color: var(--accent-text);
+  font-size: 12px;
+  cursor: pointer;
+  padding: 0;
+}
+
+.linkBtn:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.toolDesc {
+  font-size: 11px;
+  color: var(--text-3);
+  line-height: 1.4;
+}
+
+.schema {
+  font-size: 11px;
+  color: var(--text-3);
+}
+
+.schema pre {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  background: var(--bg-inset);
+  border-radius: var(--radius);
+  padding: 6px;
+  overflow-x: auto;
+  margin: 4px 0 0;
+}

--- a/src/renderer/src/components/McpTools.test.tsx
+++ b/src/renderer/src/components/McpTools.test.tsx
@@ -105,6 +105,28 @@ describe('McpServersSection', () => {
     )
   })
 
+  it('treats re-entering a removed key as a replacement (no overlap conflict)', async () => {
+    invoke.mockResolvedValue(summary())
+    render(<McpServersSection projectId={1} servers={[summary()]} showUndo={vi.fn()} />)
+    fireEvent.click(screen.getByLabelText('Edit server'))
+    fireEvent.click(screen.getByLabelText('Remove DD_API_KEY'))
+    // Re-enter the same key with a new value.
+    fireEvent.click(screen.getByText('Add variable'))
+    fireEvent.change(screen.getByPlaceholderText('DD_API_KEY'), { target: { value: 'DD_API_KEY' } })
+    fireEvent.change(screen.getByPlaceholderText('value'), { target: { value: 'rotated' } })
+    fireEvent.click(screen.getByText('Save'))
+
+    await waitFor(() =>
+      expect(invoke).toHaveBeenCalledWith('resources:mcp-update', 1, 'srv-1', {
+        label: 'Datadog prod',
+        command: 'datadog-mcp',
+        args: ['--stdio'],
+        envSet: { DD_API_KEY: 'rotated' },
+        envDelete: [],
+      })
+    )
+  })
+
   it('deletes with an undo that restores the server', async () => {
     const showUndo = vi.fn()
     invoke.mockResolvedValue(undefined)

--- a/src/renderer/src/components/McpTools.test.tsx
+++ b/src/renderer/src/components/McpTools.test.tsx
@@ -1,0 +1,161 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import type { McpServerSummary, Resource } from '@shared/ipc-channels'
+import { McpServersSection, ConnectResourceDialog } from './McpTools'
+
+const invoke = vi.fn()
+
+beforeEach(() => {
+  invoke.mockReset()
+  ;(globalThis as unknown as { window: Window }).window.electron = {
+    ipc: { invoke },
+  } as unknown as Window['electron']
+})
+
+const summary = (over: Partial<McpServerSummary> = {}): McpServerSummary => ({
+  id: 'srv-1',
+  projectId: 1,
+  label: 'Datadog prod',
+  command: 'datadog-mcp',
+  args: ['--stdio'],
+  envKeys: ['DD_API_KEY'],
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  ...over,
+})
+
+const resource = (over: Partial<Resource> = {}): Resource =>
+  ({
+    id: 7,
+    projectId: 1,
+    title: 'Checkout latency',
+    kind: 'metric_query',
+    source: 'datadog',
+    service: 'checkout',
+    env: 'prod',
+    tags: {},
+    url: null,
+    description: '',
+    aliases: [],
+    provenance: 'manual',
+    confidence: 0.5,
+    lastUsed: null,
+    lastVerified: null,
+    failureCount: 0,
+    suspect: false,
+    pinnedGroup: null,
+    mcpServer: null,
+    toolName: null,
+    toolArgs: null,
+    externalRef: null,
+    validationState: 'unverified',
+    lastErrorCode: null,
+    lastErrorMessage: null,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...over,
+  }) as Resource
+
+describe('McpServersSection', () => {
+  it('renders a server summary with env KEY names but no secret values', () => {
+    render(<McpServersSection projectId={1} servers={[summary()]} showUndo={vi.fn()} />)
+    expect(screen.getByText('Datadog prod')).toBeTruthy()
+    expect(screen.getByText('datadog-mcp')).toBeTruthy()
+    // The summary carries no values, so nothing secret can render.
+    expect(screen.queryByDisplayValue('DD_API_KEY')).toBeNull()
+  })
+
+  it('creates a server, sending the env value exactly once', async () => {
+    invoke.mockResolvedValue(summary())
+    render(<McpServersSection projectId={1} servers={[]} showUndo={vi.fn()} />)
+    fireEvent.click(screen.getByText('Add'))
+    fireEvent.change(screen.getByPlaceholderText('Datadog (prod)'), { target: { value: 'DD' } })
+    fireEvent.change(screen.getByPlaceholderText('datadog-mcp'), { target: { value: 'dd-mcp' } })
+    fireEvent.click(screen.getByText('Add variable'))
+    fireEvent.change(screen.getByPlaceholderText('DD_API_KEY'), { target: { value: 'DD_KEY' } })
+    fireEvent.change(screen.getByPlaceholderText('value'), { target: { value: 'sekret' } })
+    fireEvent.click(screen.getByText('Add server'))
+
+    await waitFor(() =>
+      expect(invoke).toHaveBeenCalledWith('resources:mcp-create', 1, {
+        label: 'DD',
+        config: { command: 'dd-mcp', args: [], env: { DD_KEY: 'sekret' } },
+      })
+    )
+  })
+
+  it('edits a server via envDelete, never prefilling the stored secret', async () => {
+    invoke.mockResolvedValue(summary())
+    render(<McpServersSection projectId={1} servers={[summary()]} showUndo={vi.fn()} />)
+    fireEvent.click(screen.getByLabelText('Edit server'))
+    // The existing env key is a chip (no value input) — the secret is never rendered.
+    expect(screen.queryByDisplayValue('DD_API_KEY')).toBeNull()
+    fireEvent.click(screen.getByLabelText('Remove DD_API_KEY'))
+    fireEvent.click(screen.getByText('Save'))
+
+    await waitFor(() =>
+      expect(invoke).toHaveBeenCalledWith('resources:mcp-update', 1, 'srv-1', {
+        label: 'Datadog prod',
+        command: 'datadog-mcp',
+        args: ['--stdio'],
+        envSet: {},
+        envDelete: ['DD_API_KEY'],
+      })
+    )
+  })
+
+  it('deletes with an undo that restores the server', async () => {
+    const showUndo = vi.fn()
+    invoke.mockResolvedValue(undefined)
+    render(<McpServersSection projectId={1} servers={[summary()]} showUndo={showUndo} />)
+    fireEvent.click(screen.getByLabelText('Disconnect server'))
+
+    await waitFor(() => expect(invoke).toHaveBeenCalledWith('resources:mcp-delete', 1, 'srv-1'))
+    expect(showUndo).toHaveBeenCalled()
+    // Invoking the undo restores it.
+    const onUndo = showUndo.mock.calls[0][1] as () => void
+    onUndo()
+    expect(invoke).toHaveBeenCalledWith('resources:mcp-restore', 1, 'srv-1')
+  })
+
+  it('checks a server and shows an honest "starts · N tools" line', async () => {
+    invoke.mockResolvedValue({ ok: true, tools: [{ name: 'query' }, { name: 'search' }] })
+    render(<McpServersSection projectId={1} servers={[summary()]} showUndo={vi.fn()} />)
+    fireEvent.click(screen.getByTitle('Check the server starts + list its tools'))
+    await waitFor(() => expect(screen.getByText('Server starts · 2 tools found')).toBeTruthy())
+  })
+})
+
+describe('ConnectResourceDialog', () => {
+  it('discovers tools then connects with parsed JSON args', async () => {
+    invoke.mockImplementation((channel: string) => {
+      if (channel === 'resources:mcp-list-tools') return Promise.resolve({ ok: true, tools: [{ name: 'query', description: 'run a query' }] })
+      return Promise.resolve(resource())
+    })
+    render(<ConnectResourceDialog projectId={1} resource={resource()} servers={[summary()]} onClose={vi.fn()} />)
+
+    fireEvent.click(screen.getByText('Discover tools'))
+    await waitFor(() => expect(screen.getByRole('option', { name: 'query' })).toBeTruthy())
+    fireEvent.change(screen.getByLabelText('Tool'), { target: { value: 'query' } })
+    expect(screen.getByText('run a query')).toBeTruthy()
+    fireEvent.change(screen.getByLabelText('Tool args'), { target: { value: '{"metric":"p99"}' } })
+    fireEvent.click(screen.getByText('Connect'))
+
+    await waitFor(() =>
+      expect(invoke).toHaveBeenCalledWith('resources:mcp-connect', 7, {
+        serverId: 'srv-1',
+        toolName: 'query',
+        toolArgs: { metric: 'p99' },
+      })
+    )
+  })
+
+  it('rejects invalid JSON args before calling connect', async () => {
+    render(<ConnectResourceDialog projectId={1} resource={resource({ toolName: 'query', mcpServer: 'srv-1' })} servers={[summary()]} onClose={vi.fn()} />)
+    fireEvent.change(screen.getByLabelText('Tool args'), { target: { value: 'not json' } })
+    fireEvent.click(screen.getByText('Connect'))
+    await waitFor(() => expect(screen.getByText('Tool args must be valid JSON')).toBeTruthy())
+    expect(invoke).not.toHaveBeenCalledWith('resources:mcp-connect', expect.anything(), expect.anything())
+  })
+})

--- a/src/renderer/src/components/McpTools.tsx
+++ b/src/renderer/src/components/McpTools.tsx
@@ -340,7 +340,7 @@ export function ConnectResourceDialog({
           <>
             <label className={styles.field}>
               <span className={styles.fieldLabel}>Server</span>
-              <select className={styles.input} value={serverId} onChange={(e) => { setServerId(e.target.value); setTools(null) }}>
+              <select className={styles.input} aria-label="Server" value={serverId} onChange={(e) => { setServerId(e.target.value); setTools(null); setError(null) }}>
                 {servers.map((s) => (
                   <option key={s.id} value={s.id}>
                     {s.label}

--- a/src/renderer/src/components/McpTools.tsx
+++ b/src/renderer/src/components/McpTools.tsx
@@ -13,6 +13,15 @@ function parseArgsLines(text: string): string[] {
     .filter((s) => s.length > 0)
 }
 
+/** Stringify that never throws (server-controlled inputSchema may hold a BigInt etc.). */
+function safeStringify(value: unknown): string {
+  try {
+    return JSON.stringify(value, null, 2)
+  } catch {
+    return String(value)
+  }
+}
+
 interface EnvRow {
   key: string
   value: string
@@ -260,7 +269,11 @@ export function ConnectResourceDialog({
   servers: McpServerSummary[]
   onClose: () => void
 }): JSX.Element {
-  const [serverId, setServerId] = useState(resource.mcpServer ?? servers[0]?.id ?? '')
+  const [serverId, setServerId] = useState(
+    resource.mcpServer !== null && servers.some((s) => s.id === resource.mcpServer)
+      ? resource.mcpServer
+      : (servers[0]?.id ?? '')
+  )
   const [toolName, setToolName] = useState(resource.toolName ?? '')
   const [argsText, setArgsText] = useState(JSON.stringify(resource.toolArgs ?? {}, null, 2))
   const [tools, setTools] = useState<McpToolInfo[] | null>(null)
@@ -359,7 +372,7 @@ export function ConnectResourceDialog({
               {selectedTool?.inputSchema !== undefined && (
                 <details className={styles.schema}>
                   <summary>Input schema</summary>
-                  <pre>{JSON.stringify(selectedTool.inputSchema, null, 2)}</pre>
+                  <pre>{safeStringify(selectedTool.inputSchema)}</pre>
                 </details>
               )}
             </div>

--- a/src/renderer/src/components/McpTools.tsx
+++ b/src/renderer/src/components/McpTools.tsx
@@ -5,7 +5,7 @@ import { Icon } from './Icon'
 import { fire } from '../ipc'
 import styles from './McpTools.module.css'
 
-/** One tool name per line; trims and drops blanks. */
+/** One command argument per line; trims and drops blanks. */
 function parseArgsLines(text: string): string[] {
   return text
     .split('\n')

--- a/src/renderer/src/components/McpTools.tsx
+++ b/src/renderer/src/components/McpTools.tsx
@@ -1,0 +1,382 @@
+import { useState } from 'react'
+import { Plus, Trash2, X, Zap, Check, RefreshCw, Pencil } from 'lucide-react'
+import type { McpServerSummary, McpToolInfo, McpToolsResult, Resource } from '@shared/ipc-channels'
+import { Icon } from './Icon'
+import { fire } from '../ipc'
+import styles from './McpTools.module.css'
+
+/** One tool name per line; trims and drops blanks. */
+function parseArgsLines(text: string): string[] {
+  return text
+    .split('\n')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0)
+}
+
+interface EnvRow {
+  key: string
+  value: string
+}
+
+// ── Server add/edit form ──────────────────────────────────────────────────────
+
+/**
+ * Add or edit a wired MCP server. Secrets are write-only: on edit, existing env
+ * values are NEVER shown (the renderer only receives key names). Existing keys
+ * can be removed (envDelete) or replaced by re-entering them (envSet); omitted
+ * keys are preserved server-side.
+ */
+function ServerForm({
+  projectId,
+  existing,
+  onDone,
+}: {
+  projectId: number
+  existing: McpServerSummary | null
+  onDone: () => void
+}): JSX.Element {
+  const [label, setLabel] = useState(existing?.label ?? '')
+  const [command, setCommand] = useState(existing?.command ?? '')
+  const [argsText, setArgsText] = useState((existing?.args ?? []).join('\n'))
+  // Edit: keys the user chose to drop. Create: unused.
+  const [removedKeys, setRemovedKeys] = useState<string[]>([])
+  // New/replacement secrets, entered once and sent one-way.
+  const [envRows, setEnvRows] = useState<EnvRow[]>([])
+  const [error, setError] = useState<string | null>(null)
+  const [saving, setSaving] = useState(false)
+
+  const isEdit = existing !== null
+  const remainingKeys = (existing?.envKeys ?? []).filter((k) => !removedKeys.includes(k))
+
+  const setRow = (i: number, patch: Partial<EnvRow>): void => {
+    setEnvRows((rows) => rows.map((r, idx) => (idx === i ? { ...r, ...patch } : r)))
+  }
+
+  const submit = async (): Promise<void> => {
+    setError(null)
+    setSaving(true)
+    try {
+      const envEntries = envRows.map((r) => ({ key: r.key.trim(), value: r.value })).filter((r) => r.key.length > 0)
+      const envSet = Object.fromEntries(envEntries.map((r) => [r.key, r.value]))
+      if (isEdit && existing) {
+        await window.electron.ipc.invoke('resources:mcp-update', projectId, existing.id, {
+          label: label.trim(),
+          command: command.trim(),
+          args: parseArgsLines(argsText),
+          envSet,
+          envDelete: removedKeys,
+        })
+      } else {
+        await window.electron.ipc.invoke('resources:mcp-create', projectId, {
+          label: label.trim(),
+          config: { command: command.trim(), args: parseArgsLines(argsText), env: envSet },
+        })
+      }
+      onDone()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not save the server')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className={styles.form}>
+      <label className={styles.field}>
+        <span className={styles.fieldLabel}>Label</span>
+        <input className={styles.input} value={label} onChange={(e) => setLabel(e.target.value)} placeholder="Datadog (prod)" autoFocus />
+      </label>
+      <label className={styles.field}>
+        <span className={styles.fieldLabel}>Command</span>
+        <input className={styles.input} value={command} onChange={(e) => setCommand(e.target.value)} placeholder="datadog-mcp" />
+      </label>
+      <label className={styles.field}>
+        <span className={styles.fieldLabel}>Arguments (one per line)</span>
+        <textarea className={styles.textarea} value={argsText} onChange={(e) => setArgsText(e.target.value)} rows={2} placeholder={'--stdio'} />
+      </label>
+
+      <div className={styles.field}>
+        <span className={styles.fieldLabel}>Environment {isEdit && <span className={styles.hint}>(values hidden — re-enter to replace)</span>}</span>
+        {isEdit && remainingKeys.length > 0 && (
+          <div className={styles.envChips}>
+            {remainingKeys.map((k) => (
+              <span key={k} className={styles.envChip}>
+                {k} <span className={styles.envSet}>•••• set</span>
+                <button type="button" className={styles.chipX} onClick={() => setRemovedKeys((r) => [...r, k])} aria-label={`Remove ${k}`}>
+                  <Icon icon={X} size={11} />
+                </button>
+              </span>
+            ))}
+          </div>
+        )}
+        {envRows.map((row, i) => (
+          <div key={i} className={styles.envRow}>
+            <input className={styles.envKey} value={row.key} onChange={(e) => setRow(i, { key: e.target.value })} placeholder="DD_API_KEY" />
+            <input
+              className={styles.envValue}
+              type="password"
+              value={row.value}
+              onChange={(e) => setRow(i, { value: e.target.value })}
+              placeholder="value"
+            />
+            <button type="button" className={styles.chipX} onClick={() => setEnvRows((r) => r.filter((_, idx) => idx !== i))} aria-label="Remove env var">
+              <Icon icon={X} size={12} />
+            </button>
+          </div>
+        ))}
+        <button type="button" className={styles.addEnv} onClick={() => setEnvRows((r) => [...r, { key: '', value: '' }])}>
+          <Icon icon={Plus} size={12} /> Add variable
+        </button>
+      </div>
+
+      {error && <div className={styles.error}>{error}</div>}
+      <div className={styles.formActions}>
+        <button type="button" className={styles.primary} onClick={() => void submit()} disabled={saving}>
+          {isEdit ? 'Save' : 'Add server'}
+        </button>
+        <button type="button" className={styles.secondary} onClick={onDone} disabled={saving}>
+          Cancel
+        </button>
+      </div>
+    </div>
+  )
+}
+
+// ── Server management section ─────────────────────────────────────────────────
+
+interface ProbeState {
+  loading: boolean
+  result: McpToolsResult | null
+}
+
+export function McpServersSection({
+  projectId,
+  servers,
+  showUndo,
+}: {
+  projectId: number
+  servers: McpServerSummary[]
+  showUndo: (message: string, onUndo: () => void, actionLabel?: string) => void
+}): JSX.Element {
+  const [mode, setMode] = useState<'idle' | 'new' | string>('idle')
+  const [probes, setProbes] = useState<Record<string, ProbeState>>({})
+
+  const check = async (id: string): Promise<void> => {
+    setProbes((p) => ({ ...p, [id]: { loading: true, result: null } }))
+    try {
+      const result = await window.electron.ipc.invoke('resources:mcp-list-tools', projectId, id)
+      setProbes((p) => ({ ...p, [id]: { loading: false, result } }))
+    } catch (err) {
+      setProbes((p) => ({ ...p, [id]: { loading: false, result: { ok: false, error: err instanceof Error ? err.message : 'Probe failed' } } }))
+    }
+  }
+
+  const remove = (server: McpServerSummary): void => {
+    const run = async (): Promise<void> => {
+      await window.electron.ipc.invoke('resources:mcp-delete', projectId, server.id)
+      showUndo(`Disconnected ${server.label}`, () =>
+        fire(window.electron.ipc.invoke('resources:mcp-restore', projectId, server.id), 'mcp-restore')
+      )
+    }
+    fire(run(), 'mcp-delete')
+  }
+
+  return (
+    <div className={styles.section}>
+      <div className={styles.sectionHead}>
+        <span className={styles.sectionTitle}>Connect a tool</span>
+        {mode === 'idle' && (
+          <button type="button" className={styles.addServer} onClick={() => setMode('new')}>
+            <Icon icon={Plus} size={13} /> Add
+          </button>
+        )}
+      </div>
+
+      {mode === 'new' && <ServerForm projectId={projectId} existing={null} onDone={() => setMode('idle')} />}
+
+      {servers.length === 0 && mode === 'idle' && (
+        <div className={styles.sectionEmpty}>No tools connected. Add an MCP server so resources can pull live values.</div>
+      )}
+
+      {servers.map((server) => {
+        const probe = probes[server.id]
+        return (
+          <div key={server.id} className={styles.serverRow}>
+            {mode === server.id ? (
+              <ServerForm projectId={projectId} existing={server} onDone={() => setMode('idle')} />
+            ) : (
+              <>
+                <div className={styles.serverInfo}>
+                  <span className={styles.serverLabel}>{server.label}</span>
+                  <span className={styles.serverCmd}>{server.command}</span>
+                  {server.envKeys.length > 0 && <span className={styles.serverEnv}>{server.envKeys.length} secret{server.envKeys.length > 1 ? 's' : ''}</span>}
+                </div>
+                <div className={styles.serverActions}>
+                  <button type="button" className={styles.iconBtn} onClick={() => void check(server.id)} title="Check the server starts + list its tools">
+                    <Icon icon={probe?.loading ? RefreshCw : Check} size={13} className={probe?.loading ? styles.spin : undefined} />
+                  </button>
+                  <button type="button" className={styles.iconBtn} onClick={() => setMode(server.id)} aria-label="Edit server">
+                    <Icon icon={Pencil} size={13} />
+                  </button>
+                  <button type="button" className={styles.iconBtn} onClick={() => remove(server)} aria-label="Disconnect server">
+                    <Icon icon={Trash2} size={13} />
+                  </button>
+                </div>
+                {probe && !probe.loading && probe.result && (
+                  <div className={probe.result.ok ? styles.probeOk : styles.probeErr}>
+                    {probe.result.ok
+                      ? `Server starts · ${probe.result.tools.length} tool${probe.result.tools.length === 1 ? '' : 's'} found`
+                      : probe.result.error}
+                  </div>
+                )}
+              </>
+            )}
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+// ── Resource wiring dialog (resource-first) ───────────────────────────────────
+
+/**
+ * Wires a single resource to a configured server tool so a resolve can pull a
+ * live value. Tool discovery is the happy path; a manual tool name works if the
+ * server can't be probed. All validation is authoritative in main.
+ */
+export function ConnectResourceDialog({
+  projectId,
+  resource,
+  servers,
+  onClose,
+}: {
+  projectId: number
+  resource: Resource
+  servers: McpServerSummary[]
+  onClose: () => void
+}): JSX.Element {
+  const [serverId, setServerId] = useState(resource.mcpServer ?? servers[0]?.id ?? '')
+  const [toolName, setToolName] = useState(resource.toolName ?? '')
+  const [argsText, setArgsText] = useState(JSON.stringify(resource.toolArgs ?? {}, null, 2))
+  const [tools, setTools] = useState<McpToolInfo[] | null>(null)
+  const [probing, setProbing] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [saving, setSaving] = useState(false)
+
+  const selectedTool = tools?.find((t) => t.name === toolName)
+
+  const discover = async (): Promise<void> => {
+    if (serverId.length === 0) return
+    setProbing(true)
+    setError(null)
+    try {
+      const result = await window.electron.ipc.invoke('resources:mcp-list-tools', projectId, serverId)
+      if (result.ok) setTools(result.tools)
+      else setError(result.error)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not reach the server')
+    } finally {
+      setProbing(false)
+    }
+  }
+
+  const connect = async (): Promise<void> => {
+    setError(null)
+    let toolArgs: Record<string, unknown>
+    try {
+      const parsed: unknown = argsText.trim().length === 0 ? {} : JSON.parse(argsText)
+      if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        setError('Tool args must be a JSON object')
+        return
+      }
+      toolArgs = parsed as Record<string, unknown>
+    } catch {
+      setError('Tool args must be valid JSON')
+      return
+    }
+    setSaving(true)
+    try {
+      await window.electron.ipc.invoke('resources:mcp-connect', resource.id, { serverId, toolName, toolArgs })
+      onClose()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not connect')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className={styles.dialogBackdrop} onClick={onClose}>
+      <div className={styles.dialog} onClick={(e) => e.stopPropagation()}>
+        <div className={styles.dialogHead}>
+          <span className={styles.dialogTitle}>Connect live value</span>
+          <button type="button" className={styles.iconBtn} onClick={onClose} aria-label="Close">
+            <Icon icon={X} size={14} />
+          </button>
+        </div>
+        <div className={styles.dialogResource}>{resource.title}</div>
+
+        {servers.length === 0 ? (
+          <div className={styles.sectionEmpty}>Add a tool below first, then connect this resource to it.</div>
+        ) : (
+          <>
+            <label className={styles.field}>
+              <span className={styles.fieldLabel}>Server</span>
+              <select className={styles.input} value={serverId} onChange={(e) => { setServerId(e.target.value); setTools(null) }}>
+                {servers.map((s) => (
+                  <option key={s.id} value={s.id}>
+                    {s.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <div className={styles.field}>
+              <div className={styles.discoverRow}>
+                <span className={styles.fieldLabel}>Tool</span>
+                <button type="button" className={styles.linkBtn} onClick={() => void discover()} disabled={probing || serverId.length === 0}>
+                  {probing ? 'Discovering…' : 'Discover tools'}
+                </button>
+              </div>
+              {tools && tools.length > 0 ? (
+                <select className={styles.input} aria-label="Tool" value={toolName} onChange={(e) => setToolName(e.target.value)}>
+                  <option value="">Select a tool…</option>
+                  {tools.map((t) => (
+                    <option key={t.name} value={t.name}>
+                      {t.name}
+                    </option>
+                  ))}
+                </select>
+              ) : (
+                <input className={styles.input} aria-label="Tool" value={toolName} onChange={(e) => setToolName(e.target.value)} placeholder="query" />
+              )}
+              {selectedTool?.description && <div className={styles.toolDesc}>{selectedTool.description}</div>}
+              {selectedTool?.inputSchema !== undefined && (
+                <details className={styles.schema}>
+                  <summary>Input schema</summary>
+                  <pre>{JSON.stringify(selectedTool.inputSchema, null, 2)}</pre>
+                </details>
+              )}
+            </div>
+
+            <label className={styles.field}>
+              <span className={styles.fieldLabel}>Tool args (JSON)</span>
+              <textarea className={styles.textarea} aria-label="Tool args" value={argsText} onChange={(e) => setArgsText(e.target.value)} rows={4} spellCheck={false} />
+            </label>
+
+            {error && <div className={styles.error}>{error}</div>}
+            <div className={styles.formActions}>
+              <button type="button" className={styles.primary} onClick={() => void connect()} disabled={saving || toolName.trim().length === 0}>
+                <Icon icon={Zap} size={13} /> Connect
+              </button>
+              <button type="button" className={styles.secondary} onClick={onClose} disabled={saving}>
+                Cancel
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/McpTools.tsx
+++ b/src/renderer/src/components/McpTools.tsx
@@ -59,12 +59,16 @@ function ServerForm({
       const envEntries = envRows.map((r) => ({ key: r.key.trim(), value: r.value })).filter((r) => r.key.length > 0)
       const envSet = Object.fromEntries(envEntries.map((r) => [r.key, r.value]))
       if (isEdit && existing) {
+        // Re-entering a removed key is a REPLACEMENT, not a conflict: drop it from
+        // envDelete so it lands in envSet only (main rejects a key in both).
+        const setKeys = new Set(Object.keys(envSet))
+        const envDelete = removedKeys.filter((k) => !setKeys.has(k))
         await window.electron.ipc.invoke('resources:mcp-update', projectId, existing.id, {
           label: label.trim(),
           command: command.trim(),
           args: parseArgsLines(argsText),
           envSet,
-          envDelete: removedKeys,
+          envDelete,
         })
       } else {
         await window.electron.ipc.invoke('resources:mcp-create', projectId, {

--- a/src/renderer/src/components/ResourcePanel.module.css
+++ b/src/renderer/src/components/ResourcePanel.module.css
@@ -371,6 +371,15 @@
   flex: none;
 }
 
+.liveBadge {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  font-size: 10.5px;
+  color: var(--accent-text);
+  flex: none;
+}
+
 .rowAction {
   background: none;
   border: none;

--- a/src/renderer/src/components/ResourcePanel.tsx
+++ b/src/renderer/src/components/ResourcePanel.tsx
@@ -158,7 +158,9 @@ function ResourceRow({
   onDisconnect: (r: Resource) => void
 }): JSX.Element {
   const hasLink = resource.url !== null
-  const hasWiring = resource.mcpServer !== null && resource.toolName !== null
+  // Match main's wiring semantics (resolve/validateToolName trim): blank or
+  // whitespace-only server/tool is NOT wired.
+  const hasWiring = (resource.mcpServer?.trim().length ?? 0) > 0 && (resource.toolName?.trim().length ?? 0) > 0
   const live = hasWiring && serverLive
   return (
     <div className={styles.browseRow}>

--- a/src/renderer/src/components/ResourcePanel.tsx
+++ b/src/renderer/src/components/ResourcePanel.tsx
@@ -218,17 +218,19 @@ export function ResourcePanel({ projectId, showUndo }: ResourcePanelProps): JSX.
   useEffect(() => {
     let active = true
     const load = async (): Promise<void> => {
+      // Load independently so a transient mcp-list failure can't blank the
+      // resources list (and vice versa).
       try {
-        const [g, s] = await Promise.all([
-          window.electron.ipc.invoke('resources:groups', projectId),
-          window.electron.ipc.invoke('resources:mcp-list', projectId),
-        ])
-        if (active) {
-          setGroups(g)
-          setServers(s)
-        }
+        const g = await window.electron.ipc.invoke('resources:groups', projectId)
+        if (active) setGroups(g)
       } catch (err) {
-        console.error('[Resources] load failed:', err)
+        console.error('[Resources] groups load failed:', err)
+      }
+      try {
+        const s = await window.electron.ipc.invoke('resources:mcp-list', projectId)
+        if (active) setServers(s)
+      } catch (err) {
+        console.error('[Resources] mcp-list load failed:', err)
       }
     }
     void load()

--- a/src/renderer/src/components/ResourcePanel.tsx
+++ b/src/renderer/src/components/ResourcePanel.tsx
@@ -9,15 +9,19 @@ import {
   CircleCheck,
   Database,
   CircleHelp,
+  Zap,
+  Unplug,
 } from 'lucide-react'
 import type {
   CaptureProposal,
   ResolveResult,
   Resource,
   ResourceGroup,
+  McpServerSummary,
 } from '@shared/ipc-channels'
 import { Icon } from './Icon'
 import { fire, openExternal } from '../ipc'
+import { McpServersSection, ConnectResourceDialog } from './McpTools'
 import styles from './ResourcePanel.module.css'
 
 interface ResourcePanelProps {
@@ -140,14 +144,22 @@ function ProposalCard({
 
 function ResourceRow({
   resource,
+  serverLive,
   onOpen,
   onDelete,
+  onConnect,
+  onDisconnect,
 }: {
   resource: Resource
+  serverLive: boolean
   onOpen: (r: Resource) => void
   onDelete: (r: Resource) => void
+  onConnect: (r: Resource) => void
+  onDisconnect: (r: Resource) => void
 }): JSX.Element {
   const hasLink = resource.url !== null
+  const hasWiring = resource.mcpServer !== null && resource.toolName !== null
+  const live = hasWiring && serverLive
   return (
     <div className={styles.browseRow}>
       <button
@@ -159,12 +171,31 @@ function ResourceRow({
       >
         <Icon icon={Database} size={14} className={styles.browseIcon} />
         <span className={styles.browseTitle}>{resource.title}</span>
+        {live && (
+          <span className={styles.liveBadge} title={`Live via ${resource.toolName}`}>
+            <Icon icon={Zap} size={11} /> {resource.toolName}
+          </span>
+        )}
+        {hasWiring && !serverLive && (
+          <span className={styles.suspectBadge} title="The wired tool is disconnected — reconnect or clear it">
+            <Icon icon={Unplug} size={11} /> connection missing
+          </span>
+        )}
         {resource.suspect && (
           <span className={styles.suspectBadge} title={resource.lastErrorMessage ?? 'Last lookup failed'}>
             <Icon icon={TriangleAlert} size={11} /> suspect
           </span>
         )}
       </button>
+      {hasWiring ? (
+        <button type="button" className={styles.rowAction} onClick={() => onDisconnect(resource)} title="Disconnect live value" aria-label="Disconnect live value">
+          <Icon icon={Unplug} size={13} />
+        </button>
+      ) : (
+        <button type="button" className={styles.rowAction} onClick={() => onConnect(resource)} title="Connect live value" aria-label="Connect live value">
+          <Icon icon={Zap} size={13} />
+        </button>
+      )}
       <button type="button" className={styles.rowAction} onClick={() => onDelete(resource)} aria-label="Delete resource">
         <Icon icon={Trash2} size={13} />
       </button>
@@ -176,18 +207,26 @@ function ResourceRow({
 
 export function ResourcePanel({ projectId, showUndo }: ResourcePanelProps): JSX.Element {
   const [groups, setGroups] = useState<ResourceGroup[]>([])
+  const [servers, setServers] = useState<McpServerSummary[]>([])
   const [question, setQuestion] = useState('')
   const [resolving, setResolving] = useState(false)
   const [answer, setAnswer] = useState<ResolveResult | null>(null)
   const [captureUrl, setCaptureUrl] = useState('')
   const [proposal, setProposal] = useState<CaptureProposal | null>(null)
+  const [connecting, setConnecting] = useState<Resource | null>(null)
 
   useEffect(() => {
     let active = true
     const load = async (): Promise<void> => {
       try {
-        const g = await window.electron.ipc.invoke('resources:groups', projectId)
-        if (active) setGroups(g)
+        const [g, s] = await Promise.all([
+          window.electron.ipc.invoke('resources:groups', projectId),
+          window.electron.ipc.invoke('resources:mcp-list', projectId),
+        ])
+        if (active) {
+          setGroups(g)
+          setServers(s)
+        }
       } catch (err) {
         console.error('[Resources] load failed:', err)
       }
@@ -277,7 +316,30 @@ export function ResourcePanel({ projectId, showUndo }: ResourcePanelProps): JSX.
     fire(run(), 'resources:delete')
   }
 
+  const disconnectResource = (r: Resource): void => {
+    const prevServer = r.mcpServer
+    const prevTool = r.toolName
+    const prevArgs = r.toolArgs
+    const run = async (): Promise<void> => {
+      await window.electron.ipc.invoke('resources:mcp-disconnect', r.id)
+      showUndo('Disconnected live value', () => {
+        if (prevServer !== null && prevTool !== null) {
+          fire(
+            window.electron.ipc.invoke('resources:mcp-connect', r.id, {
+              serverId: prevServer,
+              toolName: prevTool,
+              toolArgs: prevArgs ?? {},
+            }),
+            'resources:mcp-connect'
+          )
+        }
+      })
+    }
+    fire(run(), 'resources:mcp-disconnect')
+  }
+
   const hasResources = groups.some((g) => g.resources.length > 0)
+  const liveServerIds = new Set(servers.map((s) => s.id))
 
   return (
     <div className={styles.panel}>
@@ -321,7 +383,15 @@ export function ResourcePanel({ projectId, showUndo }: ResourcePanelProps): JSX.
             <div key={group.key} className={styles.group}>
               <div className={styles.groupLabel}>{group.label}</div>
               {group.resources.map((r) => (
-                <ResourceRow key={r.id} resource={r} onOpen={openResource} onDelete={deleteResource} />
+                <ResourceRow
+                  key={r.id}
+                  resource={r}
+                  serverLive={r.mcpServer !== null && liveServerIds.has(r.mcpServer)}
+                  onOpen={openResource}
+                  onDelete={deleteResource}
+                  onConnect={setConnecting}
+                  onDisconnect={disconnectResource}
+                />
               ))}
             </div>
           ))}
@@ -330,6 +400,18 @@ export function ResourcePanel({ projectId, showUndo }: ResourcePanelProps): JSX.
         <div className={styles.empty}>
           Nothing saved yet. Ask a question above, or paste a dashboard/query/doc link to capture one.
         </div>
+      )}
+
+      {/* Tool management (per-project MCP servers) */}
+      <McpServersSection projectId={projectId} servers={servers} showUndo={showUndo} />
+
+      {connecting && (
+        <ConnectResourceDialog
+          projectId={projectId}
+          resource={connecting}
+          servers={servers}
+          onClose={() => setConnecting(null)}
+        />
       )}
     </div>
   )

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -379,6 +379,59 @@ export interface McpStdioConfig {
 
 export type McpServerInput = Pick<McpServerConfig, 'label'> & { config: McpStdioConfig }
 
+/**
+ * Redacted view of a wired MCP server for the RENDERER. Deliberately carries no
+ * env VALUES — only the key names — so secrets never cross the IPC boundary. The
+ * full config (with env values) stays main-only via getMcpServer(), used solely
+ * by the resolver's app-owned MCP read.
+ */
+export interface McpServerSummary {
+  id: string
+  projectId: number
+  label: string
+  command: string
+  args: string[]
+  /** Names of the configured env vars; values are intentionally omitted. */
+  envKeys: string[]
+  createdAt: string
+  updatedAt: string
+}
+
+/**
+ * Explicit patch for an existing MCP server. Secrets flow ONE WAY: `envSet` adds
+ * or replaces keys, `envDelete` removes keys, and any env key not named in either
+ * is preserved server-side. This avoids a "leave blank to keep" guess and means
+ * the renderer never has to hold or re-send a stored secret value.
+ */
+export interface McpServerPatch {
+  label?: string
+  command?: string
+  args?: string[]
+  envSet?: Record<string, string>
+  envDelete?: string[]
+}
+
+/** A tool advertised by a wired MCP server (from listTools). */
+export interface McpToolInfo {
+  name: string
+  description?: string
+  inputSchema?: unknown
+}
+
+/**
+ * Result of probing a server's tools — the honest "does it start, and what can
+ * it do". A success means the server process started and answered a listTools
+ * handshake; it does NOT prove a real read (or auth for one) will succeed.
+ */
+export type McpToolsResult = { ok: true; tools: McpToolInfo[] } | { ok: false; error: string }
+
+/** Wires a resource to a configured server tool so a resolve can pull a live value. */
+export interface McpConnectInput {
+  serverId: string
+  toolName: string
+  toolArgs: Record<string, unknown>
+}
+
 /** A proposed typed record produced from a pasted/dropped URL, for one-tap accept. */
 export interface CaptureProposal {
   title: string
@@ -897,22 +950,52 @@ export type IpcChannels = {
     result: ProjectCard
   }
 
-  /** Lists a project's wired MCP servers. */
+  /** Lists a project's live (non-deleted) wired MCP servers, REDACTED (no secret values). */
   'resources:mcp-list': {
     args: [projectId: number]
-    result: McpServerConfig[]
+    result: McpServerSummary[]
   }
 
-  /** Creates or updates a wired MCP server. Pass null id to create. */
-  'resources:mcp-upsert': {
-    args: [projectId: number, id: string | null, input: McpServerInput]
-    result: McpServerConfig
+  /** Creates a wired MCP server (full config incl. secrets, entered once). Returns a redacted summary. */
+  'resources:mcp-create': {
+    args: [projectId: number, input: McpServerInput]
+    result: McpServerSummary
   }
 
-  /** Deletes a wired MCP server (scoped to its project). */
+  /** Updates a wired MCP server via an explicit patch (secrets one-way). Returns a redacted summary. */
+  'resources:mcp-update': {
+    args: [projectId: number, id: string, patch: McpServerPatch]
+    result: McpServerSummary
+  }
+
+  /** Soft-deletes a wired MCP server (undoable; resource links are preserved). */
   'resources:mcp-delete': {
     args: [projectId: number, id: string]
     result: void
+  }
+
+  /** Restores a soft-deleted MCP server. */
+  'resources:mcp-restore': {
+    args: [projectId: number, id: string]
+    result: void
+  }
+
+  /** Probes a server: starts it and lists its tools (honest connection check; no tool run). */
+  'resources:mcp-list-tools': {
+    args: [projectId: number, id: string]
+    result: McpToolsResult
+  }
+
+  /** Wires a resource to a configured server tool (validated in main). Returns the updated resource. */
+  'resources:mcp-connect': {
+    args: [resourceId: number, input: McpConnectInput]
+    result: Resource
+  }
+
+  /** Clears a resource's live wiring. Returns the updated resource. */
+  'resources:mcp-disconnect': {
+    args: [resourceId: number]
+    result: Resource
   }
 }
 


### PR DESCRIPTION
## What & why

Finishes MVP C end-to-end (#77 item 2): a per-project **"Connect a tool"** UI that wires MCP servers so the resolver can return **live values**, not just cited sources.

Scoped as "the config entry UI," but a form-only version would ship three fakes, so this PR includes the genuinely-missing backend contracts to make it correct and actually deliver live values (GPT-5.5 reviewed the plan across 3 rounds and the diff across 2):

- **Fake secrecy** - `resources:mcp-list` used to return env tokens to the renderer; UI masking alone is cosmetic.
- **Fake undo** - the old delete hard-deleted and nulled resource links; a renderer undo couldn't be lossless.
- **Fake feature** - verified: nothing in the renderer ever wired a resource to a server, so a config alone lit up **zero** live values.

## Backend contracts (main-owned; the renderer stays dumb)

- **Redact secrets at the boundary.** New `McpServerSummary` (id, label, command, args, `envKeys[]` - no env values) is returned by every renderer-facing MCP result. Full env stays main-only via `getMcpServer()` for the app-owned read.
- **Explicit env patch.** `mcp-create` takes a full config (secrets entered once); `mcp-update` takes `{label?, command?, args?, envSet?, envDelete?}` and merges in main (omitted keys preserved; `envSet∩envDelete` rejected; env keys validated on both paths). Secrets are never read back to the renderer, so there's no "leave blank to keep" guessing.
- **Lossless soft-delete undo.** Migration `016` adds `deleted_at`; `mcp-delete` soft-deletes and no longer nulls resource links; `mcp-restore` clears it; list/get filter `deleted_at`. A resource pointing at a deleted/missing server resolves to `source_available_no_live_value` with `failureClass: null` (was `connector_down` - an intentional delete is not an outage).
- **Typed, validated wiring.** `resources:mcp-connect`/`mcp-disconnect` validate in main (resource + server exist, same project, tool name non-empty, tool args a plain JSON object - cycle-safe, rejects functions/BigInt/Date). Generic `resources:create`/`update` strip `mcpServer`/`toolName`/`toolArgs` so wiring can't bypass the seam.
- **Honest tool discovery.** `resources:mcp-list-tools` connects + `listTools()` (timeout + teardown), returns `{name, description, inputSchema}`. Labeled "Server starts · N tools found," never "Connected."

## Secret trust model (documented in code)

The hard guarantee: **stored config secret values never reach the renderer** via the config surfaces (`McpServerSummary`). A wired server's runtime **output** (live values, tool metadata) is the user's own tool answering the user - surfaced by design in this local, single-user app. As defense-in-depth, configured secret values are scrubbed from server-controlled diagnostic/metadata strings (errors, tool descriptions, `inputSchema` string leaves, failure reasons); `liveValue` is intentionally not scrubbed because it is the feature. GPT-5.5 confirmed this triage is sound for a local single-user app.

## Renderer (ResourcePanel, Primer/GitHub-dark)

- **Resource-first journey:** a resource shows "Connect live value" → pick a server → discover tools (or enter manually) → tool + JSON args → connect. Connected resources show a live badge + Disconnect; a resource whose server was deleted shows "connection missing."
- **"Connect a tool" section** manages servers (add/edit/delete/check). On edit, existing env values are never shown - only key names, as masked "•••• set" chips. Delete uses undo-over-confirmation (`showUndo` → `mcp-restore`).

## How I verified it

- `bun run typecheck`, `bun run lint`, `bun run build` all clean.
- **345 tests pass** (36 files): backend units for redaction, env merge, soft-delete + restore, connect/disconnect validation, env-key/tool-args validation (incl. a cyclic-object case), and live tool discovery + secret-redaction against the synthetic `echo-mcp-server.mjs`; RTL for the server form (create sends env once, edit never renders stored values), delete→undo→restore, tool discovery, and connect with parsed JSON args.
- The echo MCP server proves discovery + the app-owned read path end-to-end in tests.

## What I could NOT verify in-sandbox (honest)

- A real **SSO-gated** MCP provider (Datadog/Splunk/Kusto) live pull, and a **packaged Electron** run of the stdio MCP client - these remain #77 item 3 / release-checklist territory. The mechanism is proven against the echo server; the wiring degrades gracefully to `source_available_no_live_value` when a server can't be reached.

## Out of scope / follow-ups (tracked on #77)

- Item 3: verify a real SSO-gated MCP end-to-end once this UI exists.
- Item 4: local embedding model provisioning + offline flag.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
