### PR TITLE
Test: assert failureClass null on no-live-value paths (soft-delete)

### DIFF
--- a/src/main/context/resolve.integration.test.ts
+++ b/src/main/context/resolve.integration.test.ts
@@ -10,7 +10,7 @@ vi.mock('../db', () => ({ getDb: vi.fn() }))
 
 import { getDb } from '../db'
 import { runMigrations } from '../db/migrate'
-import { createResource, getResource, upsertMcpServer, upsertProjectCard, connectResourceToServer, disconnectResource } from './registry'
+import { createResource, getResource, upsertMcpServer, upsertProjectCard, connectResourceToServer, disconnectResource, deleteMcpServer } from './registry'
 import { resolveQuestion, buildDecidePrompt, type ResolveDeps } from './resolve'
 import { createMcpRunner } from './mcp-client'
 import type { DecideRunner, DecideRunResult } from './copilot-run'
@@ -370,5 +370,23 @@ describe('resolveQuestion — real echo-MCP round-trip', () => {
     })
     expect(res.verdict).toBe('source_available_no_live_value')
     expect(res.liveValue).toBeNull()
+    expect(res.failureClass).toBeNull()
   }, 25_000)
+
+  it('a wired resource whose server was soft-deleted resolves to no-live-value with failureClass null (not connector_down)', async () => {
+    const { pid, resourceId } = wiredEchoResource()
+    // The resource stays wired (mcpServer='echo'), but the server config is gone.
+    // This is the branch the #80 fix targets: a deliberately-deleted config is a
+    // config state, NOT an infra outage — so failureClass is null and the source
+    // is not marked suspect. The runner must never be reached.
+    deleteMcpServer(pid, 'echo')
+    const res = await resolveQuestion(pid, 'checkout latency', {
+      decideRunner: citeC1,
+      mcpRunner: mcpNeverCalled,
+    })
+    expect(res.verdict).toBe('source_available_no_live_value')
+    expect(res.liveValue).toBeNull()
+    expect(res.failureClass).toBeNull()
+    expect(getResource(resourceId)?.suspect).toBe(false)
+  })
 })


### PR DESCRIPTION
## What & why

Follow-up to #81 that fully satisfies the design note for the live-value round-trip test.

Two gaps between the note and what #81 shipped:
1. #81 asserted the verdict + null liveValue on the no-live-value path but **not** `failureClass`.
2. #81's disconnect case clears the wiring (`mcpServer = null`), so it hits resolve's "not wired" branch - which was always `failureClass: null`. It does **not** exercise the branch the note actually targets: a resource that stays **wired** to a server whose config is gone (soft-deleted) → `getMcpServer` null → the `connector_down → null` fix from #80.

This PR closes both:
- The disconnect case now asserts `failureClass` is null.
- Adds the soft-delete scenario: wire a resource to the echo server, `deleteMcpServer` (soft-delete), resolve → `source_available_no_live_value` with `failureClass: null` (**not** `connector_down`), `liveValue` null, and the source is **not** marked suspect - with the MCP runner never reached (`mcpNeverCalled`). This is the maintenance-by-use correctness: a deliberately-deleted config isn't a broken connector, so it must not read as an outage or flag the source.

## How I verified it

- `bun run typecheck` + `bun run lint` clean; **351 tests pass** (the confident round-trip still spawns the real echo MCP; the soft-delete case is hermetic and proves the runner isn't called).

Test-only; no production changes.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
