### PR TITLE
Cross-cutting (1/2): notification rules management UI + notification-triggered snooze

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import type { Project } from '@shared/ipc-channels'
+import type { Project, SnoozeMode } from '@shared/ipc-channels'
 import styles from './App.module.css'
 import { Titlebar } from './components/Titlebar'
 import { ProjectRail } from './components/ProjectRail'
@@ -8,6 +8,7 @@ import { UndoToast } from './components/UndoToast'
 import { FocusPage } from './pages/FocusPage'
 import { InboxView } from './pages/InboxView'
 import { SettingsView } from './pages/SettingsView'
+import { RulesView } from './pages/RulesView'
 import { AgentTasksView } from './pages/AgentTasksView'
 import { EmptyFocus } from './pages/EmptyFocus'
 import { useProjects } from './hooks/useProjects'
@@ -16,7 +17,7 @@ import { useFocus } from './hooks/useFocus'
 import { useUndo } from './hooks/useUndo'
 import { parseDbTimestampMs } from '@shared/time'
 
-type View = 'focus' | 'inbox' | 'settings' | 'agent-tasks'
+type View = 'focus' | 'inbox' | 'settings' | 'agent-tasks' | 'rules'
 
 const SNOOZE_DAYS = 7
 
@@ -110,7 +111,7 @@ export function App(): JSX.Element {
       })
   }, [projects, focusedId])
 
