### PR TITLE
feat(copilot): delegate to the installed Copilot desktop app over its local WS (#86)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -13,6 +13,7 @@
         "lucide-react": "^1.23.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "ws": "^8.21.0",
         "zod": "^4.4.3",
       },
       "devDependencies": {
@@ -26,6 +27,7 @@
         "@types/node": "^20.14.0",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
+        "@types/ws": "^8.18.1",
         "@vitejs/plugin-react": "^4.3.0",
         "@vitest/coverage-v8": "^4.1.5",
         "electron": "^31.0.0",
@@ -520,6 +522,8 @@
     "@types/responselike": ["@types/responselike@1.0.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw=="],
 
     "@types/verror": ["@types/verror@1.10.11", "", {}, "sha512-RlDm9K7+o5stv0Co8i8ZRGxDbrTxhJtgjqjFyVh/tXQyl/rYtTKlnTvZ88oSTeYREWurwx20Js4kTuKCsFkUtg=="],
+
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
     "@types/yauzl": ["@types/yauzl@2.10.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q=="],
 
@@ -1550,6 +1554,8 @@
     "wrap-ansi-cjs": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
 
     "xml-name-validator": ["xml-name-validator@5.0.0", "", {}, "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="],
 

--- a/db/migrations/017_copilot_app_sessions.sql
+++ b/db/migrations/017_copilot_app_sessions.sql
@@ -1,0 +1,24 @@
+-- Migration: 017_copilot_app_sessions.sql
+-- PR2 (#86): delegated GitHub Copilot desktop-app sessions.
+--
+-- These live in a DEDICATED table (not copilot_sessions, which is github-only)
+-- so the two session kinds never collide: app sessions have a different
+-- lifecycle (WS/data.db status, no PR, deep-link open) and a separate store
+-- means they can't leak into any existing github-session reader. project_id is
+-- ON DELETE SET NULL as a safety net for hard deletes; the soft-delete detach
+-- for these rows is wired when they're surfaced on project views (PR3 / #87).
+
+CREATE TABLE copilot_app_sessions (
+  id          TEXT    PRIMARY KEY,                 -- WS session_id (uuid)
+  project_id  INTEGER REFERENCES projects(id) ON DELETE SET NULL,
+  cwd         TEXT    NOT NULL,
+  title       TEXT    NOT NULL,
+  status      TEXT    NOT NULL DEFAULT 'in_progress'
+                CHECK (status IN ('in_progress', 'waiting', 'completed', 'unknown')),
+  repo_owner  TEXT,
+  repo_name   TEXT,
+  created_at  TEXT    NOT NULL DEFAULT (datetime('now')),
+  updated_at  TEXT    NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX idx_copilot_app_sessions_project ON copilot_app_sessions(project_id);

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "lucide-react": "^1.23.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "ws": "^8.21.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {
@@ -48,6 +49,7 @@
     "@types/node": "^20.14.0",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
+    "@types/ws": "^8.18.1",
     "@vitejs/plugin-react": "^4.3.0",
     "@vitest/coverage-v8": "^4.1.5",
     "electron": "^31.0.0",

--- a/src/main/agent/copilot-app/client.integration.test.ts
+++ b/src/main/agent/copilot-app/client.integration.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { WebSocketServer, type WebSocket as WsSocket } from 'ws'
+import type { AddressInfo } from 'node:net'
+import { delegateOverWs, AppUnavailableError, CreateAmbiguousError } from './client'
+import type { WsEndpoint } from './discover'
+
+type OnConnection = (socket: WsSocket, req: { headers: Record<string, unknown> }) => void
+
+interface FakeServer {
+  endpoint: WsEndpoint
+  originsSeen: (string | undefined)[]
+  close: () => Promise<void>
+}
+
+function startServer(onConnection: OnConnection, verifyClient?: () => boolean): Promise<FakeServer> {
+  return new Promise((resolve) => {
+    const wss = new WebSocketServer({ port: 0, ...(verifyClient ? { verifyClient } : {}) })
+    const originsSeen: (string | undefined)[] = []
+    wss.on('connection', (socket, req) => {
+      originsSeen.push(req.headers.origin as string | undefined)
+      onConnection(socket, req as unknown as { headers: Record<string, unknown> })
+    })
+    wss.on('listening', () => {
+      const port = (wss.address() as AddressInfo).port
+      resolve({
+        endpoint: { port, token: 'test-token' },
+        originsSeen,
+        close: () =>
+          new Promise<void>((r) => {
+            // Force-terminate any lingering sockets so close() can't hang.
+            for (const c of wss.clients) {
+              try {
+                c.terminate()
+              } catch {
+                /* ignore */
+              }
+            }
+            const done = setTimeout(r, 1000)
+            wss.close(() => {
+              clearTimeout(done)
+              r()
+            })
+          }),
+      })
+    })
+  })
+}
+
+let server: FakeServer | null = null
+afterEach(async () => {
+  if (server) {
+    await server.close()
+    server = null
+  }
+})
+
+const fastOpts = { helloTimeoutMs: 1500, createTimeoutMs: 1500, sendConfirmMs: 300 }
+
+describe('delegateOverWs — happy path', () => {
+  it('completes the handshake with no Origin header, creates + sends', async () => {
+    server = await startServer((socket) => {
+      socket.send(JSON.stringify({ type: 'server_hello', instance_id: 'i1' }))
+      socket.on('message', (data) => {
+        const msg = JSON.parse(data.toString())
+        if (msg.type === 'create_session') {
+          socket.send(JSON.stringify({ type: 'session_created', session_id: 'srv-1', cwd: msg.cwd }))
+        } else if (msg.type === 'send_message') {
+          socket.send(JSON.stringify({ type: 'session_event', session_id: msg.session_id }))
+        }
+      })
+    })
+
+    const res = await delegateOverWs(server.endpoint, '/repos/foo', 'do it', undefined, fastOpts)
+    expect(res).toEqual({ sessionId: 'srv-1', sendOk: true })
+    // The Node ws client must NOT send an Origin header (the non-browser gate).
+    expect(server.originsSeen).toEqual([undefined])
+  })
+})
+
+describe('delegateOverWs — pre-create failures (fall-back-eligible)', () => {
+  it('AppUnavailableError when the server never sends server_hello', async () => {
+    server = await startServer(() => { /* silent — no hello */ })
+    await expect(delegateOverWs(server.endpoint, '/x', 'p', undefined, fastOpts)).rejects.toBeInstanceOf(
+      AppUnavailableError
+    )
+  })
+
+  it('AppUnavailableError when the upgrade is rejected (stale token)', async () => {
+    server = await startServer(() => { /* unreached */ }, () => false)
+    await expect(delegateOverWs(server.endpoint, '/x', 'p', undefined, fastOpts)).rejects.toBeInstanceOf(
+      AppUnavailableError
+    )
+  })
+})
+
+describe('delegateOverWs — idempotency boundary (post-create is NOT fall-back-eligible)', () => {
+  it('CreateAmbiguousError when create_session is never acknowledged', async () => {
+    server = await startServer((socket) => {
+      socket.send(JSON.stringify({ type: 'server_hello', instance_id: 'i1' }))
+      // deliberately never respond to create_session
+    })
+    await expect(delegateOverWs(server.endpoint, '/x', 'p', undefined, fastOpts)).rejects.toBeInstanceOf(
+      CreateAmbiguousError
+    )
+  })
+
+  it('CreateAmbiguousError when the socket closes right after create_session', async () => {
+    server = await startServer((socket) => {
+      socket.send(JSON.stringify({ type: 'server_hello', instance_id: 'i1' }))
+      socket.on('message', (data) => {
+        if (JSON.parse(data.toString()).type === 'create_session') socket.close()
+      })
+    })
+    await expect(delegateOverWs(server.endpoint, '/x', 'p', undefined, fastOpts)).rejects.toBeInstanceOf(
+      CreateAmbiguousError
+    )
+  })
+
+  it('returns the session (sendOk:false) when it was created but the socket then dies', async () => {
+    server = await startServer((socket) => {
+      socket.send(JSON.stringify({ type: 'server_hello', instance_id: 'i1' }))
+      socket.on('message', (data) => {
+        const msg = JSON.parse(data.toString())
+        if (msg.type === 'create_session') {
+          socket.send(JSON.stringify({ type: 'session_created', session_id: 'srv-1' }))
+          // close before the prompt confirmation
+          setTimeout(() => socket.close(), 10)
+        }
+      })
+    })
+    const res = await delegateOverWs(server.endpoint, '/x', 'p', undefined, fastOpts)
+    expect(res.sessionId).toBe('srv-1')
+    expect(res.sendOk).toBe(false)
+  })
+})

--- a/src/main/agent/copilot-app/client.ts
+++ b/src/main/agent/copilot-app/client.ts
@@ -1,0 +1,244 @@
+/**
+ * The single WebSocket connection to the Copilot desktop app.
+ *
+ * Isolated here (with protocol.ts) so the app's unofficial protocol can only
+ * break this one seam. The token is never logged, and it's never included in a
+ * thrown error (we build the URL locally and keep it out of error messages).
+ *
+ * Idempotency boundary (prevents double-delegation): cloud fallback is only safe
+ * BEFORE `create_session` is sent. So failures split into two typed errors:
+ *   - `AppUnavailableError` — discovery/connect/handshake failed, or the socket
+ *     died before we sent `create_session`. Pre-create → the caller may fall
+ *     back to cloud.
+ *   - `CreateAmbiguousError` — `create_session` was sent but we never got
+ *     `session_created`. The app MIGHT have created a session we can't see, so
+ *     the caller must NOT fall back to cloud (that would double-delegate).
+ * Once `session_created` arrives, the session exists and is returned even if the
+ * subsequent `send_message` fails.
+ */
+
+import WebSocket from 'ws'
+import type { WsEndpoint } from './discover'
+import { buildCreateSession, buildDeleteSession, buildSendMessage, encodeFrame, parseFrame } from './protocol'
+
+/** Pre-create failure. Safe for the caller to fall back to cloud. */
+export class AppUnavailableError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'AppUnavailableError'
+  }
+}
+
+/** `create_session` sent but never acknowledged. Ambiguous — do NOT fall back. */
+export class CreateAmbiguousError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'CreateAmbiguousError'
+  }
+}
+
+export interface DelegateOverWsResult {
+  sessionId: string
+  /** False when the session was created but the follow-up prompt couldn't be sent. */
+  sendOk: boolean
+}
+
+export interface WsClientOptions {
+  /** ms to wait for the 101 + server_hello. Default 8000. */
+  helloTimeoutMs?: number
+  /** ms to wait for session_created after create_session. Default 15000. */
+  createTimeoutMs?: number
+  /** ms to wait for a session_event confirming the prompt was accepted. Default 4000. */
+  sendConfirmMs?: number
+}
+
+const DEFAULTS = { helloTimeoutMs: 8000, createTimeoutMs: 15000, sendConfirmMs: 4000 }
+
+/** Build the WS URL. Kept out of error messages so the token can't leak. */
+function buildUrl(endpoint: WsEndpoint): string {
+  return `ws://127.0.0.1:${endpoint.port}/?token=${encodeURIComponent(endpoint.token)}`
+}
+
+/**
+ * Create a session in the desktop app and send it the task prompt. Resolves once
+ * the session exists and the prompt has been dispatched. Does NOT wait for the
+ * agent to finish. See the idempotency boundary above for the error contract.
+ */
+export function delegateOverWs(
+  endpoint: WsEndpoint,
+  cwd: string,
+  prompt: string,
+  model: string | undefined,
+  options: WsClientOptions = {}
+): Promise<DelegateOverWsResult> {
+  const helloTimeoutMs = options.helloTimeoutMs ?? DEFAULTS.helloTimeoutMs
+  const createTimeoutMs = options.createTimeoutMs ?? DEFAULTS.createTimeoutMs
+  const sendConfirmMs = options.sendConfirmMs ?? DEFAULTS.sendConfirmMs
+
+  return new Promise<DelegateOverWsResult>((resolve, reject) => {
+    // ws omits the Origin header by default — required for the non-browser gate.
+    const ws = new WebSocket(buildUrl(endpoint))
+
+    type Phase = 'connecting' | 'created_sent' | 'session_live' | 'settled'
+    let phase: Phase = 'connecting'
+    let sessionId: string | null = null
+    let timer: NodeJS.Timeout | null = null
+
+    const clearTimer = (): void => {
+      if (timer !== null) {
+        clearTimeout(timer)
+        timer = null
+      }
+    }
+    const settle = (fn: () => void): void => {
+      if (phase === 'settled') return
+      phase = 'settled'
+      clearTimer()
+      try {
+        ws.close()
+      } catch {
+        /* already closing */
+      }
+      fn()
+    }
+    const fail = (err: Error): void => settle(() => reject(err))
+    const succeed = (result: DelegateOverWsResult): void => settle(() => resolve(result))
+
+    /** Timeout appropriate to the current phase. */
+    const armTimer = (ms: number, onFire: () => void): void => {
+      clearTimer()
+      timer = setTimeout(onFire, ms)
+    }
+
+    armTimer(helloTimeoutMs, () =>
+      fail(new AppUnavailableError('timed out waiting for the Copilot app handshake'))
+    )
+
+    const sendPrompt = (): void => {
+      // Session exists now — from here on, never surface a fallback-eligible error.
+      const trySend = (): boolean => {
+        try {
+          ws.send(encodeFrame(buildSendMessage(sessionId as string, prompt)))
+          return true
+        } catch {
+          return false
+        }
+      }
+      // one retry on the same live connection
+      if (!(trySend() || trySend())) {
+        succeed({ sessionId: sessionId as string, sendOk: false })
+        return
+      }
+      // Give the app a moment to accept; a session_event for our id confirms it,
+      // but success doesn't depend on seeing one.
+      armTimer(sendConfirmMs, () => succeed({ sessionId: sessionId as string, sendOk: true }))
+    }
+
+    ws.on('open', () => {
+      // Connected; still waiting for server_hello (handled in 'message').
+    })
+
+    ws.on('unexpected-response', (_req, res) => {
+      // Non-101 (e.g. stale/rotated token → auth rejected). Pre-create.
+      fail(new AppUnavailableError(`Copilot app rejected the connection (HTTP ${res.statusCode})`))
+    })
+
+    ws.on('message', (data: WebSocket.RawData) => {
+      const frame = parseFrame(data.toString())
+      switch (frame.kind) {
+        case 'server_hello': {
+          if (phase !== 'connecting') return
+          phase = 'created_sent'
+          try {
+            ws.send(encodeFrame(buildCreateSession(cwd, model)))
+          } catch {
+            fail(new AppUnavailableError('failed to send create_session'))
+            return
+          }
+          armTimer(createTimeoutMs, () =>
+            fail(new CreateAmbiguousError('create_session was sent but never acknowledged'))
+          )
+          return
+        }
+        case 'session_created': {
+          if (phase !== 'created_sent') return
+          phase = 'session_live'
+          sessionId = frame.sessionId
+          sendPrompt()
+          return
+        }
+        case 'session_event': {
+          // Confirmation that our just-sent prompt was accepted.
+          if (phase === 'session_live' && sessionId !== null && frame.sessionId === sessionId) {
+            succeed({ sessionId, sendOk: true })
+          }
+          return
+        }
+        default:
+          return // ambient chatter — ignore
+      }
+    })
+
+    ws.on('error', (err: Error) => {
+      // Classify by phase: before create_session is sent → fall-back-eligible;
+      // after → ambiguous (never auto-fall-back).
+      if (phase === 'connecting') {
+        fail(new AppUnavailableError(`Copilot app connection error: ${err.message}`))
+      } else if (phase === 'created_sent') {
+        fail(new CreateAmbiguousError('connection error after create_session was sent'))
+      } else if (phase === 'session_live' && sessionId !== null) {
+        succeed({ sessionId, sendOk: false })
+      }
+      // 'settled' → ignore
+    })
+
+    ws.on('close', () => {
+      if (phase === 'connecting') {
+        fail(new AppUnavailableError('Copilot app closed the connection before the handshake completed'))
+      } else if (phase === 'created_sent') {
+        fail(new CreateAmbiguousError('connection closed after create_session was sent'))
+      } else if (phase === 'session_live' && sessionId !== null) {
+        // Session exists; the prompt may or may not have been delivered.
+        succeed({ sessionId, sendOk: false })
+      }
+    })
+  })
+}
+
+/**
+ * Best-effort delete of a session (used to clean up test/aborted sessions).
+ * Resolves when the delete frame is dispatched; never rejects on transport
+ * issues (the caller treats cleanup as best-effort).
+ */
+export function deleteAppSession(endpoint: WsEndpoint, sessionId: string, timeoutMs = 6000): Promise<void> {
+  return new Promise<void>((resolve) => {
+    const ws = new WebSocket(buildUrl(endpoint))
+    let done = false
+    const finish = (): void => {
+      if (done) return
+      done = true
+      clearTimeout(timer)
+      try {
+        ws.close()
+      } catch {
+        /* ignore */
+      }
+      resolve()
+    }
+    const timer = setTimeout(finish, timeoutMs)
+    ws.on('message', (data: WebSocket.RawData) => {
+      const frame = parseFrame(data.toString())
+      if (frame.kind === 'server_hello') {
+        try {
+          ws.send(encodeFrame(buildDeleteSession(sessionId)))
+        } catch {
+          finish()
+        }
+      } else if (frame.kind === 'session_deleted' && frame.sessionId === sessionId) {
+        finish()
+      }
+    })
+    ws.on('error', finish)
+    ws.on('close', finish)
+  })
+}

