### PR TITLE
fix: declare zod as a runtime dependency so the packaged app loads the MCP SDK

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -13,6 +13,7 @@
         "lucide-react": "^1.23.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "zod": "^4.4.3",
       },
       "devDependencies": {
         "@electron/rebuild": "^3.6.0",
@@ -38,7 +39,6 @@
         "typescript-eslint": "^8.59.0",
         "vite": "^5.3.0",
         "vitest": "^4.1.5",
-        "zod": "^4.4.3",
       },
     },
   },

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "date-fns": "^4.1.0",
     "lucide-react": "^1.23.0",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@electron/rebuild": "^3.6.0",
@@ -59,8 +60,7 @@
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.59.0",
     "vite": "^5.3.0",
-    "vitest": "^4.1.5",
-    "zod": "^4.4.3"
+    "vitest": "^4.1.5"
   },
   "build": {
     "appId": "com.robertcrandall.gh-projects",


### PR DESCRIPTION
## What I did and why

The installed macOS app crashed at launch with an uncaught main-process exception:

```
Error: Cannot find module 'zod/v3'
Require stack:
- app.asar/node_modules/zod-to-json-schema/dist/cjs/selectParser.js
- app.asar/node_modules/zod-to-json-schema/dist/cjs/parseDef.js
- app.asar/node_modules/zod-to-json-schema/dist/cjs/index.js
- app.asar/node_modules/@modelcontextprotocol/sdk/dist/cjs/server/zod-json-schema-compat.js
- app.asar/node_modules/@modelcontextprotocol/sdk/dist/cjs/shared/protocol.js
- app.asar/node_modules/@modelcontextprotocol/sdk/dist/cjs/client/index.js
- app.asar/out/main/index.js
```

The entire change: move `zod` from `devDependencies` to `dependencies` in `package.json` (range unchanged at `^4.4.3`), plus the matching `bun.lock` reclassification. No source code touched.

## Root cause

- `@modelcontextprotocol/sdk` is a production dependency, imported at main-process module-load time (`src/main/context/mcp-client.ts`).
- Its transitive dep `zod-to-json-schema@3.25.2` (hoisted to top-level `node_modules`) does a runtime `require('zod/v3')`. The `zod/v3` subpath is provided by the `zod` package.
- `electron.vite.config.ts` uses `externalizeDepsPlugin()`, so the MCP SDK and its deps are left as runtime `require()`s resolved from the packaged `node_modules` (not bundled by Vite).
- `zod` was in `devDependencies`, and electron-builder prunes devDependencies from the packaged app. So top-level `node_modules/zod` was absent from `app.asar`. The hoisted `zod-to-json-schema` resolves `zod` from the top-level `node_modules` (gone) - it does not consult the SDK's nested `zod` copy. Hence the crash.

This was introduced in #76, where `@modelcontextprotocol/sdk` correctly went into `dependencies` but `zod` landed in `devDependencies`.

## How I verified it

1. **Before-fix packaged asar** (`electron-builder --dir`, zod in devDependencies): `asar list` showed top-level `node_modules/zod/` = **0 files** (pruned), `zod-to-json-schema/` = 92 files (present, hoisted), nested `@modelcontextprotocol/sdk/node_modules/zod/` = 620 files (present but not consulted by the hoisted resolver). Reproduces the missing module.
2. **After-fix packaged asar** (zod in dependencies): top-level `node_modules/zod/` = **641 files**, including `node_modules/zod/v3/index.cjs` - the exact module the crash reported missing.
3. **Launched the after-fix packaged `.app`**: the main process ran DB migrations, created a window, and reached notification sync (`NOT_AUTHENTICATED`, expected - no GitHub token in the test env). No `zod/v3` error. Since the crash was a synchronous `require` at startup, reaching migrations/window proves the chain now resolves.
4. `bun run typecheck` and `bun run lint` pass. Full test suite under the repo's intended Bun runtime (`bun --bun x vitest run`) is green: **40 files / 382 tests passed**.

## What I did not verify / follow-ups

- I could not exercise a live authenticated flow (no GitHub token in the test env), but that path is well past the crash point.
- Nice-to-have (not in this PR): a packaged `electron-builder --dir` smoke-launch check in the dev workflow, since the normal unit tests can't catch pruned-devDependency packaging bugs.

Both the plan and the completed work were reviewed by an independent model (GPT-5.5) before opening this PR.