-  const snoozeProject = useCallback(async (id: number, mode: 'manual' | 'date') => {
+  const snoozeProject = useCallback(async (id: number, mode: SnoozeMode) => {
     try {
       const until = mode === 'date' ? new Date(Date.now() + SNOOZE_DAYS * 86400000).toISOString() : undefined
       await window.electron.ipc.invoke('projects:snooze', id, mode, until)
@@ -161,6 +162,21 @@ export function App(): JSX.Element {
     void snoozeProject(focusedId, 'manual')
     setFocusedId(nextFocusAfterRemoval(focusedId))
     if (current) showUndo(`Parked ${current.name}`, () => { void unsnooze(current.id); setFocusedId(current.id) })
+  }, [focusedId, projects, snoozeProject, nextFocusAfterRemoval, setFocusedId, showUndo, unsnooze])
+
+  // Notification-triggered snooze: the project drops off the rail and wakes on its own
+  // when the next notification routes/assigns to it. No date, no nag.
+  const onSnoozeCurrentUntilNotification = useCallback(() => {
+    if (focusedId === null) return
+    const current = projects.find((p) => p.id === focusedId)
+    void snoozeProject(focusedId, 'notification')
+    setFocusedId(nextFocusAfterRemoval(focusedId))
+    if (current) {
+      showUndo(`Snoozed ${current.name} until its next notification`, () => {
+        void unsnooze(current.id)
+        setFocusedId(current.id)
+      })
+    }
   }, [focusedId, projects, snoozeProject, nextFocusAfterRemoval, setFocusedId, showUndo, unsnooze])
 
   const onDeleteCurrent = useCallback(() => {
@@ -216,7 +232,12 @@ export function App(): JSX.Element {
         ) : view === 'agent-tasks' ? (
           <AgentTasksView />
         ) : view === 'settings' ? (
-          <SettingsView theme={theme} onClose={() => setView('focus')} />
+          <SettingsView theme={theme} onClose={() => setView('focus')} onOpenRules={() => setView('rules')} />
+        ) : view === 'rules' ? (
+          <RulesView
+            onClose={() => setView('settings')}
+            onRulesChanged={() => { void refreshProjects(); void loadInboxCount() }}
+          />
         ) : focusedId === null ? (
           <EmptyFocus onNewProject={() => void handleNewProject()} />
         ) : (
@@ -231,6 +252,7 @@ export function App(): JSX.Element {
             onSnooze={onSnooze}
             onNotNow={onNotNow}
             onSnoozeCurrent={onSnoozeCurrent}
+            onSnoozeCurrentUntilNotification={onSnoozeCurrentUntilNotification}
             onDeleteCurrent={onDeleteCurrent}
           />
         )}
@@ -243,6 +265,7 @@ export function App(): JSX.Element {
         onSelectProject={selectProject}
         onOpenInbox={() => { setView('inbox'); setPaletteOpen(false) }}
         onOpenSettings={() => { setView('settings'); setPaletteOpen(false) }}
+        onOpenRules={() => { setView('rules'); setPaletteOpen(false) }}
         onNewProject={() => void handleNewProject()}
       />
 

--- a/src/renderer/src/components/CommandPalette.test.tsx
+++ b/src/renderer/src/components/CommandPalette.test.tsx
@@ -41,6 +41,7 @@ function renderPalette(overrides: Partial<Parameters<typeof CommandPalette>[0]> 
       onSelectProject={onSelectProject}
       onOpenInbox={vi.fn()}
       onOpenSettings={vi.fn()}
+      onOpenRules={vi.fn()}
       onNewProject={vi.fn()}
       {...overrides}
     />
@@ -87,6 +88,7 @@ describe('CommandPalette', () => {
         onSelectProject={vi.fn()}
         onOpenInbox={vi.fn()}
         onOpenSettings={vi.fn()}
+        onOpenRules={vi.fn()}
         onNewProject={vi.fn()}
       />
     )

--- a/src/renderer/src/components/CommandPalette.tsx
+++ b/src/renderer/src/components/CommandPalette.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { Search, Target, Inbox, Settings, Plus } from 'lucide-react'
+import { Search, Target, Inbox, Settings, Plus, SlidersHorizontal } from 'lucide-react'
 import type { Project } from '@shared/ipc-channels'
 import type { LucideIcon } from 'lucide-react'
 import { Icon } from './Icon'
@@ -12,6 +12,7 @@ interface CommandPaletteProps {
   onSelectProject: (id: number) => void
   onOpenInbox: () => void
   onOpenSettings: () => void
+  onOpenRules: () => void
   onNewProject: () => void
 }
 
@@ -30,6 +31,7 @@ export function CommandPalette({
   onSelectProject,
   onOpenInbox,
   onOpenSettings,
+  onOpenRules,
   onNewProject,
 }: CommandPaletteProps): JSX.Element | null {
   const [query, setQuery] = useState('')
@@ -55,11 +57,12 @@ export function CommandPalette({
     }))
     const actionEntries: Entry[] = [
       { key: 'inbox', label: 'Open Inbox', hint: 'go', icon: Inbox, run: onOpenInbox },
+      { key: 'rules', label: 'Notification rules', hint: 'go', icon: SlidersHorizontal, run: onOpenRules },
       { key: 'settings', label: 'Open Settings', hint: 'go', icon: Settings, run: onOpenSettings },
       { key: 'new', label: 'New project', hint: 'create', icon: Plus, run: onNewProject },
     ]
     return [...projectEntries, ...actionEntries]
-  }, [projects, onSelectProject, onOpenInbox, onOpenSettings, onNewProject])
+  }, [projects, onSelectProject, onOpenInbox, onOpenRules, onOpenSettings, onNewProject])
 
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase()

--- a/src/renderer/src/pages/FocusPage.tsx
+++ b/src/renderer/src/pages/FocusPage.tsx
@@ -1,5 +1,5 @@
 import { useRef, useState } from 'react'
-import { MoreHorizontal, Moon, Trash2, Sun } from 'lucide-react'
+import { MoreHorizontal, Moon, Trash2, Sun, BellRing } from 'lucide-react'
 import type { LaunchTarget, Project, ProjectTodo } from '@shared/ipc-channels'
 import { Icon } from '../components/Icon'
 import { ReentryDigest } from '../components/ReentryDigest'
@@ -22,6 +22,7 @@ interface FocusPageProps {
   onSnooze: (project: Project) => void
   onNotNow: (project: Project) => void
   onSnoozeCurrent: () => void
+  onSnoozeCurrentUntilNotification: () => void
   onDeleteCurrent: () => void
 }
 
@@ -100,6 +101,18 @@ export function FocusPage(props: FocusPageProps): JSX.Element {
                   >
                     <Icon icon={Moon} size={14} />
                     Snooze project
+                  </button>
+                )}
+                {detail.status !== 'snoozed' && (
+                  <button type="button"
+                    className={styles.menuItem}
+                    onClick={() => {
+                      setMenuOpen(false)
+                      props.onSnoozeCurrentUntilNotification()
+                    }}
+                  >
+                    <Icon icon={BellRing} size={14} />
+                    Snooze until a notification
                   </button>
                 )}
                 <button type="button"

--- a/src/renderer/src/pages/RulesView.module.css
+++ b/src/renderer/src/pages/RulesView.module.css
@@ -1,0 +1,292 @@
+.main {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.toolbar {
+  height: 46px;
+  flex: none;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 0 20px;
+  border-bottom: 1px solid var(--border-muted);
+}
+
+.back {
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  color: var(--text-2);
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+}
+
+.back:hover {
+  background: var(--bg-subtle);
+  color: var(--text);
+}
+
+.title {
+  font-size: 15px;
+  font-weight: 600;
+}
+
+.content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 24px 32px;
+  max-width: 680px;
+}
+
+.empty {
+  color: var(--text-3);
+  font-size: 13px;
+}
+
+.section {
+  margin-bottom: 34px;
+}
+
+.sectionHead {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 12px;
+}
+
+.sectionTitle {
+  margin: 0 0 4px;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  color: var(--text-3);
+}
+
+.sectionDesc {
+  margin: 0;
+  font-size: 12px;
+  color: var(--text-2);
+  line-height: 1.5;
+  max-width: 460px;
+}
+
+.addButton {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  height: 28px;
+  padding: 0 10px;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text);
+  background: var(--bg-subtle);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  cursor: pointer;
+}
+
+.addButton:hover {
+  background: var(--bg-elevated);
+}
+
+.emptyRow {
+  font-size: 12px;
+  color: var(--text-3);
+  padding: 8px 0;
+}
+
+.ruleRow {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  height: var(--row);
+  padding: 0 4px 0 8px;
+  border-radius: var(--radius);
+}
+
+.ruleRow:hover {
+  background: var(--bg-subtle);
+}
+
+.ruleOrder {
+  flex: none;
+  width: 18px;
+  text-align: center;
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-3);
+}
+
+.ruleIcon {
+  flex: none;
+  color: var(--text-3);
+}
+
+.ruleText {
+  font-size: 13px;
+  color: var(--text);
+  font-family: var(--font-mono);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.ruleTarget {
+  flex: 1;
+  font-size: 12px;
+  color: var(--text-2);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.ruleRow > .ruleText:last-of-type {
+  flex: 1;
+}
+
+.deleteButton {
+  flex: none;
+  margin-left: auto;
+  width: 26px;
+  height: 26px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  color: var(--text-3);
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  opacity: 0;
+}
+
+.ruleRow:hover .deleteButton {
+  opacity: 1;
+}
+
+.deleteButton:hover {
+  background: var(--bg-elevated);
+  color: var(--danger);
+}
+
+.addForm {
+  margin-top: 10px;
+  padding: 12px;
+  background: var(--bg-subtle);
+  border: 1px solid var(--border-muted);
+  border-radius: var(--radius);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.conditionGrid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 8px;
+}
+
+.repoRow {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 8px;
+}
+
+.input {
+  height: 30px;
+  padding: 0 10px;
+  background: var(--bg-inset);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text);
+  font-size: 13px;
+  outline: none;
+  min-width: 0;
+}
+
+.input:focus {
+  border-color: var(--accent-border);
+}
+
+.formActions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.primaryButton {
+  height: 30px;
+  padding: 0 14px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--accent-fg);
+  background: var(--accent);
+  border: 1px solid transparent;
+  border-radius: var(--radius);
+  cursor: pointer;
+}
+
+.primaryButton:hover {
+  background: var(--accent-hover);
+}
+
+.ghostButton {
+  width: 30px;
+  height: 30px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text-2);
+  cursor: pointer;
+}
+
+.ghostButton:hover {
+  background: var(--bg-elevated);
+  color: var(--text);
+}
+
+.secondaryButton {
+  height: 30px;
+  padding: 0 14px;
+  font-size: 13px;
+  color: var(--text);
+  background: var(--bg-subtle);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  cursor: pointer;
+}
+
+.secondaryButton:hover {
+  background: var(--bg-elevated);
+}
+
+.sectionFooter {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-top: 12px;
+}
+
+.footerNote {
+  font-size: 12px;
+  color: var(--text-2);
+}
+
+.error {
+  color: var(--danger);
+  font-size: 12px;
+}

--- a/src/renderer/src/pages/RulesView.module.css
+++ b/src/renderer/src/pages/RulesView.module.css
@@ -171,7 +171,12 @@
   opacity: 0;
 }
 
-.ruleRow:hover .deleteButton {
+.ruleRow:hover .deleteButton,
+.ruleRow:focus-within .deleteButton {
+  opacity: 1;
+}
+
+.deleteButton:focus-visible {
   opacity: 1;
 }
 

--- a/src/renderer/src/pages/RulesView.test.tsx
+++ b/src/renderer/src/pages/RulesView.test.tsx
@@ -129,6 +129,14 @@ describe('RulesView', () => {
     })
   })
 
