### PR TITLE
Cross-cutting (2/2): dim + high-contrast theme modes + FOUC bootstrap fix

### DIFF
--- a/src/renderer/public/theme-bootstrap.js
+++ b/src/renderer/public/theme-bootstrap.js
@@ -1,8 +1,33 @@
-// Apply theme before first paint to prevent flash of unstyled content
+// Apply the persisted theme to <html> before first paint to prevent a flash of
+// the wrong color mode. Must stay in sync with useTheme.ts (same storage keys,
+// same data-attributes, same system-resolution rule). Runtime updates are still
+// owned by useTheme; this only handles the very first paint.
 (function () {
-  var supportedThemes = ['light', 'dark', 'nord', 'dracula', 'night', 'dim', 'corporate', 'lemonade'];
-  var saved = localStorage.getItem('gh-projects-theme');
-  var systemTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-  var theme = supportedThemes.indexOf(saved) !== -1 ? saved : systemTheme;
-  document.documentElement.setAttribute('data-theme', theme);
+  try {
+    var COLOR_MODES = ['light', 'dark', 'dim', 'high-contrast', 'system'];
+    var ACCENTS = ['slate', 'blue', 'green', 'violet'];
+    var DENSITIES = ['compact', 'comfortable'];
+
+    function read(key, allowed, fallback) {
+      var v = localStorage.getItem(key);
+      return v && allowed.indexOf(v) !== -1 ? v : fallback;
+    }
+
+    var mode = read('focus-color-mode', COLOR_MODES, 'system');
+    var accent = read('focus-accent', ACCENTS, 'slate');
+    var density = read('focus-density', DENSITIES, 'compact');
+
+    // 'system' resolves to light/dark only; dim/high-contrast are explicit picks.
+    var resolved = mode;
+    if (mode === 'system') {
+      resolved = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    }
+
+    var el = document.documentElement;
+    el.setAttribute('data-color-mode', resolved);
+    el.setAttribute('data-accent', accent);
+    el.setAttribute('data-density', density);
+  } catch (e) {
+    // If storage is unavailable, fall back to the CSS default (dark) — no crash.
+  }
 })();

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -209,7 +209,7 @@ export function App(): JSX.Element {
       <Titlebar
         onOpenPalette={() => setPaletteOpen(true)}
         colorMode={theme.resolvedColorMode}
-        onToggleColorMode={() => theme.setColorMode(theme.resolvedColorMode === 'dark' ? 'light' : 'dark')}
+        onToggleColorMode={() => theme.setColorMode(theme.resolvedColorMode === 'light' ? 'dark' : 'light')}
         onOpenSettings={() => setView('settings')}
       />
 

--- a/src/renderer/src/components/Titlebar.tsx
+++ b/src/renderer/src/components/Titlebar.tsx
@@ -30,9 +30,9 @@ export function Titlebar({ onOpenPalette, colorMode, onToggleColorMode, onOpenSe
         <button type="button"
           className={styles.iconButton}
           onClick={onToggleColorMode}
-          aria-label={colorMode === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+          aria-label={colorMode === 'light' ? 'Switch to dark mode' : 'Switch to light mode'}
         >
-          <Icon icon={colorMode === 'dark' ? Sun : Moon} size={15} />
+          <Icon icon={colorMode === 'light' ? Moon : Sun} size={15} />
         </button>
         <button type="button" className={styles.iconButton} onClick={onOpenSettings} aria-label="Settings">
           <Icon icon={Settings} size={15} />

--- a/src/renderer/src/hooks/theme-bootstrap.test.ts
+++ b/src/renderer/src/hooks/theme-bootstrap.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { ACCENTS, COLOR_MODES, DENSITIES } from './useTheme'
+
+// The pre-paint bootstrap (public/theme-bootstrap.js) is a plain script that runs
+// before the module bundle, so it can't import from useTheme. This guards against
+// the two drifting apart: every allowed value + storage key useTheme relies on must
+// also be present in the bootstrap, or first paint will use the wrong attributes.
+const source = readFileSync(resolve(process.cwd(), 'src/renderer/public/theme-bootstrap.js'), 'utf8')
+
+describe('theme-bootstrap parity with useTheme', () => {
+  it('references the same localStorage keys', () => {
+    for (const key of ['focus-color-mode', 'focus-accent', 'focus-density']) {
+      expect(source).toContain(key)
+    }
+  })
+
+  it('allows every color mode useTheme allows', () => {
+    for (const mode of COLOR_MODES) {
+      expect(source).toContain(`'${mode}'`)
+    }
+  })
+
+  it('allows every accent and density useTheme allows', () => {
+    for (const value of [...ACCENTS, ...DENSITIES]) {
+      expect(source).toContain(`'${value}'`)
+    }
+  })
+
+  it('resolves system via prefers-color-scheme and sets the real attributes', () => {
+    expect(source).toContain('prefers-color-scheme: dark')
+    expect(source).toContain('data-color-mode')
+    expect(source).toContain('data-accent')
+    expect(source).toContain('data-density')
+  })
+})

--- a/src/renderer/src/hooks/useTheme.test.ts
+++ b/src/renderer/src/hooks/useTheme.test.ts
@@ -75,6 +75,27 @@ describe('useTheme', () => {
     expect(document.documentElement.getAttribute('data-color-mode')).toBe('light')
   })
 
+  it.each(['dim', 'high-contrast'] as const)(
+    'treats %s as an explicit resolved mode (not system-resolved)',
+    (mode) => {
+      stubMatchMedia(false) // system would resolve to light; explicit mode must win
+      const { result } = renderHook(() => useTheme())
+      act(() => result.current.setColorMode(mode))
+      expect(result.current.colorMode).toBe(mode)
+      expect(result.current.resolvedColorMode).toBe(mode)
+      expect(localStorage.getItem('focus-color-mode')).toBe(mode)
+      expect(document.documentElement.getAttribute('data-color-mode')).toBe(mode)
+    },
+  )
+
+  it('reads a stored dim mode on mount', () => {
+    localStorage.setItem('focus-color-mode', 'dim')
+    const { result } = renderHook(() => useTheme())
+    expect(result.current.colorMode).toBe('dim')
+    expect(result.current.resolvedColorMode).toBe('dim')
+    expect(document.documentElement.getAttribute('data-color-mode')).toBe('dim')
+  })
+
   it('setAccent persists and updates the data-accent attribute', () => {
     const { result } = renderHook(() => useTheme())
     act(() => result.current.setAccent('blue'))

--- a/src/renderer/src/hooks/useTheme.ts
+++ b/src/renderer/src/hooks/useTheme.ts
@@ -1,13 +1,22 @@
 import { useCallback, useEffect, useState } from 'react'
 
-export type ColorMode = 'light' | 'dark' | 'system'
-export type ResolvedColorMode = 'light' | 'dark'
+export type ColorMode = 'light' | 'dark' | 'dim' | 'high-contrast' | 'system'
+export type ResolvedColorMode = 'light' | 'dark' | 'dim' | 'high-contrast'
 export type Accent = 'slate' | 'blue' | 'green' | 'violet'
 export type Density = 'compact' | 'comfortable'
 
 export const ACCENTS: Accent[] = ['slate', 'blue', 'green', 'violet']
-export const COLOR_MODES: ColorMode[] = ['light', 'dark', 'system']
+export const COLOR_MODES: ColorMode[] = ['system', 'light', 'dark', 'dim', 'high-contrast']
 export const DENSITIES: Density[] = ['compact', 'comfortable']
+
+/** Human-readable label for a color mode (e.g. 'high-contrast' → 'High contrast'). */
+export const COLOR_MODE_LABELS: Record<ColorMode, string> = {
+  system: 'System',
+  light: 'Light',
+  dark: 'Dark',
+  dim: 'Dim',
+  'high-contrast': 'High contrast',
+}
 
 const COLOR_MODE_KEY = 'focus-color-mode'
 const ACCENT_KEY = 'focus-accent'

--- a/src/renderer/src/pages/SettingsView.test.tsx
+++ b/src/renderer/src/pages/SettingsView.test.tsx
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { SettingsView } from './SettingsView'
+import type { UseThemeResult } from '../hooks/useTheme'
+
+const invoke = vi.fn()
+
+beforeEach(() => {
+  invoke.mockReset()
+  invoke.mockImplementation((channel: string) => {
+    switch (channel) {
+      case 'auth:status':
+        return Promise.resolve({ authenticated: false })
+      case 'settings:get-sync-interval':
+        return Promise.resolve(15)
+      case 'settings:get-max-sync-days':
+        return Promise.resolve(7)
+      default:
+        return Promise.resolve(undefined)
+    }
+  })
+  ;(globalThis as unknown as { window: Window }).window.electron = {
+    ipc: { invoke },
+    openExternal: vi.fn(() => Promise.resolve()),
+  } as unknown as Window['electron']
+})
+
+function theme(overrides: Partial<UseThemeResult> = {}): UseThemeResult {
+  return {
+    colorMode: 'system',
+    resolvedColorMode: 'dark',
+    setColorMode: vi.fn(),
+    accent: 'slate',
+    setAccent: vi.fn(),
+    density: 'compact',
+    setDensity: vi.fn(),
+    ...overrides,
+  }
+}
+
+describe('SettingsView appearance', () => {
+  it('offers all five color modes including dim and high contrast', async () => {
+    render(<SettingsView theme={theme()} onClose={vi.fn()} onOpenRules={vi.fn()} />)
+    const select = (await screen.findByLabelText('Color mode')) as HTMLSelectElement
+    const options = Array.from(select.options).map((o) => o.textContent)
+    expect(options).toEqual(['System', 'Light', 'Dark', 'Dim', 'High contrast'])
+  })
+
+  it('applies a selected color mode via the theme hook', async () => {
+    const setColorMode = vi.fn()
+    render(<SettingsView theme={theme({ setColorMode })} onClose={vi.fn()} onOpenRules={vi.fn()} />)
+    const select = await screen.findByLabelText('Color mode')
+    fireEvent.change(select, { target: { value: 'high-contrast' } })
+    await waitFor(() => expect(setColorMode).toHaveBeenCalledWith('high-contrast'))
+  })
+
+  it('opens the notification rules surface', async () => {
+    const onOpenRules = vi.fn()
+    render(<SettingsView theme={theme()} onClose={vi.fn()} onOpenRules={onOpenRules} />)
+    fireEvent.click(await screen.findByText('Notification rules'))
+    expect(onOpenRules).toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/pages/SettingsView.tsx
+++ b/src/renderer/src/pages/SettingsView.tsx
@@ -9,6 +9,7 @@ import {
   type UseThemeResult,
   ACCENTS,
   COLOR_MODES,
+  COLOR_MODE_LABELS,
   DENSITIES,
 } from '../hooks/useTheme'
 import {
@@ -101,7 +102,18 @@ export function SettingsView({ theme, onClose, onOpenRules }: SettingsViewProps)
           <h2 className={styles.sectionTitle}>Appearance</h2>
           <div className={styles.field}>
             <span className={styles.label}>Color mode</span>
-            <Segmented<ColorMode> options={COLOR_MODES} value={theme.colorMode} onChange={theme.setColorMode} />
+            <select
+              className={styles.select}
+              value={theme.colorMode}
+              onChange={(e) => theme.setColorMode(e.target.value as ColorMode)}
+              aria-label="Color mode"
+            >
+              {COLOR_MODES.map((mode) => (
+                <option key={mode} value={mode}>
+                  {COLOR_MODE_LABELS[mode]}
+                </option>
+              ))}
+            </select>
           </div>
           <div className={styles.field}>
             <span className={styles.label}>Accent</span>

--- a/src/renderer/src/theme/tokens.css
+++ b/src/renderer/src/theme/tokens.css
@@ -1,7 +1,7 @@
 /* ─────────────────────────────────────────────────────────────────────────────
    Focus design tokens — a lightweight, Primer-inspired system.
    Monochrome neutral ramp + one accent. Theming via data-attributes on <html>:
-     data-color-mode = "dark" | "light"   (resolved by useTheme; system-aware)
+     data-color-mode = "dark" | "light" | "dim" | "high-contrast"  (resolved by useTheme; system-aware)
      data-accent     = "slate" | "blue" | "green" | "violet"
      data-density    = "compact" | "comfortable"
    ───────────────────────────────────────────────────────────────────────────── */
@@ -32,6 +32,8 @@
 /* ── Dark palette (default) ──────────────────────────────────────────────────── */
 :root,
 [data-color-mode='dark'] {
+  color-scheme: dark;
+
   --bg-desktop: #05070a;
   --bg-window: #0d1117;
   --bg-rail: #0a0e13;
@@ -64,7 +66,8 @@
   --accent-text: #adbac7;
 }
 
-[data-color-mode='dark'][data-accent='blue'] {
+[data-color-mode='dark'][data-accent='blue'],
+[data-color-mode='dim'][data-accent='blue'] {
   --accent: #1f6feb;
   --accent-hover: #388bfd;
   --accent-fg: #fff;
@@ -73,7 +76,8 @@
   --accent-text: #58a6ff;
 }
 
-[data-color-mode='dark'][data-accent='green'] {
+[data-color-mode='dark'][data-accent='green'],
+[data-color-mode='dim'][data-accent='green'] {
   --accent: #238636;
   --accent-hover: #2ea043;
   --accent-fg: #fff;
@@ -82,7 +86,8 @@
   --accent-text: #3fb950;
 }
 
-[data-color-mode='dark'][data-accent='violet'] {
+[data-color-mode='dark'][data-accent='violet'],
+[data-color-mode='dim'][data-accent='violet'] {
   --accent: #8957e5;
   --accent-hover: #a371f7;
   --accent-fg: #fff;
@@ -93,6 +98,8 @@
 
 /* ── Light palette ───────────────────────────────────────────────────────────── */
 [data-color-mode='light'] {
+  color-scheme: light;
+
   --bg-desktop: #eaeef2;
   --bg-window: #ffffff;
   --bg-rail: #f6f8fa;
@@ -150,4 +157,108 @@
   --accent-subtle: rgba(130, 80, 223, 0.1);
   --accent-border: rgba(130, 80, 223, 0.4);
   --accent-text: #8250df;
+}
+
+/* ── Dim palette ─────────────────────────────────────────────────────────────────
+   A softer dark: lifted, desaturated backgrounds and gentler text so long sessions
+   are easier on the eyes. Accents are inherited from the dark family (selectors
+   above match [data-color-mode='dim'] too); only the neutral ramp changes here. */
+[data-color-mode='dim'] {
+  color-scheme: dark;
+
+  --bg-desktop: #1c2128;
+  --bg-window: #22272e;
+  --bg-rail: #1c2128;
+  --bg-subtle: #2d333b;
+  --bg-inset: #1c2128;
+  --bg-elevated: #323942;
+
+  --border: #444c56;
+  --border-muted: #373e47;
+  --border-subtle: rgba(205, 217, 229, 0.08);
+
+  --text: #cdd9e5;
+  --text-2: #909dab;
+  --text-3: #768390;
+
+  --success: #57ab5a;
+  --attention: #c69026;
+  --danger: #e5534b;
+  --info: #6cb6ff;
+  --violet: #b083f0;
+
+  --scrollbar-thumb: #454c56;
+
+  /* Accent — slate (default); blue/green/violet come from the dark accent rules. */
+  --accent: #616b78;
+  --accent-hover: #6f7a88;
+  --accent-fg: #f2f5f9;
+  --accent-subtle: rgba(124, 138, 158, 0.16);
+  --accent-border: rgba(124, 138, 158, 0.5);
+  --accent-text: #adbac7;
+}
+
+/* ── High-contrast palette ───────────────────────────────────────────────────────
+   Maximum legibility: near-black surfaces, near-white text, solid opaque borders,
+   and brighter accents. Targets WCAG AAA contrast for body text on the base surface. */
+[data-color-mode='high-contrast'] {
+  color-scheme: dark;
+
+  --bg-desktop: #000000;
+  --bg-window: #010409;
+  --bg-rail: #000000;
+  --bg-subtle: #0a0c10;
+  --bg-inset: #000000;
+  --bg-elevated: #151b23;
+
+  --border: #7a828e;
+  --border-muted: #525960;
+  --border-subtle: rgba(255, 255, 255, 0.2);
+
+  --text: #ffffff;
+  --text-2: #f0f3f6;
+  --text-3: #bdc4cc;
+
+  --success: #26cd4d;
+  --attention: #f0b72f;
+  --danger: #ff6a69;
+  --info: #71b7ff;
+  --violet: #cb9eff;
+
+  --scrollbar-thumb: #7a828e;
+
+  /* Accent — slate (default). High-contrast accents are defined per-accent below. */
+  --accent: #8f99a6;
+  --accent-hover: #adb6c2;
+  --accent-fg: #000000;
+  --accent-subtle: rgba(174, 185, 199, 0.24);
+  --accent-border: #adb6c2;
+  --accent-text: #f0f3f6;
+}
+
+[data-color-mode='high-contrast'][data-accent='blue'] {
+  --accent: #71b7ff;
+  --accent-hover: #91c9ff;
+  --accent-fg: #000000;
+  --accent-subtle: rgba(113, 183, 255, 0.24);
+  --accent-border: #91c9ff;
+  --accent-text: #91c9ff;
+}
+
+[data-color-mode='high-contrast'][data-accent='green'] {
+  --accent: #26cd4d;
+  --accent-hover: #4ae168;
+  --accent-fg: #000000;
+  --accent-subtle: rgba(38, 205, 77, 0.24);
+  --accent-border: #4ae168;
+  --accent-text: #4ae168;
+}
+
+[data-color-mode='high-contrast'][data-accent='violet'] {
+  --accent: #cb9eff;
+  --accent-hover: #dcbdff;
+  --accent-fg: #000000;
+  --accent-subtle: rgba(203, 158, 255, 0.24);
+  --accent-border: #dcbdff;
+  --accent-text: #dcbdff;
 }

--- a/src/renderer/src/theme/tokens.css
+++ b/src/renderer/src/theme/tokens.css
@@ -179,7 +179,7 @@
 
   --text: #cdd9e5;
   --text-2: #909dab;
-  --text-3: #768390;
+  --text-3: #838f9c;
 
   --success: #57ab5a;
   --attention: #c69026;


### PR DESCRIPTION
Part of #70 (Cross-cutting milestone, epic #71). This is PR 2 of 2, after #83. Renderer/CSS-only. Adds the two extra theme modes the PRD calls for (feature 9, success criterion 13's "one more mode") and fixes a real flash-of-wrong-theme bug.

## What this adds

1. **`dim` and `high-contrast` color modes** on the existing `data-color-mode` axis (a flat list, not a second axis - matches the current single-attribute model):
   - **Dim** - a softer, desaturated dark (based on GitHub's "dark dimmed" ramp) for long sessions. Reuses the dark accents.
   - **High-contrast** - near-black surfaces, near-white text, opaque borders, brighter accents. Its own accent set.
   - Both are **explicit picks**; `system` still resolves to light/dark only via `prefers-color-scheme`. Accents + density keep working across all four modes.
   - Each mode block sets the CSS `color-scheme` property (light->light, dark/dim/high-contrast->dark) so native controls and scrollbars match.
   - Settings' color-mode control moves from a 3-item segmented control to a `<select>` (5 options don't fit a segmented control); the titlebar quick-toggle is now brightness-aware (light <-> dark; dim/high-contrast are dark-family, so they toggle to light).

2. **FOUC fix.** `theme-bootstrap.js` was stale - it set the old DaisyUI `data-theme` (nord/dracula/...) from a dead `gh-projects-theme` key, doing nothing for the current system, so the app could flash the default (dark) before `useTheme` ran. It now pre-paints the real `data-color-mode`/`data-accent`/`data-density` from the actual `focus-*` keys before first paint, resolving `system` via `prefers-color-scheme`, wrapped in try/catch.

3. Reduced-motion audit: the existing global `@media (prefers-reduced-motion: reduce)` guard in `index.css` covers all CSS transitions/animations; this PR adds no JS-driven animation, so nothing new needed there.

## How I verified it
- `tsc --noEmit` clean, `eslint src` clean.
- `vitest run src/renderer`: **72 passed** (12 files), including new/extended tests:
  - `useTheme.test.ts` - dim and high-contrast are explicit resolved modes (not system-resolved even when the system prefers light), and a stored `dim` is read on mount.
  - `SettingsView.test.tsx` (new) - all five modes render in the picker (`System / Light / Dark / Dim / High contrast`), selecting one calls `setColorMode`, and the rules link works.
  - `theme-bootstrap.test.ts` (new) - **parity guard**: asserts `theme-bootstrap.js` contains every `COLOR_MODES`/`ACCENTS`/`DENSITIES` value + the three `focus-*` storage keys + the `prefers-color-scheme`/`data-*` wiring, so the pre-paint script can't silently drift from `useTheme`.
- **Token completeness check** (script): `dark`, `dim`, and `high-contrast` each define the identical 24-variable set - no mode silently falls back to a `:root`/dark default (which would break high-contrast legibility).
- **Contrast:** dim's tertiary text was lifted from `#768390` (~3.9:1) to `#838f9c` (~4.56:1 on the dim surface - clears WCAG AA) while staying clearly below `--text-2`.
- `electron-vite build` succeeds; confirmed `theme-bootstrap.js` ships to `out/renderer/` and `index.html` references it.
- Same 9 pre-existing `bun:sqlite` integration-file import failures under vitest's node runner, untouched (renderer-only PR).
- **Not verified:** no live windowed Electron smoke / screenshots of each mode - no display / Electron GUI in this environment. The theme logic is covered by the jsdom tests, the palettes by the completeness + contrast checks, and the pre-paint by the parity test.

GPT-5.5 reviewed the diff and signed off "ready to merge, no blocking issues" (I addressed its one non-blocking concern - dim contrast - and its parity-test suggestion).

## Reviewer notes
- `resolveColorMode` is unchanged in body: `system` -> light/dark only. Auto-selecting high-contrast from `prefers-contrast` is deliberately deferred (a policy decision, out of scope).
- Bootstrap<->useTheme duplication is the standard pre-paint pattern; the new parity test guards it against drift.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
