### PR TITLE
Test: real connect → live-value round-trip against the echo MCP

### DIFF
--- a/src/main/context/resolve.integration.test.ts
+++ b/src/main/context/resolve.integration.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { Database as BunDb } from 'bun:sqlite'
+import { join } from 'path'
 import type BetterSQLite3 from 'better-sqlite3'
 
 vi.mock('electron', () => ({
@@ -9,8 +10,9 @@ vi.mock('../db', () => ({ getDb: vi.fn() }))
 
 import { getDb } from '../db'
 import { runMigrations } from '../db/migrate'
-import { createResource, getResource, upsertMcpServer, upsertProjectCard } from './registry'
+import { createResource, getResource, upsertMcpServer, upsertProjectCard, connectResourceToServer, disconnectResource } from './registry'
 import { resolveQuestion, buildDecidePrompt, type ResolveDeps } from './resolve'
+import { createMcpRunner } from './mcp-client'
 import type { DecideRunner, DecideRunResult } from './copilot-run'
 import type { McpRunner, McpRunResult } from './mcp-client'
 import type { AssembledCandidate } from './assemble'
@@ -318,4 +320,55 @@ describe('resolveQuestion', () => {
     expect(res.verdict).toBe('none')
     expect(res.retrievalMode).toBe('semantic')
   })
+})
+
+// ── Real connect -> live-value round-trip (spawns the synthetic echo MCP) ──────
+// Proves the marquee path is NOT just plumbing: a resource wired through the
+// validated connect seam pulls a real live value through the resolver's
+// app-owned MCP read (a real subprocess), and disconnecting removes it.
+describe('resolveQuestion — real echo-MCP round-trip', () => {
+  const echoConfig = {
+    command: process.execPath,
+    args: [join(__dirname, 'eval', 'echo-mcp-server.mjs')],
+    env: {},
+  }
+  const citeC1: DecideRunner = decideRunnerReturning('{"verdict":"confident","citedCandidateId":"c1"}')
+
+  function wiredEchoResource(): { pid: number; resourceId: number } {
+    const pid = seedProject()
+    upsertMcpServer(pid, 'echo', { label: 'Echo', config: echoConfig })
+    const r = createResource(pid, {
+      title: 'Checkout p99 latency',
+      kind: 'metric_query',
+      service: 'checkout',
+      aliases: ['checkout latency'],
+    })
+    // Wire through the validated seam (same-project + tool/args validation).
+    connectResourceToServer(r.id, 'echo', 'echo', { metric: 'checkout.p99', value: '240ms' })
+    return { pid, resourceId: r.id }
+  }
+
+  it('a wired resource pulls a REAL live value end-to-end', async () => {
+    const { pid, resourceId } = wiredEchoResource()
+    const res = await resolveQuestion(pid, 'checkout latency', {
+      decideRunner: citeC1,
+      mcpRunner: createMcpRunner({ timeoutMs: 15_000 }),
+    })
+    expect(res.verdict).toBe('confident')
+    expect(res.liveValue).toContain('checkout.p99 = 240ms')
+    expect(res.citation?.resourceId).toBe(resourceId)
+    // The app-owned read marked the source verified.
+    expect(getResource(resourceId)?.validationState).toBe('valid')
+  }, 25_000)
+
+  it('after disconnect, the same question returns no live value', async () => {
+    const { pid, resourceId } = wiredEchoResource()
+    disconnectResource(resourceId)
+    const res = await resolveQuestion(pid, 'checkout latency', {
+      decideRunner: citeC1,
+      mcpRunner: createMcpRunner({ timeoutMs: 15_000 }),
+    })
+    expect(res.verdict).toBe('source_available_no_live_value')
+    expect(res.liveValue).toBeNull()
+  }, 25_000)
 })


### PR DESCRIPTION
## What & why

Closes the one verification gap from the MVP C live-value work (#80). The orchestrator asked to "exercise a real connect → live-value round-trip against the synthetic echo MCP so it's not just plumbing." In #80 I tested the pieces - the real app-owned read against the echo server, `listTools` discovery, registry-level wiring, and resolve's confident path - but that last one used a **mocked** `mcpRunner`, so nothing stitched the full marquee path in a single test.

This test-only PR proves the feature actually works end-to-end:

- Wire a resource to a **real** echo MCP server via `connectResourceToServer`, then `resolveQuestion` with the **real** `createMcpRunner` + a decider that cites it. Assert `verdict = confident`, the live value comes from the spawned echo server (`checkout.p99 = 240ms`), and the source is marked verified.
- After `disconnectResource`, the same question returns `source_available_no_live_value`.

## How I verified it

- `bun run typecheck` + `bun run lint` clean; **350 tests pass** (2 new). The test spawns the synthetic `echo-mcp-server.mjs` subprocess - a real MCP read over stdio, no real/SSO-gated tool.

## Scope

Test-only; no production code changes. A real SSO-gated MCP provider + a packaged-Electron run remain #77 item 3 / the release-checklist.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