+  it('shows a #id fallback for a route rule whose project name is missing', async () => {
+    mockInvoke({
+      routing: [routingRule({ id: 5, action: 'route', projectId: 9, projectName: null, matchType: 'Issue' })],
+    })
+    render(<RulesView onClose={vi.fn()} />)
+    expect(await screen.findByText('→ #9')).toBeTruthy()
+  })
+
   it('applies route rules to the inbox and reports the count', async () => {
     mockInvoke({ routing: [routingRule({ id: 1, action: 'route', matchType: 'PullRequest' })] })
     render(<RulesView onClose={vi.fn()} />)

--- a/src/renderer/src/pages/RulesView.test.tsx
+++ b/src/renderer/src/pages/RulesView.test.tsx
@@ -1,0 +1,138 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
+import type { Project, RepoRule, RoutingRule } from '@shared/ipc-channels'
+import { RulesView } from './RulesView'
+
+const invoke = vi.fn()
+
+beforeEach(() => {
+  invoke.mockReset()
+  ;(globalThis as unknown as { window: Window }).window.electron = {
+    ipc: { invoke },
+    openExternal: vi.fn(() => Promise.resolve()),
+  } as unknown as Window['electron']
+})
+
+const project: Project = {
+  id: 1, name: 'Alpha', notes: '', nextAction: '', status: 'active', sortOrder: 0,
+  createdAt: '', updatedAt: '', unreadCount: 0, activeTodoCount: 0, snoozeMode: null,
+  snoozeUntil: null, copilotStatus: null, lastFocusedAt: null, driftState: 'active',
+}
+
+function repoRule(overrides: Partial<RepoRule> = {}): RepoRule {
+  return { id: 1, repoOwner: 'acme', repoName: 'web', projectId: 1, createdAt: '', ...overrides }
+}
+
+function routingRule(overrides: Partial<RoutingRule> = {}): RoutingRule {
+  return {
+    id: 1, action: 'route', projectId: 1, projectName: 'Alpha', matchType: null,
+    matchReason: null, matchRepoOwner: null, matchRepoName: null, matchOrg: null,
+    createdAt: '', ...overrides,
+  }
+}
+
+function mockInvoke(opts: { repos?: RepoRule[]; routing?: RoutingRule[] } = {}): void {
+  invoke.mockImplementation((channel: string) => {
+    switch (channel) {
+      case 'repo-rules:list':
+        return Promise.resolve(opts.repos ?? [])
+      case 'routing-rules:list':
+        return Promise.resolve(opts.routing ?? [])
+      case 'projects:list':
+        return Promise.resolve([project])
+      case 'repo-rules:delete':
+      case 'routing-rules:delete':
+      case 'repo-rules:create':
+      case 'routing-rules:create':
+        return Promise.resolve(undefined)
+      case 'routing-rules:apply-to-inbox':
+        return Promise.resolve({ matched: 2 })
+      default:
+        return Promise.resolve(undefined)
+    }
+  })
+}
+
+describe('RulesView', () => {
+  it('renders the three rule sections', async () => {
+    mockInvoke()
+    render(<RulesView onClose={vi.fn()} />)
+    expect(await screen.findByText('Repo defaults')).toBeTruthy()
+    expect(screen.getByText('Route rules')).toBeTruthy()
+    expect(screen.getByText('Filters')).toBeTruthy()
+  })
+
+  it('lists route/suppress rules in evaluation order with an order number', async () => {
+    mockInvoke({
+      routing: [
+        routingRule({ id: 1, action: 'route', matchType: 'PullRequest', createdAt: '2026-01-01' }),
+        routingRule({ id: 2, action: 'route', matchType: 'Issue', createdAt: '2026-01-02' }),
+        routingRule({ id: 3, action: 'suppress', projectId: null, projectName: null, matchReason: 'ci_activity', createdAt: '2026-01-03' }),
+      ],
+    })
+    render(<RulesView onClose={vi.fn()} />)
+    // Two route rules numbered 1 and 2; the suppress rule renders under Filters numbered 1.
+    expect(await screen.findByText('PullRequest')).toBeTruthy()
+    expect(screen.getByText('Issue')).toBeTruthy()
+    expect(screen.getByText('ci_activity')).toBeTruthy()
+    // Route target shown for route rules.
+    expect(screen.getAllByText('→ Alpha').length).toBe(2)
+  })
+
+  it('maps a repo rule to its project name', async () => {
+    mockInvoke({ repos: [repoRule({ repoOwner: 'acme', repoName: 'web', projectId: 1 })] })
+    render(<RulesView onClose={vi.fn()} />)
+    expect(await screen.findByText('acme/web')).toBeTruthy()
+    expect(screen.getByText('→ Alpha')).toBeTruthy()
+  })
+
+  it('blocks creating a filter with no conditions and shows an error', async () => {
+    mockInvoke()
+    render(<RulesView onClose={vi.fn()} />)
+    // Open the Filters add form (the last "Add" button).
+    const addButtons = await screen.findAllByRole('button', { name: 'Add' })
+    fireEvent.click(addButtons[addButtons.length - 1])
+    fireEvent.click(screen.getByRole('button', { name: 'Create rule' }))
+    expect(await screen.findByText(/at least one condition/i)).toBeTruthy()
+    // No create IPC fired.
+    expect(invoke).not.toHaveBeenCalledWith('routing-rules:create', expect.anything())
+  })
+
+  it('creates a suppress rule from a single condition', async () => {
+    mockInvoke()
+    render(<RulesView onClose={vi.fn()} />)
+    const addButtons = await screen.findAllByRole('button', { name: 'Add' })
+    fireEvent.click(addButtons[addButtons.length - 1])
+    fireEvent.change(screen.getByLabelText('Reason'), { target: { value: 'ci_activity' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Create rule' }))
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith('routing-rules:create', {
+        action: 'suppress',
+        projectId: undefined,
+        matchType: undefined,
+        matchReason: 'ci_activity',
+        matchRepoOwner: undefined,
+        matchRepoName: undefined,
+        matchOrg: undefined,
+      })
+    })
+  })
+
+  it('deletes a repo rule via IPC', async () => {
+    mockInvoke({ repos: [repoRule({ id: 42 })] })
+    render(<RulesView onClose={vi.fn()} />)
+    const row = (await screen.findByText('acme/web')).closest('div') as HTMLElement
+    fireEvent.click(within(row).getByRole('button', { name: 'Delete rule' }))
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith('repo-rules:delete', 42)
+    })
+  })
+
+  it('applies route rules to the inbox and reports the count', async () => {
+    mockInvoke({ routing: [routingRule({ id: 1, action: 'route', matchType: 'PullRequest' })] })
+    render(<RulesView onClose={vi.fn()} />)
+    fireEvent.click(await screen.findByRole('button', { name: /Apply to inbox now/ }))
+    expect(await screen.findByText(/Routed 2 threads/)).toBeTruthy()
+  })
+})

--- a/src/renderer/src/pages/RulesView.tsx
+++ b/src/renderer/src/pages/RulesView.tsx
@@ -86,6 +86,7 @@ export function RulesView({ onClose, onRulesChanged }: RulesViewProps): JSX.Elem
   const [projects, setProjects] = useState<Project[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const [applyResult, setApplyResult] = useState<string | null>(null)
+  const [isApplying, setIsApplying] = useState(false)
   const mountedRef = useRef(true)
 
   useEffect(() => {
@@ -128,6 +129,8 @@ export function RulesView({ onClose, onRulesChanged }: RulesViewProps): JSX.Elem
   const suppressRules = routingRules.filter((r) => r.action === 'suppress')
 
   const afterMutation = useCallback(async (): Promise<void> => {
+    // A rule change can invalidate a prior "Routed N threads" message, so clear it.
+    setApplyResult(null)
     await load()
     onRulesChanged?.()
   }, [load, onRulesChanged])
@@ -164,10 +167,15 @@ export function RulesView({ onClose, onRulesChanged }: RulesViewProps): JSX.Elem
                 <button
                   type="button"
                   className={styles.secondaryButton}
+                  disabled={isApplying}
                   onClick={() => {
+                    if (isApplying) return
+                    setIsApplying(true)
                     void (async () => {
                       try {
                         const result = await window.electron.ipc.invoke('routing-rules:apply-to-inbox')
+                        // Reload first (which clears any prior message), then show the fresh count.
+                        await afterMutation()
                         if (mountedRef.current) {
                           setApplyResult(
                             result.matched === 0
@@ -175,14 +183,15 @@ export function RulesView({ onClose, onRulesChanged }: RulesViewProps): JSX.Elem
                               : `Routed ${result.matched} thread${result.matched === 1 ? '' : 's'}.`,
                           )
                         }
-                        await afterMutation()
                       } catch (err) {
                         console.error('[Rules] apply-to-inbox failed:', err)
+                      } finally {
+                        if (mountedRef.current) setIsApplying(false)
                       }
                     })()
                   }}
                 >
-                  Apply to inbox now
+                  {isApplying ? 'Applying…' : 'Apply to inbox now'}
                 </button>
               }
               footerNote={applyResult}
@@ -191,7 +200,7 @@ export function RulesView({ onClose, onRulesChanged }: RulesViewProps): JSX.Elem
               action="suppress"
               icon={EyeOff}
               heading="Filters"
-              description="Read-time filters. Threads matching a filter are hidden from the inbox and every project view."
+              description="Read-time filters. Threads matching a filter are hidden from the inbox and each project's notification list."
               rules={suppressRules}
               projects={projects}
               onChanged={afterMutation}
@@ -428,8 +437,8 @@ function RoutingRuleSection({
           <span className={styles.ruleOrder}>{i + 1}</span>
           <Icon icon={icon} size={15} className={styles.ruleIcon} />
           <span className={styles.ruleText}>{describeConditions(rule)}</span>
-          {action === 'route' && rule.projectName && (
-            <span className={styles.ruleTarget}>→ {rule.projectName}</span>
+          {action === 'route' && (
+            <span className={styles.ruleTarget}>→ {rule.projectName ?? `#${rule.projectId ?? '?'}`}</span>
           )}
           <button
             type="button"

--- a/src/renderer/src/pages/RulesView.tsx
+++ b/src/renderer/src/pages/RulesView.tsx
@@ -1,0 +1,483 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { ArrowLeft, Trash2, Plus, X, FolderInput, EyeOff, ArrowRightLeft } from 'lucide-react'
+import type { NotificationType, Project, RepoRule, RoutingRule } from '@shared/ipc-channels'
+import { Icon } from '../components/Icon'
+import {
+  type RuleConditionInput,
+  EMPTY_CONDITION,
+  buildRoutingPayload,
+  validateRepoRule,
+  describeConditions,
+} from './rulesForm'
+import styles from './RulesView.module.css'
+
+const NOTIFICATION_TYPES: NotificationType[] = [
+  'PullRequest',
+  'Issue',
+  'Release',
+  'Discussion',
+  'Commit',
+  'CheckSuite',
+]
+
+interface RulesViewProps {
+  onClose: () => void
+  /** Called after a mutation so the rest of the app (inbox counts, rail) can refresh. */
+  onRulesChanged?: () => void
+}
+
+function ConditionFields({
+  value,
+  onChange,
+}: {
+  value: RuleConditionInput
+  onChange: (v: RuleConditionInput) => void
+}): JSX.Element {
+  return (
+    <div className={styles.conditionGrid}>
+      <select
+        className={styles.input}
+        value={value.matchType}
+        onChange={(e) => onChange({ ...value, matchType: e.target.value })}
+        aria-label="Notification type"
+      >
+        <option value="">Any type</option>
+        {NOTIFICATION_TYPES.map((t) => (
+          <option key={t} value={t}>
+            {t}
+          </option>
+        ))}
+      </select>
+      <input
+        className={styles.input}
+        placeholder="Reason (e.g. review_requested)"
+        value={value.matchReason}
+        onChange={(e) => onChange({ ...value, matchReason: e.target.value })}
+        aria-label="Reason"
+      />
+      <input
+        className={styles.input}
+        placeholder="Repo owner"
+        value={value.matchRepoOwner}
+        onChange={(e) => onChange({ ...value, matchRepoOwner: e.target.value })}
+        aria-label="Repo owner"
+      />
+      <input
+        className={styles.input}
+        placeholder="Repo name"
+        value={value.matchRepoName}
+        onChange={(e) => onChange({ ...value, matchRepoName: e.target.value })}
+        aria-label="Repo name"
+      />
+      <input
+        className={styles.input}
+        placeholder="Org contains…"
+        value={value.matchOrg}
+        onChange={(e) => onChange({ ...value, matchOrg: e.target.value })}
+        aria-label="Org contains"
+      />
+    </div>
+  )
+}
+
+export function RulesView({ onClose, onRulesChanged }: RulesViewProps): JSX.Element {
+  const [repoRules, setRepoRules] = useState<RepoRule[]>([])
+  const [routingRules, setRoutingRules] = useState<RoutingRule[]>([])
+  const [projects, setProjects] = useState<Project[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [applyResult, setApplyResult] = useState<string | null>(null)
+  const mountedRef = useRef(true)
+
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+    }
+  }, [])
+
+  const load = useCallback(async () => {
+    try {
+      const [repos, routing, projectList] = await Promise.all([
+        window.electron.ipc.invoke('repo-rules:list'),
+        window.electron.ipc.invoke('routing-rules:list'),
+        window.electron.ipc.invoke('projects:list'),
+      ])
+      if (!mountedRef.current) return
+      setRepoRules(repos)
+      setRoutingRules(routing)
+      // listProjects already excludes soft-deleted projects; both active and
+      // snoozed are valid route targets (routing to a notification-snoozed project wakes it).
+      setProjects(projectList)
+    } catch (err) {
+      console.error('[Rules] load failed:', err)
+    } finally {
+      if (mountedRef.current) setIsLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void load()
+  }, [load])
+
+  const projectName = useCallback(
+    (id: number): string => projects.find((p) => p.id === id)?.name ?? `#${id}`,
+    [projects],
+  )
+
+  const routeRules = routingRules.filter((r) => r.action === 'route')
+  const suppressRules = routingRules.filter((r) => r.action === 'suppress')
+
+  const afterMutation = useCallback(async (): Promise<void> => {
+    await load()
+    onRulesChanged?.()
+  }, [load, onRulesChanged])
+
+  return (
+    <main className={styles.main}>
+      <header className={styles.toolbar}>
+        <button type="button" className={styles.back} onClick={onClose} aria-label="Back to focus">
+          <Icon icon={ArrowLeft} size={16} />
+        </button>
+        <span className={styles.title}>Notification rules</span>
+      </header>
+
+      <div className={styles.content}>
+        {isLoading ? (
+          <div className={styles.empty}>Loading…</div>
+        ) : (
+          <>
+            <RepoRuleSection
+              rules={repoRules}
+              projects={projects}
+              projectName={projectName}
+              onChanged={afterMutation}
+            />
+            <RoutingRuleSection
+              action="route"
+              icon={ArrowRightLeft}
+              heading="Route rules"
+              description="Ordered matchers. When you apply them, the first rule that matches an inbox thread wins and moves it to a project."
+              rules={routeRules}
+              projects={projects}
+              onChanged={afterMutation}
+              footer={
+                <button
+                  type="button"
+                  className={styles.secondaryButton}
+                  onClick={() => {
+                    void (async () => {
+                      try {
+                        const result = await window.electron.ipc.invoke('routing-rules:apply-to-inbox')
+                        if (mountedRef.current) {
+                          setApplyResult(
+                            result.matched === 0
+                              ? 'No inbox threads matched.'
+                              : `Routed ${result.matched} thread${result.matched === 1 ? '' : 's'}.`,
+                          )
+                        }
+                        await afterMutation()
+                      } catch (err) {
+                        console.error('[Rules] apply-to-inbox failed:', err)
+                      }
+                    })()
+                  }}
+                >
+                  Apply to inbox now
+                </button>
+              }
+              footerNote={applyResult}
+            />
+            <RoutingRuleSection
+              action="suppress"
+              icon={EyeOff}
+              heading="Filters"
+              description="Read-time filters. Threads matching a filter are hidden from the inbox and every project view."
+              rules={suppressRules}
+              projects={projects}
+              onChanged={afterMutation}
+            />
+          </>
+        )}
+      </div>
+    </main>
+  )
+}
+
+// ── Repo rules ────────────────────────────────────────────────────────────────
+
+function RepoRuleSection({
+  rules,
+  projects,
+  projectName,
+  onChanged,
+}: {
+  rules: RepoRule[]
+  projects: Project[]
+  projectName: (id: number) => string
+  onChanged: () => Promise<void>
+}): JSX.Element {
+  const [adding, setAdding] = useState(false)
+  const [owner, setOwner] = useState('')
+  const [name, setName] = useState('')
+  const [projectId, setProjectId] = useState<number | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const reset = (): void => {
+    setOwner('')
+    setName('')
+    setProjectId(null)
+    setError(null)
+    setAdding(false)
+  }
+
+  const submit = (): void => {
+    const validation = validateRepoRule(owner, name, projectId)
+    if (!validation.ok) {
+      setError(validation.error)
+      return
+    }
+    void (async () => {
+      try {
+        await window.electron.ipc.invoke('repo-rules:create', owner.trim(), name.trim(), projectId as number)
+        reset()
+        await onChanged()
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Could not create the rule.')
+      }
+    })()
+  }
+
+  const remove = (id: number): void => {
+    void (async () => {
+      try {
+        await window.electron.ipc.invoke('repo-rules:delete', id)
+        await onChanged()
+      } catch (err) {
+        console.error('[Rules] delete repo rule failed:', err)
+      }
+    })()
+  }
+
+  return (
+    <section className={styles.section}>
+      <div className={styles.sectionHead}>
+        <div>
+          <h2 className={styles.sectionTitle}>Repo defaults</h2>
+          <p className={styles.sectionDesc}>
+            New notifications from a repo are assigned to a project automatically at sync time.
+          </p>
+        </div>
+        {!adding && (
+          <button type="button" className={styles.addButton} onClick={() => setAdding(true)}>
+            <Icon icon={Plus} size={14} />
+            Add
+          </button>
+        )}
+      </div>
+
+      {rules.length === 0 && !adding && <div className={styles.emptyRow}>No repo defaults yet.</div>}
+
+      {rules.map((rule) => (
+        <div key={rule.id} className={styles.ruleRow}>
+          <Icon icon={FolderInput} size={15} className={styles.ruleIcon} />
+          <span className={styles.ruleText}>
+            {rule.repoOwner}/{rule.repoName}
+          </span>
+          <span className={styles.ruleTarget}>→ {projectName(rule.projectId)}</span>
+          <button
+            type="button"
+            className={styles.deleteButton}
+            onClick={() => remove(rule.id)}
+            aria-label="Delete rule"
+          >
+            <Icon icon={Trash2} size={14} />
+          </button>
+        </div>
+      ))}
+
+      {adding && (
+        <div className={styles.addForm}>
+          <div className={styles.repoRow}>
+            <input
+              className={styles.input}
+              placeholder="Repo owner"
+              value={owner}
+              onChange={(e) => setOwner(e.target.value)}
+              aria-label="Repo owner"
+            />
+            <input
+              className={styles.input}
+              placeholder="Repo name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              aria-label="Repo name"
+            />
+            <select
+              className={styles.input}
+              value={projectId ?? ''}
+              onChange={(e) => setProjectId(e.target.value ? Number(e.target.value) : null)}
+              aria-label="Project"
+            >
+              <option value="">Route to…</option>
+              {projects.map((p) => (
+                <option key={p.id} value={p.id}>
+                  {p.name}
+                </option>
+              ))}
+            </select>
+          </div>
+          {error && <span className={styles.error}>{error}</span>}
+          <div className={styles.formActions}>
+            <button type="button" className={styles.primaryButton} onClick={submit}>
+              Create rule
+            </button>
+            <button type="button" className={styles.ghostButton} onClick={reset} aria-label="Cancel">
+              <Icon icon={X} size={14} />
+            </button>
+          </div>
+        </div>
+      )}
+    </section>
+  )
+}
+
+// ── Route / suppress rules ──────────────────────────────────────────────────────
+
+function RoutingRuleSection({
+  action,
+  icon,
+  heading,
+  description,
+  rules,
+  projects,
+  onChanged,
+  footer,
+  footerNote,
+}: {
+  action: 'route' | 'suppress'
+  icon: typeof EyeOff
+  heading: string
+  description: string
+  rules: RoutingRule[]
+  projects: Project[]
+  onChanged: () => Promise<void>
+  footer?: JSX.Element
+  footerNote?: string | null
+}): JSX.Element {
+  const [adding, setAdding] = useState(false)
+  const [condition, setCondition] = useState<RuleConditionInput>(EMPTY_CONDITION)
+  const [projectId, setProjectId] = useState<number | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const reset = (): void => {
+    setCondition(EMPTY_CONDITION)
+    setProjectId(null)
+    setError(null)
+    setAdding(false)
+  }
+
+  const submit = (): void => {
+    const result = buildRoutingPayload(action, condition, projectId)
+    if (!result.ok) {
+      setError(result.error)
+      return
+    }
+    void (async () => {
+      try {
+        await window.electron.ipc.invoke('routing-rules:create', result.payload)
+        reset()
+        await onChanged()
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Could not create the rule.')
+      }
+    })()
+  }
+
+  const remove = (id: number): void => {
+    void (async () => {
+      try {
+        await window.electron.ipc.invoke('routing-rules:delete', id)
+        await onChanged()
+      } catch (err) {
+        console.error('[Rules] delete routing rule failed:', err)
+      }
+    })()
+  }
+
+  return (
+    <section className={styles.section}>
+      <div className={styles.sectionHead}>
+        <div>
+          <h2 className={styles.sectionTitle}>{heading}</h2>
+          <p className={styles.sectionDesc}>{description}</p>
+        </div>
+        {!adding && (
+          <button type="button" className={styles.addButton} onClick={() => setAdding(true)}>
+            <Icon icon={Plus} size={14} />
+            Add
+          </button>
+        )}
+      </div>
+
+      {rules.length === 0 && !adding && (
+        <div className={styles.emptyRow}>No {action === 'route' ? 'route rules' : 'filters'} yet.</div>
+      )}
+
+      {rules.map((rule, i) => (
+        <div key={rule.id} className={styles.ruleRow}>
+          <span className={styles.ruleOrder}>{i + 1}</span>
+          <Icon icon={icon} size={15} className={styles.ruleIcon} />
+          <span className={styles.ruleText}>{describeConditions(rule)}</span>
+          {action === 'route' && rule.projectName && (
+            <span className={styles.ruleTarget}>→ {rule.projectName}</span>
+          )}
+          <button
+            type="button"
+            className={styles.deleteButton}
+            onClick={() => remove(rule.id)}
+            aria-label="Delete rule"
+          >
+            <Icon icon={Trash2} size={14} />
+          </button>
+        </div>
+      ))}
+
+      {adding && (
+        <div className={styles.addForm}>
+          <ConditionFields value={condition} onChange={setCondition} />
+          {action === 'route' && (
+            <select
+              className={styles.input}
+              value={projectId ?? ''}
+              onChange={(e) => setProjectId(e.target.value ? Number(e.target.value) : null)}
+              aria-label="Project"
+            >
+              <option value="">Route to…</option>
+              {projects.map((p) => (
+                <option key={p.id} value={p.id}>
+                  {p.name}
+                </option>
+              ))}
+            </select>
+          )}
+          {error && <span className={styles.error}>{error}</span>}
+          <div className={styles.formActions}>
+            <button type="button" className={styles.primaryButton} onClick={submit}>
+              Create rule
+            </button>
+            <button type="button" className={styles.ghostButton} onClick={reset} aria-label="Cancel">
+              <Icon icon={X} size={14} />
+            </button>
+          </div>
+        </div>
+      )}
+
+      {(footer || footerNote) && (
+        <div className={styles.sectionFooter}>
+          {footer}
+          {footerNote && <span className={styles.footerNote}>{footerNote}</span>}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/src/renderer/src/pages/RulesView.tsx
+++ b/src/renderer/src/pages/RulesView.tsx
@@ -130,7 +130,7 @@ export function RulesView({ onClose, onRulesChanged }: RulesViewProps): JSX.Elem
 
   const afterMutation = useCallback(async (): Promise<void> => {
     // A rule change can invalidate a prior "Routed N threads" message, so clear it.
-    setApplyResult(null)
+    if (mountedRef.current) setApplyResult(null)
     await load()
     onRulesChanged?.()
   }, [load, onRulesChanged])

--- a/src/renderer/src/pages/RulesView.tsx
+++ b/src/renderer/src/pages/RulesView.tsx
@@ -138,7 +138,7 @@ export function RulesView({ onClose, onRulesChanged }: RulesViewProps): JSX.Elem
   return (
     <main className={styles.main}>
       <header className={styles.toolbar}>
-        <button type="button" className={styles.back} onClick={onClose} aria-label="Back to focus">
+        <button type="button" className={styles.back} onClick={onClose} aria-label="Back to settings">
           <Icon icon={ArrowLeft} size={16} />
         </button>
         <span className={styles.title}>Notification rules</span>

--- a/src/renderer/src/pages/SettingsView.module.css
+++ b/src/renderer/src/pages/SettingsView.module.css
@@ -223,3 +223,28 @@
   color: var(--danger);
   font-size: 12px;
 }
+
+.linkRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  width: 100%;
+  padding: 4px 0;
+  background: none;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+}
+
+.linkRowValue {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 13px;
+  color: var(--text-2);
+}
+
+.linkRow:hover .linkRowValue {
+  color: var(--text);
+}

--- a/src/renderer/src/pages/SettingsView.tsx
+++ b/src/renderer/src/pages/SettingsView.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { ArrowLeft } from 'lucide-react'
+import { ArrowLeft, ChevronRight } from 'lucide-react'
 import { Icon } from '../components/Icon'
 import { useAuth } from '../hooks/useAuth'
 import {
@@ -23,6 +23,7 @@ import styles from './SettingsView.module.css'
 interface SettingsViewProps {
   theme: UseThemeResult
   onClose: () => void
+  onOpenRules: () => void
 }
 
 function Segmented<T extends string>({
@@ -51,7 +52,7 @@ function Segmented<T extends string>({
   )
 }
 
-export function SettingsView({ theme, onClose }: SettingsViewProps): JSX.Element {
+export function SettingsView({ theme, onClose, onOpenRules }: SettingsViewProps): JSX.Element {
   const auth = useAuth()
   const [token, setToken] = useState('')
   const [syncInterval, setSyncInterval] = useState<SyncIntervalMinutes | null>(null)
@@ -201,6 +202,13 @@ export function SettingsView({ theme, onClose }: SettingsViewProps): JSX.Element
               ))}
             </select>
           </div>
+          <button type="button" className={styles.linkRow} onClick={onOpenRules}>
+            <span className={styles.label}>Notification rules</span>
+            <span className={styles.linkRowValue}>
+              Route &amp; filter
+              <Icon icon={ChevronRight} size={16} />
+            </span>
+          </button>
         </section>
       </div>
     </main>

--- a/src/renderer/src/pages/rulesForm.test.ts
+++ b/src/renderer/src/pages/rulesForm.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest'
+import {
+  EMPTY_CONDITION,
+  hasAnyCondition,
+  buildRoutingPayload,
+  validateRepoRule,
+  describeConditions,
+} from './rulesForm'
+
+describe('hasAnyCondition', () => {
+  it('is false for an empty condition', () => {
+    expect(hasAnyCondition(EMPTY_CONDITION)).toBe(false)
+  })
+
+  it('ignores whitespace-only values', () => {
+    expect(hasAnyCondition({ ...EMPTY_CONDITION, matchReason: '   ' })).toBe(false)
+  })
+
+  it('is true when any field has content', () => {
+    expect(hasAnyCondition({ ...EMPTY_CONDITION, matchOrg: 'acme' })).toBe(true)
+  })
+})
+
+describe('buildRoutingPayload', () => {
+  it('rejects a rule with no conditions', () => {
+    const result = buildRoutingPayload('suppress', EMPTY_CONDITION, null)
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error).toMatch(/at least one condition/i)
+  })
+
+  it('rejects a route rule with no project', () => {
+    const result = buildRoutingPayload('route', { ...EMPTY_CONDITION, matchType: 'PullRequest' }, null)
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error).toMatch(/project/i)
+  })
+
+  it('trims values and omits empty ones', () => {
+    const result = buildRoutingPayload(
+      'suppress',
+      { ...EMPTY_CONDITION, matchType: ' PullRequest ', matchReason: '  ' },
+      null,
+    )
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.payload).toEqual({
+        action: 'suppress',
+        projectId: undefined,
+        matchType: 'PullRequest',
+        matchReason: undefined,
+        matchRepoOwner: undefined,
+        matchRepoName: undefined,
+        matchOrg: undefined,
+      })
+    }
+  })
+
+  it('includes the project id for a valid route rule', () => {
+    const result = buildRoutingPayload('route', { ...EMPTY_CONDITION, matchOrg: 'acme' }, 7)
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.payload.action).toBe('route')
+      expect(result.payload.projectId).toBe(7)
+      expect(result.payload.matchOrg).toBe('acme')
+    }
+  })
+})
+
+describe('validateRepoRule', () => {
+  it('requires owner and name', () => {
+    expect(validateRepoRule('', 'repo', 1).ok).toBe(false)
+    expect(validateRepoRule('owner', '  ', 1).ok).toBe(false)
+  })
+
+  it('requires a project', () => {
+    expect(validateRepoRule('owner', 'repo', null).ok).toBe(false)
+  })
+
+  it('accepts a complete rule', () => {
+    expect(validateRepoRule('owner', 'repo', 1).ok).toBe(true)
+  })
+})
+
+describe('describeConditions', () => {
+  const base = {
+    matchType: null,
+    matchReason: null,
+    matchRepoOwner: null,
+    matchRepoName: null,
+    matchOrg: null,
+  }
+
+  it('summarizes an empty rule as "any thread"', () => {
+    expect(describeConditions(base)).toBe('any thread')
+  })
+
+  it('joins the set conditions in a stable order', () => {
+    expect(
+      describeConditions({
+        ...base,
+        matchType: 'PullRequest',
+        matchReason: 'review_requested',
+        matchRepoOwner: 'acme',
+      }),
+    ).toBe('PullRequest · review_requested · acme/*')
+  })
+
+  it('renders an org-only rule', () => {
+    expect(describeConditions({ ...base, matchOrg: 'acme' })).toBe('org~acme')
+  })
+})

--- a/src/renderer/src/pages/rulesForm.ts
+++ b/src/renderer/src/pages/rulesForm.ts
@@ -1,0 +1,104 @@
+import type { CreateRoutingRulePayload, RoutingRuleAction } from '@shared/ipc-channels'
+
+/** The five match dimensions a route/suppress rule can condition on (AND semantics). */
+export interface RuleConditionInput {
+  matchType: string
+  matchReason: string
+  matchRepoOwner: string
+  matchRepoName: string
+  matchOrg: string
+}
+
+export const EMPTY_CONDITION: RuleConditionInput = {
+  matchType: '',
+  matchReason: '',
+  matchRepoOwner: '',
+  matchRepoName: '',
+  matchOrg: '',
+}
+
+/** True when at least one condition field has a non-whitespace value. */
+export function hasAnyCondition(input: RuleConditionInput): boolean {
+  return (
+    input.matchType.trim().length > 0 ||
+    input.matchReason.trim().length > 0 ||
+    input.matchRepoOwner.trim().length > 0 ||
+    input.matchRepoName.trim().length > 0 ||
+    input.matchOrg.trim().length > 0
+  )
+}
+
+type BuildResult =
+  | { ok: true; payload: CreateRoutingRulePayload }
+  | { ok: false; error: string }
+
+function normalize(value: string): string | undefined {
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : undefined
+}
+
+/**
+ * Validates + builds a create payload for a route/suppress rule. Mirrors the
+ * main-process guard (`createRoutingRule`) so the UI can fail fast with a clear
+ * message instead of round-tripping to an IPC throw.
+ */
+export function buildRoutingPayload(
+  action: RoutingRuleAction,
+  input: RuleConditionInput,
+  projectId: number | null,
+): BuildResult {
+  if (!hasAnyCondition(input)) {
+    return { ok: false, error: 'Add at least one condition.' }
+  }
+  if (action === 'route' && projectId === null) {
+    return { ok: false, error: 'Choose a project to route to.' }
+  }
+  return {
+    ok: true,
+    payload: {
+      action,
+      projectId: action === 'route' ? (projectId ?? undefined) : undefined,
+      matchType: normalize(input.matchType),
+      matchReason: normalize(input.matchReason),
+      matchRepoOwner: normalize(input.matchRepoOwner),
+      matchRepoName: normalize(input.matchRepoName),
+      matchOrg: normalize(input.matchOrg),
+    },
+  }
+}
+
+/** Validates a repo → project default rule. */
+export function validateRepoRule(
+  owner: string,
+  name: string,
+  projectId: number | null,
+): { ok: true } | { ok: false; error: string } {
+  if (owner.trim().length === 0 || name.trim().length === 0) {
+    return { ok: false, error: 'Enter both a repo owner and name.' }
+  }
+  if (projectId === null) {
+    return { ok: false, error: 'Choose a project.' }
+  }
+  return { ok: true }
+}
+
+/**
+ * A short human summary of a rule's conditions, e.g. "PullRequest · review_requested · acme/*".
+ * Used to render route/suppress rules in the list without a bespoke row per dimension.
+ */
+export function describeConditions(rule: {
+  matchType: string | null
+  matchReason: string | null
+  matchRepoOwner: string | null
+  matchRepoName: string | null
+  matchOrg: string | null
+}): string {
+  const parts: string[] = []
+  if (rule.matchType) parts.push(rule.matchType)
+  if (rule.matchReason) parts.push(rule.matchReason)
+  if (rule.matchRepoOwner || rule.matchRepoName) {
+    parts.push(`${rule.matchRepoOwner ?? '*'}/${rule.matchRepoName ?? '*'}`)
+  }
+  if (rule.matchOrg) parts.push(`org~${rule.matchOrg}`)
+  return parts.length > 0 ? parts.join(' · ') : 'any thread'
+}


### PR DESCRIPTION
Part of #70 (Cross-cutting milestone, epic #71). This is PR 1 of 2. It fills two genuine gaps found while assessing `main` - it does **not** rebuild the notification sync, routing/suppress backend, snooze mechanics, inbox, or settings that MVP A already shipped.

## What was already there vs. what this adds

**Already works on `main` (left untouched):** notification sync/prefetch off-thread, auto-close (merged PR / closed issue), unsubscribe write-back, the `repo_rules` + `routing_rules` (route/suppress) backend with full list/create/delete typed IPC, and `manual`/`date` snooze end-to-end.

**Genuine gaps this PR fills:**

1. **No management UI for any rule kind.** The backend exposed list/create/delete for repo rules, route rules, and suppress rules, but there was no surface to view or manage them (suppress/filter rules had no creation path at all). This was the deferral logged on #70. This PR adds a `RulesView` (renderer-only, over existing IPC - no backend change) with three clearly-labeled kinds:
   - **Repo defaults** - `repo_rules` (repo → project), applied at sync.
   - **Route rules** - `routing_rules action='route'`, multi-condition (type/reason/repoOwner/repoName/org, AND), **first-match-wins by creation order**, listed in evaluation order with an order number.
   - **Filters** - `routing_rules action='suppress'`, read-time hiding.
   - Reachable from Settings ("Notification rules") and the command palette.

2. **Notification-triggered snooze had no UI.** The `'notification'` `SnoozeMode` and its wake path were already implemented and integration-tested, but nothing in the renderer ever set that mode. Adds a "Snooze until a notification" affordance to the Focus project menu (`App.snoozeProject` widened from `'manual'|'date'` to `SnoozeMode`).

## Design decision: no in-place edit (deliberate)

Route/suppress rules are first-match-wins by `created_at`. An "edit" implemented as delete+recreate would move a rule to the end and silently change which rule fires first - a real precedence bug. So the UI ships **view / create / delete only**; changing a rule means delete + add (which appends), and the list shows evaluation order so that isn't a surprise. Drag-reordering is deferred (would need a backend `order` column). GPT-5.5 flagged the delete+recreate trap during plan review; this is the fix.

## How I verified it
- `tsc --noEmit` clean, `eslint src` clean.
- `vitest run src/renderer`: **62 passed** (10 files), including **20 new tests**:
  - `rulesForm.test.ts` - validation/normalization/summary helpers (12 cases).
  - `RulesView.test.tsx` - renders the three sections, lists route/suppress rules in evaluation order with order numbers, maps repo rules to project names, blocks a no-condition filter with an error (no IPC fired), creates a suppress rule from one condition, deletes a repo rule via IPC, applies route rules and reports the count, and shows a `#id` fallback for a route rule whose project is unnamed.
  - Updated `CommandPalette.test.tsx` for the new `onOpenRules` entry.
- `electron-vite build` succeeds (main + preload + renderer bundle clean).
- Full suite unchanged otherwise: the 9 `*.integration.test.ts` files still fail to import `bun:sqlite` under vitest's node runner - a pre-existing infra quirk documented in `vitest.config.ts`, not touched here (this PR is renderer-only, so the main-process integration tests are unaffected).
- **Not verified:** I did not run a live windowed Electron smoke / screenshots - no display or Electron GUI in this environment. The RTL tests render the real components and assert real create/delete/apply/validation behavior against mocked IPC, which covers the logic; the visual layer is CSS-only.

## Reviewer notes / known follow-up
- The rules list order and the evaluator both use `created_at ASC` (`listRoutingRules`, `listSuppressRules`, `applyRoutingRulesToInbox`), so displayed order matches evaluation order.
- **Badge-count consistency (follow-up, not in this PR):** `getUnreadCounts` (rail) is suppression-aware, but `listProjects.unreadCount` (the in-project Notifications tab badge) is a raw SQL count and isn't. Making it suppression-aware is a backend change to a hot count path, out of scope for this renderer-only PR. Filter copy is worded to match what suppress actually does today (hides from the inbox + each project's notification *list*).

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>