--- a/src/main/agent/copilot-app/cwd.test.ts
+++ b/src/main/agent/copilot-app/cwd.test.ts
@@ -68,49 +68,49 @@ describe('expandHome', () => {
 describe('resolveLocalCwd', () => {
   const matchingGit: GitInspection = { insideWorkTree: true, remoteUrls: ['git@github.com:me/foo.git'] }
 
-  it('resolves <repos-root>/<repo> when it exists, is a worktree, and the remote matches', () => {
-    const res = resolveLocalCwd('me', 'foo', {
+  it('resolves <repos-root>/<repo> when it exists, is a worktree, and the remote matches', async () => {
+    const res = await resolveLocalCwd('me', 'foo', {
       reposRoot: '/repos',
       dirProbe: (p) => p === '/repos/foo',
-      gitInspector: () => matchingGit,
+      gitInspector: async () => matchingGit,
     })
     expect(res).toEqual({ ok: true, cwd: '/repos/foo' })
   })
 
-  it('rejects when the path is not a directory', () => {
-    const res = resolveLocalCwd('me', 'foo', {
+  it('rejects when the path is not a directory', async () => {
+    const res = await resolveLocalCwd('me', 'foo', {
       reposRoot: '/repos',
       dirProbe: () => false,
-      gitInspector: () => matchingGit,
+      gitInspector: async () => matchingGit,
     })
     expect(res).toEqual({ ok: false, reason: 'no_local_cwd' })
   })
 
-  it('rejects when the directory is not a git worktree', () => {
-    const res = resolveLocalCwd('me', 'foo', {
+  it('rejects when the directory is not a git worktree', async () => {
+    const res = await resolveLocalCwd('me', 'foo', {
       reposRoot: '/repos',
       dirProbe: () => true,
-      gitInspector: () => ({ insideWorkTree: false, remoteUrls: [] }),
+      gitInspector: async () => ({ insideWorkTree: false, remoteUrls: [] }),
     })
     expect(res).toEqual({ ok: false, reason: 'no_local_cwd' })
   })
 
-  it('rejects when the remote points at a different owner (owner collision)', () => {
-    const res = resolveLocalCwd('me', 'foo', {
+  it('rejects when the remote points at a different owner (owner collision)', async () => {
+    const res = await resolveLocalCwd('me', 'foo', {
       reposRoot: '/repos',
       dirProbe: () => true,
-      gitInspector: () => ({ insideWorkTree: true, remoteUrls: ['git@github.com:someoneelse/foo.git'] }),
+      gitInspector: async () => ({ insideWorkTree: true, remoteUrls: ['git@github.com:someoneelse/foo.git'] }),
     })
     expect(res).toEqual({ ok: false, reason: 'no_local_cwd' })
   })
 
-  it('uses an explicit override path over the convention', () => {
+  it('uses an explicit override path over the convention', async () => {
     const seen: string[] = []
-    const res = resolveLocalCwd('me', 'foo', {
+    const res = await resolveLocalCwd('me', 'foo', {
       reposRoot: '/repos',
       overridePath: '/custom/checkout',
       dirProbe: (p) => { seen.push(p); return p === '/custom/checkout' },
-      gitInspector: () => matchingGit,
+      gitInspector: async () => matchingGit,
     })
     expect(res).toEqual({ ok: true, cwd: '/custom/checkout' })
     expect(seen).toContain('/custom/checkout')

--- a/src/main/agent/copilot-app/cwd.test.ts
+++ b/src/main/agent/copilot-app/cwd.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest'
+import {
+  normalizeRemoteToOwnerRepo,
+  remotesMatchRepo,
+  resolveLocalCwd,
+  expandHome,
+  type GitInspection,
+} from './cwd'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+describe('normalizeRemoteToOwnerRepo', () => {
+  it('handles https, scp, ssh, and bare forms, case-insensitively', () => {
+    expect(normalizeRemoteToOwnerRepo('https://github.com/Owner/Repo.git')).toBe('owner/repo')
+    expect(normalizeRemoteToOwnerRepo('https://github.com/owner/repo')).toBe('owner/repo')
+    expect(normalizeRemoteToOwnerRepo('git@github.com:owner/repo.git')).toBe('owner/repo')
+    expect(normalizeRemoteToOwnerRepo('ssh://git@github.com/owner/repo.git')).toBe('owner/repo')
+    // GHE host works too (host-agnostic)
+    expect(normalizeRemoteToOwnerRepo('https://github.example.com/owner/repo')).toBe('owner/repo')
+  })
+
+  it('rejects nested paths so a deeper remote cannot false-match owner/repo', () => {
+    // Only an exact two-segment owner/repo is trusted.
+    expect(normalizeRemoteToOwnerRepo('https://host/a/b/owner/repo.git')).toBeNull()
+    expect(normalizeRemoteToOwnerRepo('https://gitlab.example.com/acme/owner/repo.git')).toBeNull()
+    expect(normalizeRemoteToOwnerRepo('git@host:acme/owner/repo.git')).toBeNull()
+    expect(normalizeRemoteToOwnerRepo('acme/owner/repo')).toBeNull()
+  })
+
+  it('rejects empty/doubled segments (no collapsing) and partial owner/repo', () => {
+    expect(normalizeRemoteToOwnerRepo('https://host//owner/repo.git')).toBeNull()
+    expect(normalizeRemoteToOwnerRepo('https://host/owner//repo.git')).toBeNull()
+    expect(normalizeRemoteToOwnerRepo('git@host:/owner/repo.git')).toBeNull()
+    expect(normalizeRemoteToOwnerRepo('owner/')).toBeNull()
+  })
+
+  it('accepts a valid remote with a trailing slash after .git', () => {
+    expect(normalizeRemoteToOwnerRepo('https://github.com/owner/repo.git/')).toBe('owner/repo')
+    expect(normalizeRemoteToOwnerRepo('https://github.com/owner/repo/')).toBe('owner/repo')
+  })
+
+  it('returns null for non-repo urls', () => {
+    expect(normalizeRemoteToOwnerRepo('')).toBeNull()
+    expect(normalizeRemoteToOwnerRepo('justowner')).toBeNull()
+    expect(normalizeRemoteToOwnerRepo('https://host/only')).toBeNull()
+  })
+})
+
+describe('remotesMatchRepo', () => {
+  it('matches when any remote normalizes to owner/repo', () => {
+    expect(remotesMatchRepo(['git@github.com:me/foo.git'], 'me', 'foo')).toBe(true)
+    expect(remotesMatchRepo(['https://github.com/ME/FOO'], 'me', 'foo')).toBe(true)
+  })
+  it('does not match a different owner (the owner-collision guard)', () => {
+    expect(remotesMatchRepo(['https://github.com/someoneelse/foo'], 'me', 'foo')).toBe(false)
+    expect(remotesMatchRepo([], 'me', 'foo')).toBe(false)
+  })
+})
+
+describe('expandHome', () => {
+  it('expands ~ and ~/...', () => {
+    expect(expandHome('~')).toBe(homedir())
+    expect(expandHome('~/repos')).toBe(join(homedir(), 'repos'))
+    expect(expandHome('/abs/path')).toBe('/abs/path')
+  })
+})
+
+describe('resolveLocalCwd', () => {
+  const matchingGit: GitInspection = { insideWorkTree: true, remoteUrls: ['git@github.com:me/foo.git'] }
+
+  it('resolves <repos-root>/<repo> when it exists, is a worktree, and the remote matches', () => {
+    const res = resolveLocalCwd('me', 'foo', {
+      reposRoot: '/repos',
+      dirProbe: (p) => p === '/repos/foo',
+      gitInspector: () => matchingGit,
+    })
+    expect(res).toEqual({ ok: true, cwd: '/repos/foo' })
+  })
+
+  it('rejects when the path is not a directory', () => {
+    const res = resolveLocalCwd('me', 'foo', {
+      reposRoot: '/repos',
+      dirProbe: () => false,
+      gitInspector: () => matchingGit,
+    })
+    expect(res).toEqual({ ok: false, reason: 'no_local_cwd' })
+  })
+
+  it('rejects when the directory is not a git worktree', () => {
+    const res = resolveLocalCwd('me', 'foo', {
+      reposRoot: '/repos',
+      dirProbe: () => true,
+      gitInspector: () => ({ insideWorkTree: false, remoteUrls: [] }),
+    })
+    expect(res).toEqual({ ok: false, reason: 'no_local_cwd' })
+  })
+
+  it('rejects when the remote points at a different owner (owner collision)', () => {
+    const res = resolveLocalCwd('me', 'foo', {
+      reposRoot: '/repos',
+      dirProbe: () => true,
+      gitInspector: () => ({ insideWorkTree: true, remoteUrls: ['git@github.com:someoneelse/foo.git'] }),
+    })
+    expect(res).toEqual({ ok: false, reason: 'no_local_cwd' })
+  })
+
+  it('uses an explicit override path over the convention', () => {
+    const seen: string[] = []
+    const res = resolveLocalCwd('me', 'foo', {
+      reposRoot: '/repos',
+      overridePath: '/custom/checkout',
+      dirProbe: (p) => { seen.push(p); return p === '/custom/checkout' },
+      gitInspector: () => matchingGit,
+    })
+    expect(res).toEqual({ ok: true, cwd: '/custom/checkout' })
+    expect(seen).toContain('/custom/checkout')
+    expect(seen).not.toContain('/repos/foo')
+  })
+})

--- a/src/main/agent/copilot-app/cwd.ts
+++ b/src/main/agent/copilot-app/cwd.ts
@@ -20,10 +20,11 @@ import { statSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { isAbsolute, join } from 'node:path'
 import { promisify } from 'node:util'
+import { DEFAULT_REPOS_ROOT } from '../../../shared/ipc-channels'
+
+export { DEFAULT_REPOS_ROOT }
 
 const execFileAsync = promisify(execFile)
-
-export const DEFAULT_REPOS_ROOT = '~/repos'
 
 /** Expand a leading `~` / `~/…` to the user's home directory. Pure-ish (reads homedir). */
 export function expandHome(p: string): string {

--- a/src/main/agent/copilot-app/cwd.ts
+++ b/src/main/agent/copilot-app/cwd.ts
@@ -1,0 +1,164 @@
+/**
+ * Trusted local-checkout resolver for desktop-app delegation.
+ *
+ * WS `create_session` needs a real on-disk `cwd`, but Focus only knows a repo as
+ * `owner/repo`. Resolution (owner's confirmed UX — convention + override):
+ *   1. a per-project explicit override path, if provided; else
+ *   2. `<repos-root>/<repo>` (repos-root defaults to ~/repos, overridable).
+ * The resolved path is only accepted when ALL strict checks hold:
+ *   - it exists and is a directory;
+ *   - it's inside a git worktree; and
+ *   - a git remote NORMALIZES to the exact attempted `owner/repo`.
+ * The remote check is what makes repo-name-only safe against owner collisions
+ * (two different owners' `foo` won't both validate). Anything short of that →
+ * unavailable → the caller falls back to cloud. We never infer a cwd from repo
+ * metadata and never use the app's own cwd.
+ */
+
+import { execFileSync } from 'node:child_process'
+import { statSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { isAbsolute, join } from 'node:path'
+
+export const DEFAULT_REPOS_ROOT = '~/repos'
+
+/** Expand a leading `~` / `~/…` to the user's home directory. Pure-ish (reads homedir). */
+export function expandHome(p: string): string {
+  const trimmed = p.trim()
+  if (trimmed === '~') return homedir()
+  if (trimmed.startsWith('~/')) return join(homedir(), trimmed.slice(2))
+  return trimmed
+}
+
+/**
+ * Normalize a git remote URL to a lowercase `owner/repo`, or null if it doesn't
+ * look like one. Handles https, `git@host:owner/repo`, and `ssh://` forms, with
+ * or without a trailing `.git`. Host-agnostic (works for github.com + GHE).
+ * Pure.
+ */
+export function normalizeRemoteToOwnerRepo(url: string): string | null {
+  let s = url.trim()
+  if (s.length === 0) return null
+  // Trim trailing slashes FIRST, then drop a trailing `.git` (so `repo.git/`
+  // normalizes correctly rather than leaving a stray `.git`).
+  s = s.replace(/\/+$/, '').replace(/\.git$/i, '')
+
+  // scp-like syntax: git@host:owner/repo
+  const scp = /^[^/@]+@[^:/]+:(.+)$/.exec(s)
+  if (scp !== null && scp[1] !== undefined) {
+    return exactlyTwoSegments(scp[1])
+  }
+  // URL syntax: scheme://[user@]host/owner/repo
+  const url2 = /^[a-z][a-z0-9+.-]*:\/\/(?:[^/@]+@)?[^/]+\/(.+)$/i.exec(s)
+  if (url2 !== null && url2[1] !== undefined) {
+    return exactlyTwoSegments(url2[1])
+  }
+  // Bare path: owner/repo
+  if (s.includes('/')) return exactlyTwoSegments(s)
+  return null
+}
+
+/**
+ * Return `owner/repo` (lowercased) ONLY when the path is EXACTLY two non-empty
+ * segments. Empty segments are NOT filtered out, so a doubled/leading slash
+ * (e.g. `//owner/repo` or `owner//repo`) is rejected rather than collapsed — a
+ * checkout whose remote merely *ends* with the target owner/repo can't
+ * false-validate as trusted. Pure.
+ */
+function exactlyTwoSegments(path: string): string | null {
+  const parts = path.split('/')
+  if (parts.length !== 2) return null
+  const [owner, repo] = parts
+  if (owner === undefined || owner.length === 0 || repo === undefined || repo.length === 0) return null
+  return `${owner}/${repo}`.toLowerCase()
+}
+
+/** Do any of the remote URLs normalize to exactly `owner/repo` (case-insensitive)? Pure. */
+export function remotesMatchRepo(remoteUrls: string[], owner: string, repo: string): boolean {
+  const target = `${owner}/${repo}`.toLowerCase()
+  return remoteUrls.some((u) => normalizeRemoteToOwnerRepo(u) === target)
+}
+
+// ── Injectable filesystem/git probes (real impls by default; faked in tests) ──
+
+export interface GitInspection {
+  insideWorkTree: boolean
+  remoteUrls: string[]
+}
+
+/** Inspect a directory's git state. Returns insideWorkTree=false when not a repo. */
+export type GitInspector = (dirPath: string) => GitInspection
+
+/** True when the path exists and is a directory. */
+export type DirProbe = (dirPath: string) => boolean
+
+const defaultDirProbe: DirProbe = (dirPath) => {
+  try {
+    return statSync(dirPath).isDirectory()
+  } catch {
+    return false
+  }
+}
+
+const defaultGitInspector: GitInspector = (dirPath) => {
+  const run = (args: string[]): string | null => {
+    try {
+      return execFileSync('git', ['-C', dirPath, ...args], {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+        timeout: 5000,
+      })
+    } catch {
+      return null
+    }
+  }
+  const inside = run(['rev-parse', '--is-inside-work-tree'])
+  const insideWorkTree = inside !== null && inside.trim() === 'true'
+  if (!insideWorkTree) return { insideWorkTree: false, remoteUrls: [] }
+
+  const remotes = run(['remote', '-v'])
+  const remoteUrls: string[] = []
+  if (remotes !== null) {
+    for (const line of remotes.split(/\r?\n/)) {
+      // "origin\thttps://github.com/owner/repo.git (fetch)"
+      const m = /^\S+\s+(\S+)\s+\((?:fetch|push)\)/.exec(line.trim())
+      if (m !== null && m[1] !== undefined) remoteUrls.push(m[1])
+    }
+  }
+  return { insideWorkTree: true, remoteUrls }
+}
+
+export interface ResolveCwdOptions {
+  /** Repos-root setting (raw; `~` expanded here). Defaults to ~/repos. */
+  reposRoot?: string
+  /** Per-project explicit override path (wins over the convention). */
+  overridePath?: string | null
+  dirProbe?: DirProbe
+  gitInspector?: GitInspector
+}
+
+export type CwdResolution = { ok: true; cwd: string } | { ok: false; reason: 'no_local_cwd' }
+
+/**
+ * Resolve a trusted local checkout for `owner/repo`, or report that none is
+ * available. See the module doc for the strict-validation contract.
+ */
+export function resolveLocalCwd(owner: string, repo: string, options: ResolveCwdOptions = {}): CwdResolution {
+  const dirProbe = options.dirProbe ?? defaultDirProbe
+  const gitInspector = options.gitInspector ?? defaultGitInspector
+
+  const override = options.overridePath?.trim()
+  const candidate =
+    override !== undefined && override.length > 0
+      ? expandHome(override)
+      : join(expandHome(options.reposRoot?.trim() || DEFAULT_REPOS_ROOT), repo)
+
+  // Must be an absolute directory that exists.
+  if (!isAbsolute(candidate) || !dirProbe(candidate)) return { ok: false, reason: 'no_local_cwd' }
+
+  const git = gitInspector(candidate)
+  if (!git.insideWorkTree) return { ok: false, reason: 'no_local_cwd' }
+  if (!remotesMatchRepo(git.remoteUrls, owner, repo)) return { ok: false, reason: 'no_local_cwd' }
+
+  return { ok: true, cwd: candidate }
+}

--- a/src/main/agent/copilot-app/cwd.ts
+++ b/src/main/agent/copilot-app/cwd.ts
@@ -15,10 +15,13 @@
  * metadata and never use the app's own cwd.
  */
 
-import { execFileSync } from 'node:child_process'
+import { execFile } from 'node:child_process'
 import { statSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { isAbsolute, join } from 'node:path'
+import { promisify } from 'node:util'
+
+const execFileAsync = promisify(execFile)
 
 export const DEFAULT_REPOS_ROOT = '~/repos'
 
@@ -87,7 +90,7 @@ export interface GitInspection {
 }
 
 /** Inspect a directory's git state. Returns insideWorkTree=false when not a repo. */
-export type GitInspector = (dirPath: string) => GitInspection
+export type GitInspector = (dirPath: string) => Promise<GitInspection>
 
 /** True when the path exists and is a directory. */
 export type DirProbe = (dirPath: string) => boolean
@@ -100,23 +103,25 @@ const defaultDirProbe: DirProbe = (dirPath) => {
   }
 }
 
-const defaultGitInspector: GitInspector = (dirPath) => {
-  const run = (args: string[]): string | null => {
+/**
+ * Real git inspection. Runs git ASYNC (promisified execFile) so it never blocks
+ * the Electron main-process event loop — matching the rest of the codebase's
+ * async subprocess pattern. A hung git can't freeze IPC (5s timeout per call).
+ */
+const defaultGitInspector: GitInspector = async (dirPath) => {
+  const run = async (args: string[]): Promise<string | null> => {
     try {
-      return execFileSync('git', ['-C', dirPath, ...args], {
-        encoding: 'utf8',
-        stdio: ['ignore', 'pipe', 'ignore'],
-        timeout: 5000,
-      })
+      const { stdout } = await execFileAsync('git', ['-C', dirPath, ...args], { timeout: 5000 })
+      return stdout
     } catch {
       return null
     }
   }
-  const inside = run(['rev-parse', '--is-inside-work-tree'])
+  const inside = await run(['rev-parse', '--is-inside-work-tree'])
   const insideWorkTree = inside !== null && inside.trim() === 'true'
   if (!insideWorkTree) return { insideWorkTree: false, remoteUrls: [] }
 
-  const remotes = run(['remote', '-v'])
+  const remotes = await run(['remote', '-v'])
   const remoteUrls: string[] = []
   if (remotes !== null) {
     for (const line of remotes.split(/\r?\n/)) {
@@ -141,9 +146,14 @@ export type CwdResolution = { ok: true; cwd: string } | { ok: false; reason: 'no
 
 /**
  * Resolve a trusted local checkout for `owner/repo`, or report that none is
- * available. See the module doc for the strict-validation contract.
+ * available. See the module doc for the strict-validation contract. Async: the
+ * git inspection runs off the main-thread event loop.
  */
-export function resolveLocalCwd(owner: string, repo: string, options: ResolveCwdOptions = {}): CwdResolution {
+export async function resolveLocalCwd(
+  owner: string,
+  repo: string,
+  options: ResolveCwdOptions = {}
+): Promise<CwdResolution> {
   const dirProbe = options.dirProbe ?? defaultDirProbe
   const gitInspector = options.gitInspector ?? defaultGitInspector
 
@@ -156,7 +166,7 @@ export function resolveLocalCwd(owner: string, repo: string, options: ResolveCwd
   // Must be an absolute directory that exists.
   if (!isAbsolute(candidate) || !dirProbe(candidate)) return { ok: false, reason: 'no_local_cwd' }
 
-  const git = gitInspector(candidate)
+  const git = await gitInspector(candidate)
   if (!git.insideWorkTree) return { ok: false, reason: 'no_local_cwd' }
   if (!remotesMatchRepo(git.remoteUrls, owner, repo)) return { ok: false, reason: 'no_local_cwd' }
 

--- a/src/main/agent/copilot-app/delegate.test.ts
+++ b/src/main/agent/copilot-app/delegate.test.ts
@@ -35,7 +35,7 @@ function makeDeps(overrides: Partial<DelegateDeps> = {}): DelegateDeps {
   return {
     appEnabled: () => true,
     discover: () => ({ port: 1, token: 't' }),
-    resolveCwd: () => ({ ok: true, cwd: '/repos/foo' }),
+    resolveCwd: async () => ({ ok: true, cwd: '/repos/foo' }),
     wsDelegate: async (): Promise<DelegateOverWsResult> => ({ sessionId: 'app-1', sendOk: true }),
     persistAppSession: () => appSession,
     cloudDelegate: async () => cloudSession,
@@ -74,7 +74,7 @@ describe('delegateTask — cloud fallback (pre-create only)', () => {
   })
 
   it('falls back to cloud when no trusted local checkout resolves', async () => {
-    const res = await delegateTask(payload, makeDeps({ resolveCwd: () => ({ ok: false, reason: 'no_local_cwd' }) }))
+    const res = await delegateTask(payload, makeDeps({ resolveCwd: async () => ({ ok: false, reason: 'no_local_cwd' }) }))
     expect(res.kind).toBe('cloud')
   })
 
@@ -121,17 +121,17 @@ describe('delegateTask — idempotency boundary (never double-delegate)', () => 
 })
 
 describe('appDelegateAvailability', () => {
-  it('reports the specific skip reason', () => {
-    expect(appDelegateAvailability('me', 'foo', 1, makeDeps({ appEnabled: () => false }))).toEqual({
+  it('reports the specific skip reason', async () => {
+    expect(await appDelegateAvailability('me', 'foo', 1, makeDeps({ appEnabled: () => false }))).toEqual({
       appAvailable: false, reason: 'flag_disabled',
     })
-    expect(appDelegateAvailability('me', 'foo', 1, makeDeps({ discover: () => null }))).toEqual({
+    expect(await appDelegateAvailability('me', 'foo', 1, makeDeps({ discover: () => null }))).toEqual({
       appAvailable: false, reason: 'app_not_running',
     })
     expect(
-      appDelegateAvailability('me', 'foo', 1, makeDeps({ resolveCwd: () => ({ ok: false, reason: 'no_local_cwd' }) }))
+      await appDelegateAvailability('me', 'foo', 1, makeDeps({ resolveCwd: async () => ({ ok: false, reason: 'no_local_cwd' }) }))
     ).toEqual({ appAvailable: false, reason: 'no_local_cwd' })
-    expect(appDelegateAvailability('me', 'foo', 1, makeDeps())).toEqual({ appAvailable: true })
+    expect(await appDelegateAvailability('me', 'foo', 1, makeDeps())).toEqual({ appAvailable: true })
   })
 })
 

--- a/src/main/agent/copilot-app/delegate.test.ts
+++ b/src/main/agent/copilot-app/delegate.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi } from 'vitest'
+
+// delegate.ts transitively imports the production db/electron modules via
+// createDefaultDelegateDeps; these tests only use injected fakes, so stub the db
+// layer to keep the module graph from loading electron/better-sqlite3.
+vi.mock('../../db', () => ({ getDb: vi.fn() }))
+
+import {
+  delegateTask,
+  appDelegateAvailability,
+  buildAppSessionDeepLink,
+  type DelegateDeps,
+} from './delegate'
+import { AppUnavailableError, CreateAmbiguousError, type DelegateOverWsResult } from './client'
+import type { CopilotAppSession, CopilotSession, DelegatePayload } from '../../../shared/ipc-channels'
+
+const payload: DelegatePayload = {
+  prompt: 'do the thing',
+  repoOwner: 'me',
+  repoName: 'foo',
+  projectId: 1,
+}
+
+const appSession: CopilotAppSession = {
+  id: 'app-1', projectId: 1, cwd: '/repos/foo', title: 'do the thing',
+  status: 'in_progress', repoOwner: 'me', repoName: 'foo', createdAt: '', updatedAt: '',
+}
+const cloudSession: CopilotSession = {
+  id: 'cloud-1', projectId: 1, source: 'github', status: 'in_progress', title: 'do the thing',
+  htmlUrl: null, startedAt: '', updatedAt: '', repoOwner: 'me', repoName: 'foo',
+  branch: null, linkedPrUrl: null, pinnedProjectId: 1,
+}
+
+function makeDeps(overrides: Partial<DelegateDeps> = {}): DelegateDeps {
+  return {
+    appEnabled: () => true,
+    discover: () => ({ port: 1, token: 't' }),
+    resolveCwd: () => ({ ok: true, cwd: '/repos/foo' }),
+    wsDelegate: async (): Promise<DelegateOverWsResult> => ({ sessionId: 'app-1', sendOk: true }),
+    persistAppSession: () => appSession,
+    cloudDelegate: async () => cloudSession,
+    ...overrides,
+  }
+}
+
+describe('delegateTask — app path', () => {
+  it('delegates to the app when enabled + running + cwd resolves (no cloud)', async () => {
+    const cloud = vi.fn(async () => cloudSession)
+    const res = await delegateTask(payload, makeDeps({ cloudDelegate: cloud }))
+    expect(res).toEqual({ kind: 'app', session: appSession })
+    expect(cloud).not.toHaveBeenCalled()
+  })
+
+  it('returns app-send-failed when the session was created but the prompt did not send', async () => {
+    const cloud = vi.fn(async () => cloudSession)
+    const res = await delegateTask(
+      payload,
+      makeDeps({ wsDelegate: async () => ({ sessionId: 'app-1', sendOk: false }), cloudDelegate: cloud })
+    )
+    expect(res).toEqual({ kind: 'app-send-failed', session: appSession })
+    expect(cloud).not.toHaveBeenCalled()
+  })
+})
+
+describe('delegateTask — cloud fallback (pre-create only)', () => {
+  it('falls back to cloud when the flag is off', async () => {
+    const res = await delegateTask(payload, makeDeps({ appEnabled: () => false }))
+    expect(res).toEqual({ kind: 'cloud', session: cloudSession })
+  })
+
+  it('falls back to cloud when the app is not running', async () => {
+    const res = await delegateTask(payload, makeDeps({ discover: () => null }))
+    expect(res.kind).toBe('cloud')
+  })
+
+  it('falls back to cloud when no trusted local checkout resolves', async () => {
+    const res = await delegateTask(payload, makeDeps({ resolveCwd: () => ({ ok: false, reason: 'no_local_cwd' }) }))
+    expect(res.kind).toBe('cloud')
+  })
+
+  it('falls back to cloud when a base branch is requested (app WS has no branch concept)', async () => {
+    const ws = vi.fn(async () => ({ sessionId: 'x', sendOk: true }))
+    const res = await delegateTask({ ...payload, baseBranch: 'main' }, makeDeps({ wsDelegate: ws }))
+    expect(res.kind).toBe('cloud')
+    expect(ws).not.toHaveBeenCalled()
+  })
+
+  it('falls back to cloud on a pre-create AppUnavailableError', async () => {
+    const res = await delegateTask(
+      payload,
+      makeDeps({ wsDelegate: async () => { throw new AppUnavailableError('handshake timeout') } })
+    )
+    expect(res.kind).toBe('cloud')
+  })
+})
+
+describe('delegateTask — idempotency boundary (never double-delegate)', () => {
+  it('does NOT fall back to cloud after an ambiguous create; surfaces a check-the-app message', async () => {
+    const cloud = vi.fn(async () => cloudSession)
+    await expect(
+      delegateTask(
+        payload,
+        makeDeps({
+          wsDelegate: async () => { throw new CreateAmbiguousError('create sent, no ack') },
+          cloudDelegate: cloud,
+        })
+      )
+    ).rejects.toThrow(/check the Copilot app before retrying/)
+    expect(cloud).not.toHaveBeenCalled()
+  })
+
+  it('rejects an empty prompt without touching either path', async () => {
+    const ws = vi.fn(async () => ({ sessionId: 'x', sendOk: true }))
+    const cloud = vi.fn(async () => cloudSession)
+    await expect(
+      delegateTask({ ...payload, prompt: '   ' }, makeDeps({ wsDelegate: ws, cloudDelegate: cloud }))
+    ).rejects.toThrow(/DELEGATE_FAILED/)
+    expect(ws).not.toHaveBeenCalled()
+    expect(cloud).not.toHaveBeenCalled()
+  })
+})
+
+describe('appDelegateAvailability', () => {
+  it('reports the specific skip reason', () => {
+    expect(appDelegateAvailability('me', 'foo', 1, makeDeps({ appEnabled: () => false }))).toEqual({
+      appAvailable: false, reason: 'flag_disabled',
+    })
+    expect(appDelegateAvailability('me', 'foo', 1, makeDeps({ discover: () => null }))).toEqual({
+      appAvailable: false, reason: 'app_not_running',
+    })
+    expect(
+      appDelegateAvailability('me', 'foo', 1, makeDeps({ resolveCwd: () => ({ ok: false, reason: 'no_local_cwd' }) }))
+    ).toEqual({ appAvailable: false, reason: 'no_local_cwd' })
+    expect(appDelegateAvailability('me', 'foo', 1, makeDeps())).toEqual({ appAvailable: true })
+  })
+})
+
+describe('buildAppSessionDeepLink', () => {
+  it('builds the deep link for a safe id', () => {
+    expect(buildAppSessionDeepLink('2adcd1f7-57ee-47ee-82fa-360a99454c4f')).toBe(
+      'github-app://sessions/2adcd1f7-57ee-47ee-82fa-360a99454c4f'
+    )
+  })
+  it('rejects unsafe ids (no injection)', () => {
+    expect(buildAppSessionDeepLink('../evil')).toBeNull()
+    expect(buildAppSessionDeepLink('a b')).toBeNull()
+    expect(buildAppSessionDeepLink('')).toBeNull()
+    expect(buildAppSessionDeepLink('x?foo=bar')).toBeNull()
+  })
+})

--- a/src/main/agent/copilot-app/delegate.ts
+++ b/src/main/agent/copilot-app/delegate.ts
@@ -30,7 +30,7 @@ import { insertLaunchedSession } from '../../copilot/db'
 export interface DelegateDeps {
   appEnabled: () => boolean
   discover: () => WsEndpoint | null
-  resolveCwd: (owner: string, repo: string, projectId: number | null) => CwdResolution
+  resolveCwd: (owner: string, repo: string, projectId: number | null) => Promise<CwdResolution>
   wsDelegate: (endpoint: WsEndpoint, cwd: string, prompt: string, model?: string) => Promise<DelegateOverWsResult>
   persistAppSession: (input: InsertAppSessionInput) => CopilotAppSession
   cloudDelegate: (payload: DelegatePayload) => Promise<CopilotSession>
@@ -91,7 +91,7 @@ async function tryAppDelegate(
   if (payload.baseBranch !== undefined && payload.baseBranch.trim().length > 0) return 'skip'
   const endpoint = deps.discover()
   if (endpoint === null) return 'skip' // app not running
-  const cwd = deps.resolveCwd(payload.repoOwner.trim(), payload.repoName.trim(), payload.projectId)
+  const cwd = await deps.resolveCwd(payload.repoOwner.trim(), payload.repoName.trim(), payload.projectId)
   if (!cwd.ok) return 'skip' // no trusted local checkout → cloud
 
   let ws: DelegateOverWsResult
@@ -134,15 +134,16 @@ export async function delegateTask(payload: DelegatePayload, deps: DelegateDeps)
 }
 
 /** Diagnose whether the app path would be taken for a repo (for a UI hint). */
-export function appDelegateAvailability(
+export async function appDelegateAvailability(
   owner: string,
   repo: string,
   projectId: number | null,
   deps: DelegateDeps
-): { appAvailable: true } | { appAvailable: false; reason: AppDelegateSkipReason } {
+): Promise<{ appAvailable: true } | { appAvailable: false; reason: AppDelegateSkipReason }> {
   if (!deps.appEnabled()) return { appAvailable: false, reason: 'flag_disabled' }
   if (deps.discover() === null) return { appAvailable: false, reason: 'app_not_running' }
-  if (!deps.resolveCwd(owner.trim(), repo.trim(), projectId).ok) {
+  const cwd = await deps.resolveCwd(owner.trim(), repo.trim(), projectId)
+  if (!cwd.ok) {
     return { appAvailable: false, reason: 'no_local_cwd' }
   }
   return { appAvailable: true }

--- a/src/main/agent/copilot-app/delegate.ts
+++ b/src/main/agent/copilot-app/delegate.ts
@@ -1,0 +1,160 @@
+/**
+ * Delegate strategy: try the installed Copilot desktop app, else fall back to a
+ * cloud `gh agent-task`. This is the one place the two paths meet.
+ *
+ * Idempotency boundary (prevents double-delegation): the app path is only
+ * attempted when the flag is on, the app is running, AND a trusted local
+ * checkout resolves. A pre-create failure (`AppUnavailableError`) is safe to
+ * fall back to cloud. Anything after `create_session` was sent
+ * (`CreateAmbiguousError` and beyond) must NOT fall back — we surface a
+ * DELEGATE_FAILED error instead, because the app may have created a session we
+ * can't see and a cloud task would duplicate the work.
+ */
+
+import type {
+  AppDelegateSkipReason,
+  CopilotAppSession,
+  CopilotSession,
+  DelegatePayload,
+  DelegateResult,
+} from '../../../shared/ipc-channels'
+import { discoverWsEndpoint, type WsEndpoint } from './discover'
+import { resolveLocalCwd, type CwdResolution } from './cwd'
+import { AppUnavailableError, CreateAmbiguousError, delegateOverWs, type DelegateOverWsResult } from './client'
+import { insertAppSession, type InsertAppSessionInput } from './store'
+import { getAppDelegateEnabled, getReposRoot } from './settings'
+import { getProjectOverridePath } from './project-cwd'
+import { launchAgentTask } from '../../copilot/launch'
+import { insertLaunchedSession } from '../../copilot/db'
+
+export interface DelegateDeps {
+  appEnabled: () => boolean
+  discover: () => WsEndpoint | null
+  resolveCwd: (owner: string, repo: string, projectId: number | null) => CwdResolution
+  wsDelegate: (endpoint: WsEndpoint, cwd: string, prompt: string, model?: string) => Promise<DelegateOverWsResult>
+  persistAppSession: (input: InsertAppSessionInput) => CopilotAppSession
+  cloudDelegate: (payload: DelegatePayload) => Promise<CopilotSession>
+}
+
+/** Production wiring for the delegate strategy. */
+export function createDefaultDelegateDeps(): DelegateDeps {
+  return {
+    appEnabled: getAppDelegateEnabled,
+    discover: () => discoverWsEndpoint(),
+    resolveCwd: (owner, repo, projectId) =>
+      resolveLocalCwd(owner, repo, {
+        reposRoot: getReposRoot(),
+        overridePath: projectId !== null ? getProjectOverridePath(projectId) : null,
+      }),
+    wsDelegate: (endpoint, cwd, prompt, model) => delegateOverWs(endpoint, cwd, prompt, model),
+    persistAppSession: insertAppSession,
+    cloudDelegate: async (payload) => {
+      const parsed = await launchAgentTask(payload)
+      return insertLaunchedSession({
+        id: parsed.sessionId,
+        title: payload.prompt.trim(),
+        repoOwner: payload.repoOwner.trim(),
+        repoName: payload.repoName.trim(),
+        htmlUrl: parsed.prUrl ?? parsed.sessionUrl,
+        linkedPrUrl: parsed.prUrl,
+        projectId: payload.projectId,
+      })
+    },
+  }
+}
+
+function validatePayload(payload: DelegatePayload): { prompt: string; owner: string; name: string } {
+  const prompt = payload.prompt.trim()
+  if (prompt.length === 0) throw new Error('DELEGATE_FAILED: a prompt is required')
+  const owner = payload.repoOwner.trim()
+  const name = payload.repoName.trim()
+  if (owner.length === 0 || name.length === 0) {
+    throw new Error('DELEGATE_FAILED: a target repository is required')
+  }
+  return { prompt, owner, name }
+}
+
+/**
+ * Attempt the desktop-app path. Returns a `DelegateResult` when the app handled
+ * it, `'skip'` when the app path isn't taken (fall back to cloud), or throws a
+ * DELEGATE_FAILED error when the create was ambiguous (must NOT fall back).
+ */
+async function tryAppDelegate(
+  payload: DelegatePayload,
+  prompt: string,
+  deps: DelegateDeps
+): Promise<DelegateResult | 'skip'> {
+  if (!deps.appEnabled()) return 'skip'
+  // A base-branch request can only be honored by the cloud path (`gh agent-task
+  // -b`); the desktop app runs in whatever branch the local checkout is on. So
+  // an explicit base branch routes to cloud rather than silently ignoring it.
+  if (payload.baseBranch !== undefined && payload.baseBranch.trim().length > 0) return 'skip'
+  const endpoint = deps.discover()
+  if (endpoint === null) return 'skip' // app not running
+  const cwd = deps.resolveCwd(payload.repoOwner.trim(), payload.repoName.trim(), payload.projectId)
+  if (!cwd.ok) return 'skip' // no trusted local checkout → cloud
+
+  let ws: DelegateOverWsResult
+  try {
+    ws = await deps.wsDelegate(endpoint, cwd.cwd, prompt, undefined)
+  } catch (err) {
+    if (err instanceof AppUnavailableError) return 'skip' // pre-create → cloud is safe
+    if (err instanceof CreateAmbiguousError) {
+      // The app may have opened a session we can't see. Never start a cloud task
+      // too (that would double-delegate); tell the user to check the app.
+      throw new Error(
+        'DELEGATE_FAILED: The Copilot app may have opened a session, and no cloud task was started - check the Copilot app before retrying.',
+        { cause: err }
+      )
+    }
+    // Any other post-create failure is also not safe to fall back on.
+    throw new Error(`DELEGATE_FAILED: ${err instanceof Error ? err.message : String(err)}`, { cause: err })
+  }
+
+  const session = deps.persistAppSession({
+    id: ws.sessionId,
+    projectId: payload.projectId,
+    cwd: cwd.cwd,
+    title: prompt,
+    repoOwner: payload.repoOwner.trim(),
+    repoName: payload.repoName.trim(),
+  })
+  return ws.sendOk ? { kind: 'app', session } : { kind: 'app-send-failed', session }
+}
+
+/** Run the full delegate ladder. */
+export async function delegateTask(payload: DelegatePayload, deps: DelegateDeps): Promise<DelegateResult> {
+  const { prompt } = validatePayload(payload)
+
+  const appResult = await tryAppDelegate(payload, prompt, deps)
+  if (appResult !== 'skip') return appResult
+
+  const session = await deps.cloudDelegate(payload)
+  return { kind: 'cloud', session }
+}
+
+/** Diagnose whether the app path would be taken for a repo (for a UI hint). */
+export function appDelegateAvailability(
+  owner: string,
+  repo: string,
+  projectId: number | null,
+  deps: DelegateDeps
+): { appAvailable: true } | { appAvailable: false; reason: AppDelegateSkipReason } {
+  if (!deps.appEnabled()) return { appAvailable: false, reason: 'flag_disabled' }
+  if (deps.discover() === null) return { appAvailable: false, reason: 'app_not_running' }
+  if (!deps.resolveCwd(owner.trim(), repo.trim(), projectId).ok) {
+    return { appAvailable: false, reason: 'no_local_cwd' }
+  }
+  return { appAvailable: true }
+}
+
+/**
+ * Validate a session id and build the sanctioned open-in-app deep link, or null
+ * when the id is unsafe. Only uuid-shaped / alphanumeric-dash ids are allowed so
+ * nothing can be injected into the URL.
+ */
+export function buildAppSessionDeepLink(sessionId: string): string | null {
+  const id = sessionId.trim()
+  if (!/^[A-Za-z0-9-]{1,64}$/.test(id)) return null
+  return `github-app://sessions/${id}`
+}

--- a/src/main/agent/copilot-app/delegate.ts
+++ b/src/main/agent/copilot-app/delegate.ts
@@ -63,7 +63,7 @@ export function createDefaultDelegateDeps(): DelegateDeps {
   }
 }
 
-function validatePayload(payload: DelegatePayload): { prompt: string; owner: string; name: string } {
+function validatePayload(payload: DelegatePayload): { prompt: string } {
   const prompt = payload.prompt.trim()
   if (prompt.length === 0) throw new Error('DELEGATE_FAILED: a prompt is required')
   const owner = payload.repoOwner.trim()
@@ -71,7 +71,7 @@ function validatePayload(payload: DelegatePayload): { prompt: string; owner: str
   if (owner.length === 0 || name.length === 0) {
     throw new Error('DELEGATE_FAILED: a target repository is required')
   }
-  return { prompt, owner, name }
+  return { prompt }
 }
 
 /**

--- a/src/main/agent/copilot-app/discover.test.ts
+++ b/src/main/agent/copilot-app/discover.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { discoverWsEndpoint } from './discover'
+
+let dir: string
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'ws-discover-'))
+})
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true })
+})
+
+describe('discoverWsEndpoint', () => {
+  it('reads the first line of port + token', () => {
+    writeFileSync(join(dir, 'ws.port'), '62599\n')
+    writeFileSync(join(dir, 'ws.token'), 'abc123token\nignored-second-line')
+    expect(discoverWsEndpoint(dir)).toEqual({ port: 62599, token: 'abc123token' })
+  })
+
+  it('returns null when files are missing (app not running)', () => {
+    expect(discoverWsEndpoint(dir)).toBeNull()
+  })
+
+  it('returns null on a non-numeric or out-of-range port', () => {
+    writeFileSync(join(dir, 'ws.token'), 'tok')
+    writeFileSync(join(dir, 'ws.port'), 'notaport')
+    expect(discoverWsEndpoint(dir)).toBeNull()
+    writeFileSync(join(dir, 'ws.port'), '99999')
+    expect(discoverWsEndpoint(dir)).toBeNull()
+  })
+
+  it('returns null on an empty token', () => {
+    writeFileSync(join(dir, 'ws.port'), '62599')
+    writeFileSync(join(dir, 'ws.token'), '\n\n')
+    expect(discoverWsEndpoint(dir)).toBeNull()
+  })
+})

--- a/src/main/agent/copilot-app/discover.ts
+++ b/src/main/agent/copilot-app/discover.ts
@@ -1,0 +1,60 @@
+/**
+ * Discover the installed Copilot desktop app's local WebSocket endpoint.
+ *
+ * The app writes two files under `~/.copilot/run/` when it's running:
+ *   - `ws.port`  — line 1 is the localhost port it listens on.
+ *   - `ws.token` — line 1 is a 43-char base64 auth token (mode 0600). It
+ *     ROTATES on every app launch, so callers must re-read on every connect.
+ *
+ * We only ever READ these files (never write), and the token value is never
+ * logged. When the app isn't running the files may be absent or stale; a stale
+ * token simply fails the handshake, at which point delegation falls back to the
+ * cloud path.
+ */
+
+import { readFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+export interface WsEndpoint {
+  port: number
+  /** The auth token. Treat as a secret: never log or persist it. */
+  token: string
+}
+
+/** Directory the desktop app writes its runtime files to. */
+export function copilotRunDir(): string {
+  return join(homedir(), '.copilot', 'run')
+}
+
+/** First non-empty line of a file's contents, trimmed; null when unreadable. */
+function firstLine(path: string): string | null {
+  let raw: string
+  try {
+    raw = readFileSync(path, 'utf8')
+  } catch {
+    return null // file missing / unreadable → app not running
+  }
+  for (const line of raw.split(/\r?\n/)) {
+    const trimmed = line.trim()
+    if (trimmed.length > 0) return trimmed
+  }
+  return null
+}
+
+/**
+ * Read the current WS endpoint (port + token). Returns null when the app isn't
+ * running (files absent) or the contents are malformed. Re-read on every
+ * connect — the token rotates per app launch.
+ */
+export function discoverWsEndpoint(runDir: string = copilotRunDir()): WsEndpoint | null {
+  const portRaw = firstLine(join(runDir, 'ws.port'))
+  const token = firstLine(join(runDir, 'ws.token'))
+  if (portRaw === null || token === null) return null
+
+  const port = Number(portRaw)
+  if (!Number.isInteger(port) || port <= 0 || port > 65535) return null
+  if (token.length === 0) return null
+
+  return { port, token }
+}

--- a/src/main/agent/copilot-app/discover.ts
+++ b/src/main/agent/copilot-app/discover.ts
@@ -52,7 +52,9 @@ export function discoverWsEndpoint(runDir: string = copilotRunDir()): WsEndpoint
   const token = firstLine(join(runDir, 'ws.token'))
   if (portRaw === null || token === null) return null
 
-  const port = Number(portRaw)
+  // Digits-only: reject hex/exponent/other Number() quirks (ws.port is decimal).
+  if (!/^\d+$/.test(portRaw)) return null
+  const port = Number.parseInt(portRaw, 10)
   if (!Number.isInteger(port) || port <= 0 || port > 65535) return null
   if (token.length === 0) return null
 

--- a/src/main/agent/copilot-app/project-cwd.ts
+++ b/src/main/agent/copilot-app/project-cwd.ts
@@ -1,0 +1,33 @@
+/**
+ * Per-project local-checkout override path — the "override" half of the owner's
+ * "convention + override" cwd UX. Stored in `sync_metadata` keyed by project id
+ * so no migration is needed. Unset for the common case (the repos-root
+ * convention resolves `<repos-root>/<repo>`); set only when the convention
+ * doesn't fit a given project's checkout.
+ */
+
+import { getDb } from '../../db'
+
+function key(projectId: number): string {
+  return `copilot_project_cwd_override:${projectId}`
+}
+
+/** The explicit override checkout path for a project, or null when unset. */
+export function getProjectOverridePath(projectId: number): string | null {
+  const row = getDb().prepare('SELECT value FROM sync_metadata WHERE key = ?').get(key(projectId)) as
+    | { value: string }
+    | undefined
+  const value = row?.value.trim()
+  return value !== undefined && value.length > 0 ? value : null
+}
+
+/** Set (or clear, with an empty string) a project's override checkout path. */
+export function setProjectOverridePath(projectId: number, path: string | null): void {
+  const db = getDb()
+  const trimmed = path?.trim() ?? ''
+  if (trimmed.length === 0) {
+    db.prepare('DELETE FROM sync_metadata WHERE key = ?').run(key(projectId))
+    return
+  }
+  db.prepare('INSERT OR REPLACE INTO sync_metadata (key, value) VALUES (?, ?)').run(key(projectId), trimmed)
+}

--- a/src/main/agent/copilot-app/protocol.test.ts
+++ b/src/main/agent/copilot-app/protocol.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest'
+import {
+  buildCreateSession,
+  buildSendMessage,
+  buildDeleteSession,
+  encodeFrame,
+  parseFrame,
+} from './protocol'
+
+describe('protocol builders', () => {
+  it('builds create_session with and without a model', () => {
+    expect(buildCreateSession('/tmp/x')).toEqual({ type: 'create_session', cwd: '/tmp/x' })
+    expect(buildCreateSession('/tmp/x', 'gpt-5-mini')).toEqual({
+      type: 'create_session',
+      cwd: '/tmp/x',
+      model: 'gpt-5-mini',
+    })
+    // blank model is dropped
+    expect(buildCreateSession('/tmp/x', '   ')).toEqual({ type: 'create_session', cwd: '/tmp/x' })
+  })
+
+  it('builds send_message and delete_session', () => {
+    expect(buildSendMessage('s1', 'hi')).toEqual({ type: 'send_message', session_id: 's1', prompt: 'hi' })
+    expect(buildDeleteSession('s1')).toEqual({ type: 'delete_session', session_id: 's1' })
+  })
+
+  it('encodes frames to JSON', () => {
+    expect(JSON.parse(encodeFrame(buildDeleteSession('s1')))).toEqual({ type: 'delete_session', session_id: 's1' })
+  })
+})
+
+describe('parseFrame', () => {
+  it('parses server_hello with instance_id', () => {
+    expect(parseFrame('{"type":"server_hello","instance_id":"abc"}')).toEqual({
+      kind: 'server_hello',
+      instanceId: 'abc',
+    })
+  })
+
+  it('parses session_created / session_deleted with an id', () => {
+    expect(parseFrame('{"type":"session_created","session_id":"s1","cwd":"/x"}')).toEqual({
+      kind: 'session_created',
+      sessionId: 's1',
+    })
+    expect(parseFrame('{"type":"session_deleted","session_id":"s1"}')).toEqual({
+      kind: 'session_deleted',
+      sessionId: 's1',
+    })
+  })
+
+  it('treats an id-less session_created as ambient (not a real create)', () => {
+    expect(parseFrame('{"type":"session_created"}')).toEqual({ kind: 'other', type: 'session_created' })
+  })
+
+  it('parses session_event and preserves its session_id for filtering', () => {
+    expect(parseFrame('{"type":"session_event","session_id":"s2","x":1}')).toEqual({
+      kind: 'session_event',
+      sessionId: 's2',
+    })
+    expect(parseFrame('{"type":"session_event"}')).toEqual({ kind: 'session_event', sessionId: null })
+  })
+
+  it('maps ambient/unknown frames to other without throwing', () => {
+    expect(parseFrame('{"type":"keep_awake_changed","enabled":true}')).toEqual({
+      kind: 'other',
+      type: 'keep_awake_changed',
+    })
+    expect(parseFrame('not json')).toEqual({ kind: 'other', type: '<unparseable>' })
+    expect(parseFrame('123')).toEqual({ kind: 'other', type: '<non-object>' })
+    expect(parseFrame('{"noType":1}')).toEqual({ kind: 'other', type: '<untyped>' })
+  })
+})

--- a/src/main/agent/copilot-app/protocol.ts
+++ b/src/main/agent/copilot-app/protocol.ts
@@ -1,0 +1,133 @@
+/**
+ * The Copilot desktop app's local WebSocket protocol — pure builders + parsers.
+ *
+ * This is the app's UNOFFICIAL internal protocol (serde `tag:"type"`,
+ * snake_case). It's isolated here so a Copilot-app update can only break this
+ * one module. Everything is pure and unit-tested; the socket lives in client.ts.
+ *
+ * Verified against GitHub Copilot app v1.0.67 (see the PR2 spike):
+ *   server → { type: "server_hello", instance_id }
+ *   client → { type: "create_session", cwd, model? }
+ *   server → { type: "session_created", session_id, cwd, session_type, ... }
+ *   client → { type: "send_message", session_id, prompt }
+ *   client → { type: "delete_session", session_id }
+ *   server → { type: "session_deleted", session_id }
+ *   server → { type: "session_event", session_id, ... }   (for ALL sessions)
+ */
+
+// ── Outgoing frames (client → app) ────────────────────────────────────────────
+
+export interface CreateSessionFrame {
+  type: 'create_session'
+  cwd: string
+  model?: string
+}
+
+export interface SendMessageFrame {
+  type: 'send_message'
+  session_id: string
+  prompt: string
+}
+
+export interface DeleteSessionFrame {
+  type: 'delete_session'
+  session_id: string
+}
+
+/** Build a `create_session` frame (optionally pinning a model). Pure. */
+export function buildCreateSession(cwd: string, model?: string): CreateSessionFrame {
+  const frame: CreateSessionFrame = { type: 'create_session', cwd }
+  if (model !== undefined && model.trim().length > 0) frame.model = model.trim()
+  return frame
+}
+
+/** Build a `send_message` frame. Pure. */
+export function buildSendMessage(sessionId: string, prompt: string): SendMessageFrame {
+  return { type: 'send_message', session_id: sessionId, prompt }
+}
+
+/** Build a `delete_session` frame (used to clean up test/aborted sessions). Pure. */
+export function buildDeleteSession(sessionId: string): DeleteSessionFrame {
+  return { type: 'delete_session', session_id: sessionId }
+}
+
+/** Serialize an outgoing frame to a WS text payload. Pure. */
+export function encodeFrame(frame: CreateSessionFrame | SendMessageFrame | DeleteSessionFrame): string {
+  return JSON.stringify(frame)
+}
+
+// ── Incoming frames (app → client) ────────────────────────────────────────────
+
+export interface ServerHello {
+  kind: 'server_hello'
+  instanceId: string | null
+}
+
+export interface SessionCreated {
+  kind: 'session_created'
+  sessionId: string
+}
+
+export interface SessionDeleted {
+  kind: 'session_deleted'
+  sessionId: string
+}
+
+export interface SessionEvent {
+  kind: 'session_event'
+  /** The session this event belongs to (frames arrive for ALL sessions). */
+  sessionId: string | null
+}
+
+/** Any frame type we don't model explicitly (ambient app chatter). */
+export interface OtherFrame {
+  kind: 'other'
+  type: string
+}
+
+export type IncomingFrame = ServerHello | SessionCreated | SessionDeleted | SessionEvent | OtherFrame
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === 'object' ? (value as Record<string, unknown>) : null
+}
+
+function readString(obj: Record<string, unknown>, key: string): string | null {
+  const v = obj[key]
+  return typeof v === 'string' ? v : null
+}
+
+/**
+ * Parse a raw WS text frame into a typed incoming frame. Pure. Unknown or
+ * malformed frames become `{ kind: 'other' }` rather than throwing, so the
+ * client can ignore ambient chatter (`keep_awake_changed`, `resource_snapshot`,
+ * auth updates, session_event for other sessions, …) gracefully.
+ */
+export function parseFrame(raw: string): IncomingFrame {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return { kind: 'other', type: '<unparseable>' }
+  }
+  const obj = asRecord(parsed)
+  if (obj === null) return { kind: 'other', type: '<non-object>' }
+
+  const type = readString(obj, 'type') ?? '<untyped>'
+  switch (type) {
+    case 'server_hello':
+      return { kind: 'server_hello', instanceId: readString(obj, 'instance_id') }
+    case 'session_created': {
+      const sessionId = readString(obj, 'session_id')
+      // A session_created with no id is malformed; treat as ambient.
+      return sessionId !== null ? { kind: 'session_created', sessionId } : { kind: 'other', type }
+    }
+    case 'session_deleted': {
+      const sessionId = readString(obj, 'session_id')
+      return sessionId !== null ? { kind: 'session_deleted', sessionId } : { kind: 'other', type }
+    }
+    case 'session_event':
+      return { kind: 'session_event', sessionId: readString(obj, 'session_id') }
+    default:
+      return { kind: 'other', type }
+  }
+}

--- a/src/main/agent/copilot-app/settings.ts
+++ b/src/main/agent/copilot-app/settings.ts
@@ -1,0 +1,45 @@
+/**
+ * Persisted settings for desktop-app delegation, stored in the shared
+ * `sync_metadata` key-value table (same pattern as the notification-sync
+ * settings). Two keys:
+ *   - the app-delegate feature flag (default OFF until PR3 gives the delegated
+ *     session durable rediscovery on its todo); and
+ *   - the "repos root" used to resolve local checkouts (default ~/repos).
+ */
+
+import { getDb } from '../../db'
+import { DEFAULT_REPOS_ROOT } from './cwd'
+
+const APP_DELEGATE_ENABLED_KEY = 'copilot_app_delegate_enabled'
+const REPOS_ROOT_KEY = 'copilot_repos_root'
+
+function readMeta(key: string): string | null {
+  const row = getDb().prepare('SELECT value FROM sync_metadata WHERE key = ?').get(key) as
+    | { value: string }
+    | undefined
+  return row === undefined ? null : row.value
+}
+
+function writeMeta(key: string, value: string): void {
+  getDb().prepare('INSERT OR REPLACE INTO sync_metadata (key, value) VALUES (?, ?)').run(key, value)
+}
+
+/** Whether the desktop-app delegate path is enabled. Default false. */
+export function getAppDelegateEnabled(): boolean {
+  return readMeta(APP_DELEGATE_ENABLED_KEY) === 'true'
+}
+
+export function setAppDelegateEnabled(enabled: boolean): void {
+  writeMeta(APP_DELEGATE_ENABLED_KEY, enabled ? 'true' : 'false')
+}
+
+/** The configured repos root (raw string; `~` is expanded by the cwd resolver). */
+export function getReposRoot(): string {
+  const value = readMeta(REPOS_ROOT_KEY)?.trim()
+  return value !== undefined && value.length > 0 ? value : DEFAULT_REPOS_ROOT
+}
+
+export function setReposRoot(root: string): void {
+  const trimmed = root.trim()
+  writeMeta(REPOS_ROOT_KEY, trimmed.length > 0 ? trimmed : DEFAULT_REPOS_ROOT)
+}

--- a/src/main/agent/copilot-app/store.integration.test.ts
+++ b/src/main/agent/copilot-app/store.integration.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Database as BunDb } from 'bun:sqlite'
+import type BetterSQLite3 from 'better-sqlite3'
+
+vi.mock('electron', () => ({
+  app: { isPackaged: false, getAppPath: () => process.cwd() },
+}))
+
+vi.mock('../../db', () => ({ getDb: vi.fn() }))
+
+import { getDb } from '../../db'
+import { runMigrations } from '../../db/migrate'
+import { insertAppSession, getAppSession, getAppSessionsForProject, updateAppSessionStatus } from './store'
+import {
+  getSessionsForProject,
+  getUnassignedSessions,
+  getUnassignedActiveCount,
+  getAllStatuses,
+} from '../../copilot/db'
+import { listProjects, getProject } from '../../db/projects'
+
+let db: BunDb
+
+beforeEach(() => {
+  db = new BunDb(':memory:')
+  db.exec('PRAGMA foreign_keys = ON')
+  const betterDb = db as unknown as BetterSQLite3.Database
+  runMigrations(betterDb)
+  vi.mocked(getDb).mockReturnValue(betterDb)
+})
+
+function makeProject(name: string): number {
+  const row = db.prepare('INSERT INTO projects (name) VALUES (?) RETURNING id').get(name) as { id: number }
+  return row.id
+}
+
+describe('copilot_app_sessions store', () => {
+  it('inserts + reads back an app session', () => {
+    const pid = makeProject('P')
+    const s = insertAppSession({
+      id: 'app-1', projectId: pid, cwd: '/repos/foo', title: 'do it', repoOwner: 'me', repoName: 'foo',
+    })
+    expect(s.id).toBe('app-1')
+    expect(s.status).toBe('in_progress')
+    expect(getAppSession('app-1')).toEqual(s)
+    expect(getAppSessionsForProject(pid).map((r) => r.id)).toEqual(['app-1'])
+  })
+
+  it('updates status', () => {
+    const pid = makeProject('P')
+    insertAppSession({ id: 'app-1', projectId: pid, cwd: '/x', title: 't', repoOwner: null, repoName: null })
+    updateAppSessionStatus('app-1', 'completed')
+    expect(getAppSession('app-1')?.status).toBe('completed')
+  })
+
+  it('tracks a session unassigned when the originating project is soft-deleted', () => {
+    const pid = makeProject('P')
+    db.prepare("UPDATE projects SET deleted_at = datetime('now') WHERE id = ?").run(pid)
+    const s = insertAppSession({ id: 'app-1', projectId: pid, cwd: '/x', title: 't', repoOwner: null, repoName: null })
+    expect(s.projectId).toBeNull()
+  })
+})
+
+describe('reader isolation — app sessions never leak into github-session surfaces', () => {
+  it('is invisible to every existing copilot_sessions reader', () => {
+    const pid = makeProject('P')
+    insertAppSession({ id: 'app-1', projectId: pid, cwd: '/x', title: 't', repoOwner: 'me', repoName: 'foo' })
+
+    // None of the github-session readers (which query copilot_sessions) see it.
+    expect(getSessionsForProject(pid)).toEqual([])
+    expect(getUnassignedSessions()).toEqual([])
+    expect(getUnassignedActiveCount()).toBe(0)
+    expect(getAllStatuses()).toEqual({})
+
+    // Project status aggregates are unaffected too.
+    const listed = listProjects().find((p) => p.id === pid)
+    expect(listed?.copilotStatus ?? null).toBeNull()
+    expect(getProject(pid)?.copilotStatus ?? null).toBeNull()
+  })
+})

--- a/src/main/agent/copilot-app/store.ts
+++ b/src/main/agent/copilot-app/store.ts
@@ -16,7 +16,7 @@ interface AppSessionRow {
   project_id: number | null
   cwd: string
   title: string
-  status: string
+  status: CopilotAppSessionStatus
   repo_owner: string | null
   repo_name: string | null
   created_at: string
@@ -29,7 +29,7 @@ function toSession(row: AppSessionRow): CopilotAppSession {
     projectId: row.project_id,
     cwd: row.cwd,
     title: row.title,
-    status: row.status as CopilotAppSessionStatus,
+    status: row.status,
     repoOwner: row.repo_owner,
     repoName: row.repo_name,
     createdAt: row.created_at,

--- a/src/main/agent/copilot-app/store.ts
+++ b/src/main/agent/copilot-app/store.ts
@@ -1,0 +1,98 @@
+/**
+ * Accessors for the dedicated `copilot_app_sessions` table.
+ *
+ * These rows are PRIVATE to the desktop-app delegate feature: no existing
+ * github-session reader touches this table, so app sessions can't leak into the
+ * project rail / digest / unassigned surfaces until those are intentionally made
+ * source-aware (PR3 / #87). All operations are synchronous (better-sqlite3) and
+ * run in the main process.
+ */
+
+import { getDb } from '../../db'
+import type { CopilotAppSession, CopilotAppSessionStatus } from '../../../shared/ipc-channels'
+
+interface AppSessionRow {
+  id: string
+  project_id: number | null
+  cwd: string
+  title: string
+  status: string
+  repo_owner: string | null
+  repo_name: string | null
+  created_at: string
+  updated_at: string
+}
+
+function toSession(row: AppSessionRow): CopilotAppSession {
+  return {
+    id: row.id,
+    projectId: row.project_id,
+    cwd: row.cwd,
+    title: row.title,
+    status: row.status as CopilotAppSessionStatus,
+    repoOwner: row.repo_owner,
+    repoName: row.repo_name,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  }
+}
+
+export interface InsertAppSessionInput {
+  id: string
+  projectId: number | null
+  cwd: string
+  title: string
+  repoOwner: string | null
+  repoName: string | null
+}
+
+/**
+ * Insert a just-delegated app session (status starts `in_progress`). Only pins a
+ * live project: if the originating project vanished mid-delegate (or is
+ * soft-deleted), the session is tracked unassigned instead, so a successful
+ * delegate is never lost to an FK failure.
+ */
+export function insertAppSession(input: InsertAppSessionInput): CopilotAppSession {
+  const db = getDb()
+  const projectIsLive =
+    input.projectId !== null &&
+    db.prepare('SELECT 1 FROM projects WHERE id = ? AND deleted_at IS NULL').get(input.projectId) != null
+  const projectId = projectIsLive ? input.projectId : null
+
+  db.prepare(`
+    INSERT INTO copilot_app_sessions
+      (id, project_id, cwd, title, status, repo_owner, repo_name)
+    VALUES
+      (?, ?, ?, ?, 'in_progress', ?, ?)
+    ON CONFLICT(id) DO UPDATE SET
+      cwd        = excluded.cwd,
+      title      = excluded.title,
+      repo_owner = excluded.repo_owner,
+      repo_name  = excluded.repo_name,
+      updated_at = datetime('now')
+  `).run(input.id, projectId, input.cwd, input.title, input.repoOwner, input.repoName)
+
+  const row = db.prepare('SELECT * FROM copilot_app_sessions WHERE id = ?').get(input.id) as AppSessionRow
+  return toSession(row)
+}
+
+/** Returns a single app session by id, or null. */
+export function getAppSession(id: string): CopilotAppSession | null {
+  const row = getDb().prepare('SELECT * FROM copilot_app_sessions WHERE id = ?').get(id) as AppSessionRow | undefined
+  return row === undefined ? null : toSession(row)
+}
+
+/** Updates the status of an app session (used by the status reader in PR3). */
+export function updateAppSessionStatus(id: string, status: CopilotAppSessionStatus): void {
+  getDb()
+    .prepare("UPDATE copilot_app_sessions SET status = ?, updated_at = datetime('now') WHERE id = ?")
+    .run(status, id)
+}
+
+/** All app sessions for a project, newest first. */
+export function getAppSessionsForProject(projectId: number): CopilotAppSession[] {
+  const rows = getDb()
+    .prepare('SELECT * FROM copilot_app_sessions WHERE project_id = ? ORDER BY updated_at DESC')
+    .all(projectId) as AppSessionRow[]
+  return rows.map(toSession)
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -41,7 +41,9 @@ import { validateMcpServerInput, validateMcpServerPatch, validateToolName, valid
 import { listMcpTools } from './context/mcp-client'
 import { resolveQuestion } from './context/resolve'
 import { createResolveDeps } from './context/resolve-deps'
-import type { ProjectPatch, ProjectTodoPatch, ProjectLinkPatch, SnoozeMode, SyncIntervalMinutes, MaxSyncDays, CreateRoutingRulePayload, LaunchAgentTaskPayload, ResourceInput, ResourcePatch, ProjectCardPatch, McpServerInput, McpServerPatch, McpConnectInput } from '../shared/ipc-channels'
+import { delegateTask, appDelegateAvailability, buildAppSessionDeepLink, createDefaultDelegateDeps } from './agent/copilot-app/delegate'
+import { getAppDelegateEnabled, setAppDelegateEnabled, getReposRoot, setReposRoot } from './agent/copilot-app/settings'
+import type { ProjectPatch, ProjectTodoPatch, ProjectLinkPatch, SnoozeMode, SyncIntervalMinutes, MaxSyncDays, CreateRoutingRulePayload, LaunchAgentTaskPayload, ResourceInput, ResourcePatch, ProjectCardPatch, McpServerInput, McpServerPatch, McpConnectInput, DelegatePayload } from '../shared/ipc-channels'
 import { SYNC_INTERVAL_OPTIONS, MAX_SYNC_DAYS_OPTIONS } from '../shared/ipc-channels'
 
 /** Broadcasts a push event to all renderer windows. */
@@ -285,6 +287,7 @@ app.whenReady().then(async () => {
   })
 
   // Copilot session handlers
+  const delegateDeps = createDefaultDelegateDeps()
   ipcMain.handle('copilot:sessions-for-project', (_event, projectId: number) =>
     getSessionsForProject(projectId)
   )
@@ -321,6 +324,41 @@ app.whenReady().then(async () => {
     broadcast('projects:updated')
   })
   ipcMain.handle('copilot:launch-targets', (_event, projectId: number) => getLaunchTargets(projectId))
+
+  // Delegate: try the installed Copilot desktop app (flag on + running + local
+  // checkout), else fall back to a cloud gh agent-task. One adapter contains the
+  // app's unofficial WS; the cloud path stays the resilient fallback.
+  ipcMain.handle('copilot:delegate', async (_event, payload: DelegatePayload) => {
+    const result = await delegateTask(payload, delegateDeps)
+    broadcast('copilot:updated')
+    if (result.kind === 'cloud') {
+      // Match the cloud-launch reconcile: pull real title/status in the background.
+      void syncCopilotSessions().catch((err: unknown) => {
+        console.error('[copilot] Post-delegate reconcile sync failed:', err)
+      })
+    }
+    return result
+  })
+  ipcMain.handle('copilot:delegate-availability', (_event, repoOwner: string, repoName: string) =>
+    // Availability is repo-scoped; a project override is only consulted on the
+    // actual delegate call, so pass null here.
+    appDelegateAvailability(repoOwner, repoName, null, delegateDeps)
+  )
+  ipcMain.handle('copilot:open-app-session', async (_event, sessionId: string) => {
+    const deepLink = buildAppSessionDeepLink(sessionId)
+    if (deepLink === null) throw new Error('Invalid session id')
+    await shell.openExternal(deepLink)
+  })
+
+  // Desktop-app delegate settings.
+  ipcMain.handle('settings:get-app-delegate-enabled', () => getAppDelegateEnabled())
+  ipcMain.handle('settings:set-app-delegate-enabled', (_event, enabled: boolean) => {
+    setAppDelegateEnabled(enabled)
+  })
+  ipcMain.handle('settings:get-repos-root', () => getReposRoot())
+  ipcMain.handle('settings:set-repos-root', (_event, root: string) => {
+    setReposRoot(root)
+  })
 
   // Focus: re-entry digest + drift handlers
   ipcMain.handle('digest:get', (_event, projectId: number) => getDigest(projectId))

--- a/src/renderer/src/components/DelegateComposer.test.tsx
+++ b/src/renderer/src/components/DelegateComposer.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
-import type { CopilotSession } from '@shared/ipc-channels'
+import type { CopilotSession, DelegateResult } from '@shared/ipc-channels'
 import { DelegateComposer } from './DelegateComposer'
 
 const invoke = vi.fn()
@@ -18,10 +18,11 @@ const session: CopilotSession = {
   htmlUrl: 'https://x/pull/1', startedAt: '', updatedAt: '', repoOwner: 'o', repoName: 'r',
   branch: null, linkedPrUrl: 'https://x/pull/1', pinnedProjectId: 1,
 }
+const cloudResult: DelegateResult = { kind: 'cloud', session }
 
 describe('DelegateComposer', () => {
-  it('pre-fills the prompt and launches with the fixed repo', async () => {
-    invoke.mockResolvedValue(session)
+  it('pre-fills the prompt and delegates with the fixed repo', async () => {
+    invoke.mockResolvedValue(cloudResult)
     const onLaunched = vi.fn()
     const onClose = vi.fn()
     render(
@@ -39,14 +40,14 @@ describe('DelegateComposer', () => {
 
     fireEvent.click(screen.getByText('Launch task'))
 
-    await waitFor(() => expect(invoke).toHaveBeenCalledWith('copilot:launch', {
+    await waitFor(() => expect(invoke).toHaveBeenCalledWith('copilot:delegate', {
       prompt: 'Fix the flaky test',
       repoOwner: 'o',
       repoName: 'r',
       baseBranch: undefined,
       projectId: 1,
     }))
-    await waitFor(() => expect(onLaunched).toHaveBeenCalledWith(session))
+    await waitFor(() => expect(onLaunched).toHaveBeenCalledWith(cloudResult))
     expect(onClose).toHaveBeenCalled()
   })
 

--- a/src/renderer/src/components/DelegateComposer.tsx
+++ b/src/renderer/src/components/DelegateComposer.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { Sparkles, X } from 'lucide-react'
-import type { CopilotSession, LaunchTarget } from '@shared/ipc-channels'
+import type { DelegateResult, LaunchTarget } from '@shared/ipc-channels'
 import { Icon } from './Icon'
 import styles from './DelegateComposer.module.css'
 
@@ -15,7 +15,7 @@ export interface DelegateComposerProps {
    */
   fixedRepo?: LaunchTarget
   onClose: () => void
-  onLaunched: (session: CopilotSession) => void
+  onLaunched: (result: DelegateResult) => void
 }
 
 const OTHER_REPO = '__other__'
@@ -28,7 +28,7 @@ function friendlyError(message: string): string {
   if (message.includes('GH_NOT_AUTHENTICATED')) {
     return 'gh isn’t authenticated for agent tasks. Run `gh auth login` in a terminal, then try again.'
   }
-  const stripped = message.replace(/^Error:\s*/, '').replace(/^LAUNCH_FAILED:\s*/, '')
+  const stripped = message.replace(/^Error:\s*/, '').replace(/^(LAUNCH_FAILED|DELEGATE_FAILED):\s*/, '')
   return stripped.length > 0 ? stripped : 'Could not launch the task.'
 }
 
@@ -102,14 +102,14 @@ export function DelegateComposer({
     setBusy(true)
     setError(null)
     try {
-      const session = await window.electron.ipc.invoke('copilot:launch', {
+      const result = await window.electron.ipc.invoke('copilot:delegate', {
         prompt: prompt.trim(),
         repoOwner: resolvedRepo.repoOwner,
         repoName: resolvedRepo.repoName,
         baseBranch: baseBranch.trim() || undefined,
         projectId,
       })
-      onLaunched(session)
+      onLaunched(result)
       onClose()
     } catch (err: unknown) {
       setError(friendlyError(err instanceof Error ? err.message : String(err)))

--- a/src/renderer/src/pages/FocusPage.tsx
+++ b/src/renderer/src/pages/FocusPage.tsx
@@ -164,12 +164,24 @@ export function FocusPage(props: FocusPageProps): JSX.Element {
           projectId={props.projectId}
           fixedRepo={delegate.fixedRepo}
           onClose={() => setDelegate(null)}
-          onLaunched={(session) => {
-            props.showUndo(
-              'Copilot is on it — I’ll fold the result into your digest.',
-              () => { if (session.htmlUrl) openExternal(session.htmlUrl) },
-              'Open'
-            )
+          onLaunched={(result) => {
+            if (result.kind === 'cloud') {
+              props.showUndo(
+                'Copilot is on it — I’ll fold the result into your digest.',
+                () => { if (result.session.htmlUrl) openExternal(result.session.htmlUrl) },
+                'Open'
+              )
+            } else {
+              const message =
+                result.kind === 'app-send-failed'
+                  ? 'Opened a Copilot session, but I couldn’t hand off the task — open it to retry.'
+                  : 'Copilot is on it in the desktop app.'
+              props.showUndo(
+                message,
+                () => { fire(window.electron.ipc.invoke('copilot:open-app-session', result.session.id)) },
+                'Open'
+              )
+            }
           }}
         />
       )}

--- a/src/renderer/src/pages/FocusPage.tsx
+++ b/src/renderer/src/pages/FocusPage.tsx
@@ -178,7 +178,7 @@ export function FocusPage(props: FocusPageProps): JSX.Element {
                   : 'Copilot is on it in the desktop app.'
               props.showUndo(
                 message,
-                () => { fire(window.electron.ipc.invoke('copilot:open-app-session', result.session.id)) },
+                () => { fire(window.electron.ipc.invoke('copilot:open-app-session', result.session.id), 'copilot:open-app-session') },
                 'Open'
               )
             }

--- a/src/renderer/src/pages/SettingsView.module.css
+++ b/src/renderer/src/pages/SettingsView.module.css
@@ -88,6 +88,10 @@
   cursor: pointer;
 }
 
+.checkbox:disabled {
+  cursor: default;
+}
+
 .segmented {
   display: inline-flex;
   padding: 2px;

--- a/src/renderer/src/pages/SettingsView.module.css
+++ b/src/renderer/src/pages/SettingsView.module.css
@@ -72,6 +72,22 @@
   color: var(--text);
 }
 
+.hint {
+  display: block;
+  margin-top: 3px;
+  max-width: 340px;
+  font-size: 12px;
+  color: var(--text-3);
+}
+
+.checkbox {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  accent-color: var(--accent);
+  cursor: pointer;
+}
+
 .segmented {
   display: inline-flex;
   padding: 2px;

--- a/src/renderer/src/pages/SettingsView.test.tsx
+++ b/src/renderer/src/pages/SettingsView.test.tsx
@@ -81,7 +81,7 @@ describe('SettingsView appearance', () => {
     render(<SettingsView theme={theme()} onClose={vi.fn()} onOpenRules={vi.fn()} />)
     const input = (await screen.findByPlaceholderText('~/repos')) as HTMLInputElement
     fireEvent.change(input, { target: { value: '~/code' } })
-    fireEvent.blur(input)
+    fireEvent.click(screen.getByText('Save'))
     await waitFor(() => expect(invoke).toHaveBeenCalledWith('settings:set-repos-root', '~/code'))
   })
 })

--- a/src/renderer/src/pages/SettingsView.test.tsx
+++ b/src/renderer/src/pages/SettingsView.test.tsx
@@ -84,4 +84,13 @@ describe('SettingsView appearance', () => {
     fireEvent.click(screen.getByText('Save'))
     await waitFor(() => expect(invoke).toHaveBeenCalledWith('settings:set-repos-root', '~/code'))
   })
+
+  it('normalizes a cleared repos root to the default and reflects it in the input', async () => {
+    render(<SettingsView theme={theme()} onClose={vi.fn()} onOpenRules={vi.fn()} />)
+    const input = (await screen.findByPlaceholderText('~/repos')) as HTMLInputElement
+    fireEvent.change(input, { target: { value: '   ' } })
+    fireEvent.click(screen.getByText('Save'))
+    await waitFor(() => expect(invoke).toHaveBeenCalledWith('settings:set-repos-root', '~/repos'))
+    expect(input.value).toBe('~/repos')
+  })
 })

--- a/src/renderer/src/pages/SettingsView.test.tsx
+++ b/src/renderer/src/pages/SettingsView.test.tsx
@@ -16,6 +16,10 @@ beforeEach(() => {
         return Promise.resolve(15)
       case 'settings:get-max-sync-days':
         return Promise.resolve(7)
+      case 'settings:get-app-delegate-enabled':
+        return Promise.resolve(false)
+      case 'settings:get-repos-root':
+        return Promise.resolve('~/repos')
       default:
         return Promise.resolve(undefined)
     }
@@ -60,5 +64,24 @@ describe('SettingsView appearance', () => {
     render(<SettingsView theme={theme()} onClose={vi.fn()} onOpenRules={onOpenRules} />)
     fireEvent.click(await screen.findByText('Notification rules'))
     expect(onOpenRules).toHaveBeenCalled()
+  })
+
+  it('toggles the Copilot app-delegate flag and persists it', async () => {
+    render(<SettingsView theme={theme()} onClose={vi.fn()} onOpenRules={vi.fn()} />)
+    const toggle = (await screen.findByText('Delegate to the Copilot app')).closest('label')?.querySelector('input')
+    expect(toggle).toBeTruthy()
+    expect((toggle as HTMLInputElement).checked).toBe(false)
+    fireEvent.click(toggle as HTMLInputElement)
+    await waitFor(() =>
+      expect(invoke).toHaveBeenCalledWith('settings:set-app-delegate-enabled', true)
+    )
+  })
+
+  it('saves the repos root', async () => {
+    render(<SettingsView theme={theme()} onClose={vi.fn()} onOpenRules={vi.fn()} />)
+    const input = (await screen.findByPlaceholderText('~/repos')) as HTMLInputElement
+    fireEvent.change(input, { target: { value: '~/code' } })
+    fireEvent.blur(input)
+    await waitFor(() => expect(invoke).toHaveBeenCalledWith('settings:set-repos-root', '~/code'))
   })
 })

--- a/src/renderer/src/pages/SettingsView.tsx
+++ b/src/renderer/src/pages/SettingsView.tsx
@@ -266,7 +266,6 @@ export function SettingsView({ theme, onClose, onOpenRules }: SettingsViewProps)
                 spellCheck={false}
                 disabled={reposRoot === null}
                 onChange={(e) => setReposRoot(e.target.value)}
-                onBlur={saveReposRoot}
               />
               <button
                 type="button"

--- a/src/renderer/src/pages/SettingsView.tsx
+++ b/src/renderer/src/pages/SettingsView.tsx
@@ -15,6 +15,7 @@ import {
 import {
   SYNC_INTERVAL_OPTIONS,
   MAX_SYNC_DAYS_OPTIONS,
+  DEFAULT_REPOS_ROOT,
   type SyncIntervalMinutes,
   type MaxSyncDays,
 } from '@shared/ipc-channels'
@@ -99,7 +100,11 @@ export function SettingsView({ theme, onClose, onOpenRules }: SettingsViewProps)
   }
   const saveReposRoot = (): void => {
     if (reposRoot === null) return
-    fire(window.electron.ipc.invoke('settings:set-repos-root', reposRoot), 'settings:set-repos-root')
+    // Mirror main's normalization (blank → default) so the input reflects what
+    // was actually stored instead of looking like the save was lost.
+    const normalized = reposRoot.trim().length > 0 ? reposRoot.trim() : DEFAULT_REPOS_ROOT
+    setReposRoot(normalized)
+    fire(window.electron.ipc.invoke('settings:set-repos-root', normalized), 'settings:set-repos-root')
   }
 
   return (

--- a/src/renderer/src/pages/SettingsView.tsx
+++ b/src/renderer/src/pages/SettingsView.tsx
@@ -58,18 +58,24 @@ export function SettingsView({ theme, onClose, onOpenRules }: SettingsViewProps)
   const [token, setToken] = useState('')
   const [syncInterval, setSyncInterval] = useState<SyncIntervalMinutes | null>(null)
   const [maxDays, setMaxDays] = useState<MaxSyncDays | null>(null)
+  const [appDelegate, setAppDelegate] = useState<boolean | null>(null)
+  const [reposRoot, setReposRoot] = useState<string | null>(null)
 
   useEffect(() => {
     let active = true
     void (async () => {
       try {
-        const [interval, days] = await Promise.all([
+        const [interval, days, delegate, root] = await Promise.all([
           window.electron.ipc.invoke('settings:get-sync-interval'),
           window.electron.ipc.invoke('settings:get-max-sync-days'),
+          window.electron.ipc.invoke('settings:get-app-delegate-enabled'),
+          window.electron.ipc.invoke('settings:get-repos-root'),
         ])
         if (!active) return
         setSyncInterval(interval)
         setMaxDays(days)
+        setAppDelegate(delegate)
+        setReposRoot(root)
       } catch (err) {
         console.error('[Settings] load failed:', err)
       }
@@ -86,6 +92,14 @@ export function SettingsView({ theme, onClose, onOpenRules }: SettingsViewProps)
   const changeMaxDays = (value: MaxSyncDays): void => {
     setMaxDays(value)
     fire(window.electron.ipc.invoke('settings:set-max-sync-days', value), 'settings:set-max-sync-days')
+  }
+  const changeAppDelegate = (value: boolean): void => {
+    setAppDelegate(value)
+    fire(window.electron.ipc.invoke('settings:set-app-delegate-enabled', value), 'settings:set-app-delegate-enabled')
+  }
+  const saveReposRoot = (): void => {
+    if (reposRoot === null) return
+    fire(window.electron.ipc.invoke('settings:set-repos-root', reposRoot), 'settings:set-repos-root')
   }
 
   return (
@@ -221,6 +235,49 @@ export function SettingsView({ theme, onClose, onOpenRules }: SettingsViewProps)
               <Icon icon={ChevronRight} size={16} />
             </span>
           </button>
+        </section>
+
+        <section className={styles.section}>
+          <h2 className={styles.sectionTitle}>Copilot</h2>
+          <label className={styles.field}>
+            <span className={styles.label}>
+              Delegate to the Copilot app
+              <span className={styles.hint}> — experimental; hands tasks to the installed desktop app when it's running and the repo is checked out locally, otherwise the cloud agent.</span>
+            </span>
+            <input
+              type="checkbox"
+              className={styles.checkbox}
+              checked={appDelegate ?? false}
+              disabled={appDelegate === null}
+              onChange={(e) => changeAppDelegate(e.target.checked)}
+            />
+          </label>
+          <div className={styles.field}>
+            <span className={styles.label}>Repos root</span>
+            <div className={styles.tokenRow}>
+              <input
+                className={styles.tokenInput}
+                type="text"
+                value={reposRoot ?? ''}
+                placeholder="~/repos"
+                autoComplete="off"
+                autoCorrect="off"
+                autoCapitalize="off"
+                spellCheck={false}
+                disabled={reposRoot === null}
+                onChange={(e) => setReposRoot(e.target.value)}
+                onBlur={saveReposRoot}
+              />
+              <button
+                type="button"
+                className={styles.primaryButton}
+                disabled={reposRoot === null}
+                onClick={saveReposRoot}
+              >
+                Save
+              </button>
+            </div>
+          </div>
         </section>
       </div>
     </main>

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -83,6 +83,60 @@ export interface LaunchTarget {
   repoName: string
 }
 
+// ── Copilot desktop-app delegation (#86) ──────────────────────────────────────
+
+/** Status of a delegated Copilot desktop-app session (dedicated store). */
+export type CopilotAppSessionStatus =
+  | 'in_progress' // agent is actively working
+  | 'waiting'     // waiting for the user
+  | 'completed'   // session finished
+  | 'unknown'     // app closed / status unreadable
+
+/**
+ * A task delegated to the INSTALLED GitHub Copilot desktop app over its local
+ * WebSocket. Kept in a dedicated table (`copilot_app_sessions`), never mixed
+ * with cloud `gh agent-task` sessions.
+ */
+export interface CopilotAppSession {
+  id: string                     // WS session_id (uuid)
+  projectId: number | null
+  cwd: string                    // the local checkout the app runs in
+  title: string
+  status: CopilotAppSessionStatus
+  repoOwner: string | null
+  repoName: string | null
+  createdAt: string              // ISO 8601
+  updatedAt: string              // ISO 8601
+}
+
+/** Payload to delegate a task (tries the desktop app, falls back to cloud). */
+export interface DelegatePayload {
+  prompt: string
+  repoOwner: string
+  repoName: string
+  /** Base branch for the cloud fallback's PR; ignored by the app path. */
+  baseBranch?: string
+  /** Originating project, pinned so the session stays co-located. Null = none. */
+  projectId: number | null
+}
+
+/**
+ * The outcome of a delegate. Discriminated so the renderer knows how to open /
+ * track the result. The automatic ladder never returns `untracked` — that's a
+ * separate explicit "open untracked in the app" action.
+ */
+export type DelegateResult =
+  | { kind: 'app'; session: CopilotAppSession }
+  | { kind: 'app-send-failed'; session: CopilotAppSession }
+  | { kind: 'cloud'; session: CopilotSession }
+
+/** Why the desktop-app path wasn't taken for a delegate (diagnostic, non-fatal). */
+export type AppDelegateSkipReason =
+  | 'flag_disabled'   // the app-delegate feature flag is off
+  | 'app_not_running' // no WS discovery / connection refused
+  | 'no_local_cwd'    // no trusted local checkout resolved for the repo
+
+
 export interface Project {
   id: number
   name: string
@@ -838,6 +892,61 @@ export type IpcChannels = {
   'copilot:launch-targets': {
     args: [projectId: number]
     result: LaunchTarget[]
+  }
+
+  /**
+   * Delegate a task: try the installed Copilot desktop app over its local WS
+   * (when the feature flag is on, the app is running, and a trusted local
+   * checkout resolves for the repo), else fall back to a cloud `gh agent-task`.
+   * Returns a discriminated `DelegateResult`. Rejects with an `Error` whose
+   * `message` is `'GH_NOT_AUTHENTICATED'` or starts with `'DELEGATE_FAILED: '`.
+   */
+  'copilot:delegate': {
+    args: [payload: DelegatePayload]
+    result: DelegateResult
+  }
+
+  /**
+   * Whether the desktop-app delegate path is currently available for a repo
+   * (flag on + app running + a trusted local checkout resolves). Lets the UI
+   * hint where a delegate will land. Never throws; returns a skip reason.
+   */
+  'copilot:delegate-availability': {
+    args: [repoOwner: string, repoName: string]
+    result: { appAvailable: true } | { appAvailable: false; reason: AppDelegateSkipReason }
+  }
+
+  /**
+   * Open a delegated desktop-app session in the Copilot app via the sanctioned
+   * `github-app://sessions/<id>` deep link. The id is validated before use.
+   */
+  'copilot:open-app-session': {
+    args: [sessionId: string]
+    result: void
+  }
+
+  /** Reads the app-delegate feature flag (default false). */
+  'settings:get-app-delegate-enabled': {
+    args: []
+    result: boolean
+  }
+
+  /** Sets the app-delegate feature flag. */
+  'settings:set-app-delegate-enabled': {
+    args: [enabled: boolean]
+    result: void
+  }
+
+  /** Reads the configured "repos root" used to resolve local checkouts. */
+  'settings:get-repos-root': {
+    args: []
+    result: string
+  }
+
+  /** Sets the "repos root" (raw string; `~` is expanded in main). */
+  'settings:set-repos-root': {
+    args: [root: string]
+    result: void
   }
 
   // ── Focus: re-entry digest + drift ───────────────────────────────────────────

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -133,7 +133,7 @@ export type DelegateResult =
 /** Why the desktop-app path wasn't taken for a delegate (diagnostic, non-fatal). */
 export type AppDelegateSkipReason =
   | 'flag_disabled'   // the app-delegate feature flag is off
-  | 'app_not_running' // no WS discovery / connection refused
+  | 'app_not_running' // WS discovery files (ws.port/ws.token) absent — no connection is attempted
   | 'no_local_cwd'    // no trusted local checkout resolved for the repo
 
 
@@ -909,9 +909,11 @@ export type IpcChannels = {
   }
 
   /**
-   * Whether the desktop-app delegate path is currently available for a repo
-   * (flag on + app running + a trusted local checkout resolves). Lets the UI
-   * hint where a delegate will land. Never throws; returns a skip reason.
+   * Best-effort hint for where a delegate will land for a repo: flag on + WS
+   * discovery files present (app appears to be running) + a trusted local
+   * checkout resolves. It does NOT open the WS or handshake, so a real delegate
+   * can still fall back to cloud (e.g. a stale token). Never throws; returns a
+   * skip reason when the app path wouldn't be taken.
    */
   'copilot:delegate-availability': {
     args: [repoOwner: string, repoName: string]

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -105,8 +105,8 @@ export interface CopilotAppSession {
   status: CopilotAppSessionStatus
   repoOwner: string | null
   repoName: string | null
-  createdAt: string              // ISO 8601
-  updatedAt: string              // ISO 8601
+  createdAt: string              // SQLite datetime, UTC ("YYYY-MM-DD HH:MM:SS")
+  updatedAt: string              // SQLite datetime, UTC ("YYYY-MM-DD HH:MM:SS")
 }
 
 /** Payload to delegate a task (tries the desktop app, falls back to cloud). */

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -899,7 +899,9 @@ export type IpcChannels = {
    * (when the feature flag is on, the app is running, and a trusted local
    * checkout resolves for the repo), else fall back to a cloud `gh agent-task`.
    * Returns a discriminated `DelegateResult`. Rejects with an `Error` whose
-   * `message` is `'GH_NOT_AUTHENTICATED'` or starts with `'DELEGATE_FAILED: '`.
+   * `message` is `'GH_NOT_AUTHENTICATED'`, or starts with `'DELEGATE_FAILED: '`
+   * (app path) or `'LAUNCH_FAILED: '` (cloud fallback path). The renderer strips
+   * both prefixes for display.
    */
   'copilot:delegate': {
     args: [payload: DelegatePayload]

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -136,6 +136,9 @@ export type AppDelegateSkipReason =
   | 'app_not_running' // WS discovery files (ws.port/ws.token) absent — no connection is attempted
   | 'no_local_cwd'    // no trusted local checkout resolved for the repo
 
+/** Default "repos root" used to resolve local checkouts (`~` expanded in main). */
+export const DEFAULT_REPOS_ROOT = '~/repos'
+
 
 export interface Project {
   id: number


### PR DESCRIPTION
Part of epic #71. Implements **A (#86)** of the Copilot-app integration reframe. Builds on the docs reframe (#89).

## What

Delegating a task now tries the **installed GitHub Copilot desktop app** over its local WebSocket, and falls back to a cloud `gh agent-task` otherwise. The app's *unofficial* WS protocol is contained behind one adapter (`src/main/agent/copilot-app/`) so an app update can only break one seam; cloud stays the resilient fallback.

The app path ships behind a **feature flag (default OFF)** - with it off, `copilot:delegate` behaves exactly like the old cloud launch. So this PR is a safe merge slice; the delegated-session visibility (link + live status on the todo) lands in the next PR (B / #87).

## The adapter (`src/main/agent/copilot-app/`)

- **discover.ts** - reads `~/.copilot/run/ws.{port,token}` (read-only; the 43-char token is never logged and never put in an error).
- **protocol.ts** - pure builders/parsers for the `create_session` / `send_message` / `session_created` / `session_event` frames.
- **cwd.ts** - trusted local-checkout resolver. Returns a `cwd` only when the path exists, is inside a git worktree, **and a git remote normalizes to the exact `owner/repo`**. That remote check makes the repo-name-under-a-root convention safe against owner collisions.
- **client.ts** - one `ws` connection (no Origin header). **Idempotency boundary:** cloud fallback is only allowed *before* `create_session` is sent; after that, an ambiguous failure never falls back (no double-delegation).
- **delegate.ts** - the WS → cloud strategy with a discriminated `DelegateResult`. A base-branch request routes to cloud (the app WS has no branch concept).
- **store.ts** - a **dedicated `copilot_app_sessions` table** so app sessions can't leak into any existing github-session reader (proven by a reader-isolation test).
- **settings.ts / project-cwd.ts** - the app-delegate flag + the "repos root" convention (default `~/repos`, from the owner's confirmed UX) and a per-project override.

## Wiring

`copilot:delegate` / `copilot:delegate-availability` / `copilot:open-app-session` IPC + a Settings section (flag toggle + repos-root input). `DelegateComposer` now calls `copilot:delegate`.

## Verification

- **45 tests**: protocol, discover, cwd (incl. remote-match edge cases: nested paths, doubled/empty segments, `.git/`), the delegate failure matrix + idempotency boundary, the ws client against a fake server (handshake with no Origin, create/send, pre-create vs post-create classification), and reader isolation (app sessions invisible to `getSessionsForProject` / `getUnassignedSessions` / `getAllStatuses` / `listProjects` / `getProject`).
- **Full suite green** (431 tests), typecheck, lint, and a production build.
- **Real end-to-end**: drove the actual `client.ts` against the running Copilot app with a throwaway prompt + throwaway cwd (create → send → observe → `delete_session`), cleaned up - 0 rows left.
- Reviewed via GPT-5.5 (3 rounds; fixed a remote-normalization false-match, base-branch routing, and the ambiguous-failure UX copy).

## Honest about the seams

The WS is the app's unofficial protocol - it only works when the app is running (and, for the app path, when the repo is checked out under the repos root and validates), and the token rotates per app launch (re-read every connect). Cloud `gh agent-task` is the resilient fallback for everything else.