### PR TITLE
feat(copilot): show the delegated Copilot app session on its todo (#87)

### DIFF
--- a/db/migrations/018_todo_copilot_app_sessions.sql
+++ b/db/migrations/018_todo_copilot_app_sessions.sql
@@ -1,0 +1,18 @@
+-- Migration: 018_todo_copilot_app_sessions.sql
+-- PR3 (#87): link delegated Copilot desktop-app sessions to the todo they came
+-- from, so a todo can show "Copilot working on this" + live status.
+--
+-- A join table (not a single column) so a todo can carry MULTIPLE app sessions
+-- over time — re-delegating a todo never hides a still-running prior session.
+-- Both sides ON DELETE CASCADE: deleting the todo (hard) or the app session
+-- removes the link. (Todos soft-delete via deleted_at, which keeps the link so a
+-- restore re-surfaces it.)
+
+CREATE TABLE todo_copilot_app_sessions (
+  todo_id     INTEGER NOT NULL REFERENCES project_todos(id) ON DELETE CASCADE,
+  session_id  TEXT    NOT NULL REFERENCES copilot_app_sessions(id) ON DELETE CASCADE,
+  created_at  TEXT    NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (todo_id, session_id)
+);
+
+CREATE INDEX idx_todo_app_sessions_session ON todo_copilot_app_sessions(session_id);

--- a/db/migrations/018_todo_copilot_app_sessions.sql
+++ b/db/migrations/018_todo_copilot_app_sessions.sql
@@ -1,12 +1,13 @@
 -- Migration: 018_todo_copilot_app_sessions.sql
--- PR3 (#87): link delegated Copilot desktop-app sessions to the todo they came
--- from, so a todo can show "Copilot working on this" + live status.
+-- #87: link delegated Copilot desktop-app sessions to the todo they came from,
+-- so a todo can show "Copilot working on this" + live status.
 --
 -- A join table (not a single column) so a todo can carry MULTIPLE app sessions
 -- over time — re-delegating a todo never hides a still-running prior session.
 -- Both sides ON DELETE CASCADE: deleting the todo (hard) or the app session
 -- removes the link. (Todos soft-delete via deleted_at, which keeps the link so a
--- restore re-surfaces it.)
+-- restore re-surfaces it.) A session belongs to exactly one todo, enforced by the
+-- UNIQUE index on session_id (belt-and-suspenders alongside the app-code guard).
 
 CREATE TABLE todo_copilot_app_sessions (
   todo_id     INTEGER NOT NULL REFERENCES project_todos(id) ON DELETE CASCADE,
@@ -15,4 +16,4 @@ CREATE TABLE todo_copilot_app_sessions (
   PRIMARY KEY (todo_id, session_id)
 );
 
-CREATE INDEX idx_todo_app_sessions_session ON todo_copilot_app_sessions(session_id);
+CREATE UNIQUE INDEX idx_todo_app_sessions_session ON todo_copilot_app_sessions(session_id);

--- a/src/main/agent/copilot-app/status.test.ts
+++ b/src/main/agent/copilot-app/status.test.ts
@@ -75,4 +75,18 @@ describe('refreshTodoAppSessionsForProject', () => {
     expect(pairs[0]?.session.status).toBe('in_progress') // unchanged
     expect(getAppSession('app-1')?.status).toBe('in_progress')
   })
+
+  it('does not touch updated_at when the status is unchanged (avoids poll churn)', async () => {
+    const pid = makeProject('P')
+    const todoId = makeTodo(pid, 'do it')
+    insertAppSession({ id: 'app-1', projectId: pid, cwd: '/x', title: 'do it', repoOwner: null, repoName: null })
+    linkTodoSession(todoId, 'app-1') // status 'in_progress'
+    db.prepare("UPDATE copilot_app_sessions SET updated_at = '2000-01-01 00:00:00' WHERE id = 'app-1'").run()
+
+    // Reader reports the SAME status → no write, updated_at preserved.
+    const reader = vi.fn(async (): Promise<AppStatusRead> => ({ ok: true, statuses: new Map([['app-1', 'in_progress']]) }))
+    await refreshTodoAppSessionsForProject(pid, reader)
+    const row = db.prepare("SELECT updated_at FROM copilot_app_sessions WHERE id = 'app-1'").get() as { updated_at: string }
+    expect(row.updated_at).toBe('2000-01-01 00:00:00')
+  })
 })

--- a/src/main/agent/copilot-app/status.test.ts
+++ b/src/main/agent/copilot-app/status.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Database as BunDb } from 'bun:sqlite'
+import type BetterSQLite3 from 'better-sqlite3'
+
+vi.mock('electron', () => ({
+  app: { isPackaged: false, getAppPath: () => process.cwd() },
+}))
+vi.mock('../../db', () => ({ getDb: vi.fn() }))
+
+import { getDb } from '../../db'
+import { runMigrations } from '../../db/migrate'
+import { mapRunningRows, refreshTodoAppSessionsForProject, type AppStatusRead } from './status'
+import { insertAppSession, linkTodoSession, getAppSession } from './store'
+
+let db: BunDb
+
+beforeEach(() => {
+  db = new BunDb(':memory:')
+  db.exec('PRAGMA foreign_keys = ON')
+  const betterDb = db as unknown as BetterSQLite3.Database
+  runMigrations(betterDb)
+  vi.mocked(getDb).mockReturnValue(betterDb)
+})
+
+function makeProject(name: string): number {
+  return (db.prepare('INSERT INTO projects (name) VALUES (?) RETURNING id').get(name) as { id: number }).id
+}
+function makeTodo(projectId: number, text: string): number {
+  return (
+    db.prepare('INSERT INTO project_todos (project_id, text) VALUES (?, ?) RETURNING id').get(projectId, text) as {
+      id: number
+    }
+  ).id
+}
+
+describe('mapRunningRows', () => {
+  it('maps running/idle/absent correctly', () => {
+    const m = mapRunningRows(['a', 'b', 'c'], [
+      { id: 'a', is_running: 1 },
+      { id: 'b', is_running: 0 },
+    ])
+    expect(m.get('a')).toBe('in_progress')
+    expect(m.get('b')).toBe('waiting')
+    expect(m.get('c')).toBe('unknown') // absent → unknown, NOT completed
+  })
+})
+
+describe('refreshTodoAppSessionsForProject', () => {
+  it('updates stored status from the reader and returns (todo, session) pairs', async () => {
+    const pid = makeProject('P')
+    const todoId = makeTodo(pid, 'do it')
+    insertAppSession({ id: 'app-1', projectId: pid, cwd: '/x', title: 'do it', repoOwner: 'me', repoName: 'foo' })
+    linkTodoSession(todoId, 'app-1')
+
+    const reader = vi.fn(async (): Promise<AppStatusRead> => ({
+      ok: true,
+      statuses: new Map([['app-1', 'in_progress']]),
+    }))
+    const pairs = await refreshTodoAppSessionsForProject(pid, reader)
+
+    expect(reader).toHaveBeenCalledWith(['app-1'])
+    expect(pairs).toEqual([{ todoId, session: expect.objectContaining({ id: 'app-1', status: 'in_progress' }) }])
+    expect(getAppSession('app-1')?.status).toBe('in_progress')
+  })
+
+  it('keeps the last-known status on a transient read failure', async () => {
+    const pid = makeProject('P')
+    const todoId = makeTodo(pid, 'do it')
+    insertAppSession({ id: 'app-1', projectId: pid, cwd: '/x', title: 'do it', repoOwner: null, repoName: null })
+    linkTodoSession(todoId, 'app-1') // stored status starts 'in_progress'
+
+    const reader = vi.fn(async (): Promise<AppStatusRead> => ({ ok: false }))
+    const pairs = await refreshTodoAppSessionsForProject(pid, reader)
+
+    expect(pairs[0]?.session.status).toBe('in_progress') // unchanged
+    expect(getAppSession('app-1')?.status).toBe('in_progress')
+  })
+})

--- a/src/main/agent/copilot-app/status.ts
+++ b/src/main/agent/copilot-app/status.ts
@@ -110,10 +110,17 @@ export async function refreshTodoAppSessionsForProject(
   const links = getTodoAppSessionsForProject(projectId)
   const ids = [...new Set(links.map((l) => l.session.id))]
   const read = await reader(ids)
-  if (read.ok) {
-    for (const [id, status] of read.statuses) updateAppSessionStatus(id, status)
-    // Re-read so the returned rows carry the freshly-written status.
-    return getTodoAppSessionsForProject(projectId)
+  if (!read.ok) return links // transient failure -> last-known
+
+  // Only write when the status actually changed, so 20s polling doesn't bump
+  // updated_at (and reorder sessions) on every refresh.
+  const current = new Map(links.map((l) => [l.session.id, l.session.status]))
+  let changed = false
+  for (const [id, status] of read.statuses) {
+    if (current.get(id) !== status) {
+      updateAppSessionStatus(id, status)
+      changed = true
+    }
   }
-  return links // transient failure -> last-known
+  return changed ? getTodoAppSessionsForProject(projectId) : links
 }

--- a/src/main/agent/copilot-app/status.ts
+++ b/src/main/agent/copilot-app/status.ts
@@ -1,0 +1,119 @@
+/**
+ * Read delegated-session status from the Copilot desktop app's OWN sqlite
+ * (`~/.copilot/data.db`), read-only, for the ids Focus created.
+ *
+ * Privacy + safety: we only ever SELECT `id, is_running` and only for the ids we
+ * pass in (`WHERE id IN (...)`), so no other session's row or content is read,
+ * and nothing is logged. The handle is opened read-only and always closed.
+ *
+ * Status mapping (verified against the app schema — sessions persist after
+ * finishing, so there is no terminal "completed" signal):
+ *   present & is_running = 1 -> in_progress  (working)
+ *   present & is_running = 0 -> waiting       (idle / not running)
+ *   absent (db readable)     -> unknown        (NOT "completed" — absence != done)
+ * When the db can't be opened or is locked, the caller keeps the last-known
+ * status; a schema drift (missing table/column) maps everything to unknown.
+ *
+ * `better-sqlite3` is imported LAZILY (dynamic import) so this module can be
+ * loaded in tests without the native binding; the pure mapping + the refresh
+ * orchestration are tested with an injected reader.
+ */
+
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import type { CopilotAppSessionStatus, TodoAppSession } from '../../../shared/ipc-channels'
+import { getTodoAppSessionsForProject, updateAppSessionStatus } from './store'
+
+/** Path to the desktop app's own sqlite database. */
+export function copilotDataDbPath(): string {
+  return join(homedir(), '.copilot', 'data.db')
+}
+
+export type AppStatusRead =
+  /** Statuses read: present ids mapped, absent ids -> 'unknown'. */
+  | { ok: true; statuses: Map<string, CopilotAppSessionStatus> }
+  /** Transient (app closed / db locked): the caller should keep last-known status. */
+  | { ok: false }
+
+/** A status reader (injectable for tests). */
+export type AppStatusReader = (ids: string[]) => Promise<AppStatusRead>
+
+const CHUNK = 400 // keep well under SQLite's default 999-variable limit
+
+/** Pure: map raw {id, is_running} rows to statuses; absent ids -> 'unknown'. */
+export function mapRunningRows(
+  ids: string[],
+  rows: { id: string; is_running: number }[]
+): Map<string, CopilotAppSessionStatus> {
+  const present = new Map<string, CopilotAppSessionStatus>(
+    rows.map((r) => [r.id, r.is_running ? 'in_progress' : 'waiting'])
+  )
+  const out = new Map<string, CopilotAppSessionStatus>()
+  for (const id of ids) out.set(id, present.get(id) ?? 'unknown')
+  return out
+}
+
+/**
+ * Default reader: opens the app's data.db read-only and reads is_running for our
+ * ids. See the module doc for the failure contract. Lazily loads better-sqlite3.
+ */
+export async function readAppSessionStatuses(
+  ids: string[],
+  dbPath: string = copilotDataDbPath()
+): Promise<AppStatusRead> {
+  if (ids.length === 0) return { ok: true, statuses: new Map() }
+
+  const { default: Database } = await import('better-sqlite3')
+  let db: import('better-sqlite3').Database
+  try {
+    db = new Database(dbPath, { readonly: true, fileMustExist: true })
+  } catch {
+    return { ok: false } // app not running / file missing -> keep last-known
+  }
+
+  try {
+    const rows: { id: string; is_running: number }[] = []
+    for (let i = 0; i < ids.length; i += CHUNK) {
+      const chunk = ids.slice(i, i + CHUNK)
+      const placeholders = chunk.map(() => '?').join(',')
+      const got = db
+        .prepare(`SELECT id, is_running FROM sessions WHERE id IN (${placeholders})`)
+        .all(...chunk) as { id: string; is_running: number }[]
+      rows.push(...got)
+    }
+    return { ok: true, statuses: mapRunningRows(ids, rows) }
+  } catch (err) {
+    const code = (err as { code?: string }).code ?? ''
+    // A locked/busy db is transient — keep last-known. A missing table/column
+    // (schema drift) means we genuinely can't tell -> unknown for all.
+    if (code === 'SQLITE_BUSY' || code === 'SQLITE_LOCKED') return { ok: false }
+    return { ok: true, statuses: new Map(ids.map((id) => [id, 'unknown'])) }
+  } finally {
+    try {
+      db.close()
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+/**
+ * Refresh the stored status of every app session linked to a project's todos
+ * from the app's data.db, then return the (todo, session) pairs. On a transient
+ * read failure the stored (last-known) status is kept. `reader` is injectable
+ * for tests.
+ */
+export async function refreshTodoAppSessionsForProject(
+  projectId: number,
+  reader: AppStatusReader = readAppSessionStatuses
+): Promise<TodoAppSession[]> {
+  const links = getTodoAppSessionsForProject(projectId)
+  const ids = [...new Set(links.map((l) => l.session.id))]
+  const read = await reader(ids)
+  if (read.ok) {
+    for (const [id, status] of read.statuses) updateAppSessionStatus(id, status)
+    // Re-read so the returned rows carry the freshly-written status.
+    return getTodoAppSessionsForProject(projectId)
+  }
+  return links // transient failure -> last-known
+}

--- a/src/main/agent/copilot-app/store.integration.test.ts
+++ b/src/main/agent/copilot-app/store.integration.test.ts
@@ -10,7 +10,7 @@ vi.mock('../../db', () => ({ getDb: vi.fn() }))
 
 import { getDb } from '../../db'
 import { runMigrations } from '../../db/migrate'
-import { insertAppSession, getAppSession, getAppSessionsForProject, updateAppSessionStatus } from './store'
+import { insertAppSession, getAppSession, getAppSessionsForProject, updateAppSessionStatus, linkTodoSession, getTodoAppSessionsForProject } from './store'
 import {
   getSessionsForProject,
   getUnassignedSessions,
@@ -32,6 +32,14 @@ beforeEach(() => {
 function makeProject(name: string): number {
   const row = db.prepare('INSERT INTO projects (name) VALUES (?) RETURNING id').get(name) as { id: number }
   return row.id
+}
+
+function makeTodo(projectId: number, text: string): number {
+  return (
+    db.prepare('INSERT INTO project_todos (project_id, text) VALUES (?, ?) RETURNING id').get(projectId, text) as {
+      id: number
+    }
+  ).id
 }
 
 describe('copilot_app_sessions store', () => {
@@ -76,5 +84,69 @@ describe('reader isolation — app sessions never leak into github-session surfa
     const listed = listProjects().find((p) => p.id === pid)
     expect(listed?.copilotStatus ?? null).toBeNull()
     expect(getProject(pid)?.copilotStatus ?? null).toBeNull()
+  })
+})
+
+describe('todo ↔ app-session links (#87)', () => {
+  it('links a session to a todo and reads it back paired', () => {
+    const pid = makeProject('P')
+    const todoId = makeTodo(pid, 'do it')
+    insertAppSession({ id: 'app-1', projectId: pid, cwd: '/x', title: 'do it', repoOwner: 'me', repoName: 'foo' })
+    linkTodoSession(todoId, 'app-1')
+    const pairs = getTodoAppSessionsForProject(pid)
+    expect(pairs).toHaveLength(1)
+    expect(pairs[0]?.todoId).toBe(todoId)
+    expect(pairs[0]?.session.id).toBe('app-1')
+  })
+
+  it('is idempotent per (todo, session) pair', () => {
+    const pid = makeProject('P')
+    const todoId = makeTodo(pid, 'do it')
+    insertAppSession({ id: 'app-1', projectId: pid, cwd: '/x', title: 't', repoOwner: null, repoName: null })
+    linkTodoSession(todoId, 'app-1')
+    linkTodoSession(todoId, 'app-1')
+    expect(getTodoAppSessionsForProject(pid)).toHaveLength(1)
+  })
+
+  it('lets a todo carry multiple sessions (re-delegation never hides a prior one)', () => {
+    const pid = makeProject('P')
+    const todoId = makeTodo(pid, 'do it')
+    insertAppSession({ id: 'app-1', projectId: pid, cwd: '/x', title: 't', repoOwner: null, repoName: null })
+    insertAppSession({ id: 'app-2', projectId: pid, cwd: '/x', title: 't', repoOwner: null, repoName: null })
+    linkTodoSession(todoId, 'app-1')
+    linkTodoSession(todoId, 'app-2')
+    expect(getTodoAppSessionsForProject(pid).map((p) => p.session.id).sort()).toEqual(['app-1', 'app-2'])
+  })
+
+  it('rejects a missing todo / missing session / project mismatch', () => {
+    const pid = makeProject('P')
+    const other = makeProject('Other')
+    const todoId = makeTodo(pid, 'do it')
+    insertAppSession({ id: 'app-1', projectId: pid, cwd: '/x', title: 't', repoOwner: null, repoName: null })
+    insertAppSession({ id: 'app-other', projectId: other, cwd: '/x', title: 't', repoOwner: null, repoName: null })
+
+    expect(() => linkTodoSession(9999, 'app-1')).toThrow('TODO_NOT_FOUND')
+    expect(() => linkTodoSession(todoId, 'nope')).toThrow('SESSION_NOT_FOUND')
+    expect(() => linkTodoSession(todoId, 'app-other')).toThrow('PROJECT_MISMATCH')
+  })
+
+  it('rejects linking a null-project (unassigned) session to a todo', () => {
+    const pid = makeProject('P')
+    const todoId = makeTodo(pid, 'do it')
+    // Soft-delete the project so insertAppSession pins no project → project_id NULL.
+    const gone = makeProject('Gone')
+    db.prepare("UPDATE projects SET deleted_at = datetime('now') WHERE id = ?").run(gone)
+    const s = insertAppSession({ id: 'app-null', projectId: gone, cwd: '/x', title: 't', repoOwner: null, repoName: null })
+    expect(s.projectId).toBeNull()
+    expect(() => linkTodoSession(todoId, 'app-null')).toThrow('PROJECT_MISMATCH')
+  })
+
+  it('does not surface a link whose todo is soft-deleted', () => {
+    const pid = makeProject('P')
+    const todoId = makeTodo(pid, 'do it')
+    insertAppSession({ id: 'app-1', projectId: pid, cwd: '/x', title: 't', repoOwner: null, repoName: null })
+    linkTodoSession(todoId, 'app-1')
+    db.prepare("UPDATE project_todos SET deleted_at = datetime('now') WHERE id = ?").run(todoId)
+    expect(getTodoAppSessionsForProject(pid)).toEqual([])
   })
 })

--- a/src/main/agent/copilot-app/store.integration.test.ts
+++ b/src/main/agent/copilot-app/store.integration.test.ts
@@ -118,6 +118,17 @@ describe('todo ↔ app-session links (#87)', () => {
     expect(getTodoAppSessionsForProject(pid).map((p) => p.session.id).sort()).toEqual(['app-1', 'app-2'])
   })
 
+  it('rejects linking one session to two different todos (a session comes from one todo)', () => {
+    const pid = makeProject('P')
+    const todoA = makeTodo(pid, 'A')
+    const todoB = makeTodo(pid, 'B')
+    insertAppSession({ id: 'app-1', projectId: pid, cwd: '/x', title: 't', repoOwner: null, repoName: null })
+    linkTodoSession(todoA, 'app-1')
+    linkTodoSession(todoA, 'app-1') // same pair → idempotent, no throw
+    expect(() => linkTodoSession(todoB, 'app-1')).toThrow('SESSION_ALREADY_LINKED')
+    expect(getTodoAppSessionsForProject(pid)).toHaveLength(1)
+  })
+
   it('rejects a missing todo / missing session / project mismatch', () => {
     const pid = makeProject('P')
     const other = makeProject('Other')

--- a/src/main/agent/copilot-app/store.ts
+++ b/src/main/agent/copilot-app/store.ts
@@ -96,3 +96,50 @@ export function getAppSessionsForProject(projectId: number): CopilotAppSession[]
     .all(projectId) as AppSessionRow[]
   return rows.map(toSession)
 }
+
+/**
+ * Link a delegated app session to the todo it came from (#87). Transactional +
+ * validated: the todo must exist (not soft-deleted), the session must exist, and
+ * their projects must match EXACTLY (a null-project session can't attach to a
+ * todo). Never trusts the renderer for the relationship. Idempotent per pair.
+ */
+export function linkTodoSession(todoId: number, sessionId: string): void {
+  const db = getDb()
+  const tx = db.transaction(() => {
+    const todo = db
+      .prepare('SELECT project_id FROM project_todos WHERE id = ? AND deleted_at IS NULL')
+      .get(todoId) as { project_id: number } | undefined | null
+    if (todo === undefined || todo === null) throw new Error('TODO_NOT_FOUND')
+    const session = db
+      .prepare('SELECT project_id FROM copilot_app_sessions WHERE id = ?')
+      .get(sessionId) as { project_id: number | null } | undefined | null
+    if (session === undefined || session === null) throw new Error('SESSION_NOT_FOUND')
+    if (session.project_id !== todo.project_id) {
+      throw new Error('PROJECT_MISMATCH')
+    }
+    db.prepare(
+      'INSERT OR IGNORE INTO todo_copilot_app_sessions (todo_id, session_id) VALUES (?, ?)'
+    ).run(todoId, sessionId)
+  })
+  tx()
+}
+
+/**
+ * Returns each app session linked to a todo in the given project, paired with
+ * its todo id. Joins through the project's (non-deleted) todos, so a session
+ * only surfaces where its todo is visible. The `s.project_id = t.project_id`
+ * guard is defense-in-depth against a stale/mismatched link.
+ */
+export function getTodoAppSessionsForProject(projectId: number): { todoId: number; session: CopilotAppSession }[] {
+  const rows = getDb()
+    .prepare(`
+      SELECT l.todo_id AS todo_id, s.*
+      FROM todo_copilot_app_sessions l
+      JOIN project_todos t ON t.id = l.todo_id
+      JOIN copilot_app_sessions s ON s.id = l.session_id
+      WHERE t.project_id = ? AND t.deleted_at IS NULL AND s.project_id = t.project_id
+      ORDER BY l.created_at DESC
+    `)
+    .all(projectId) as (AppSessionRow & { todo_id: number })[]
+  return rows.map((r) => ({ todoId: r.todo_id, session: toSession(r) }))
+}

--- a/src/main/agent/copilot-app/store.ts
+++ b/src/main/agent/copilot-app/store.ts
@@ -99,9 +99,10 @@ export function getAppSessionsForProject(projectId: number): CopilotAppSession[]
 
 /**
  * Link a delegated app session to the todo it came from (#87). Transactional +
- * validated: the todo must exist (not soft-deleted), the session must exist, and
- * their projects must match EXACTLY (a null-project session can't attach to a
- * todo). Never trusts the renderer for the relationship. Idempotent per pair.
+ * validated: the todo must exist (not soft-deleted), the session must exist,
+ * their projects must match EXACTLY (a null-project session can't attach), and
+ * the session must not already belong to a different todo (a session comes from
+ * exactly one todo). Never trusts the renderer. Idempotent per pair.
  */
 export function linkTodoSession(todoId: number, sessionId: string): void {
   const db = getDb()
@@ -116,6 +117,13 @@ export function linkTodoSession(todoId: number, sessionId: string): void {
     if (session === undefined || session === null) throw new Error('SESSION_NOT_FOUND')
     if (session.project_id !== todo.project_id) {
       throw new Error('PROJECT_MISMATCH')
+    }
+    // A session belongs to exactly one todo — fail fast if it's already elsewhere.
+    const existing = db
+      .prepare('SELECT todo_id FROM todo_copilot_app_sessions WHERE session_id = ?')
+      .get(sessionId) as { todo_id: number } | undefined | null
+    if (existing !== undefined && existing !== null && existing.todo_id !== todoId) {
+      throw new Error('SESSION_ALREADY_LINKED')
     }
     db.prepare(
       'INSERT OR IGNORE INTO todo_copilot_app_sessions (todo_id, session_id) VALUES (?, ?)'

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -42,6 +42,8 @@ import { listMcpTools } from './context/mcp-client'
 import { resolveQuestion } from './context/resolve'
 import { createResolveDeps } from './context/resolve-deps'
 import { delegateTask, appDelegateAvailability, buildAppSessionDeepLink, createDefaultDelegateDeps } from './agent/copilot-app/delegate'
+import { linkTodoSession } from './agent/copilot-app/store'
+import { refreshTodoAppSessionsForProject } from './agent/copilot-app/status'
 import { getAppDelegateEnabled, setAppDelegateEnabled, getReposRoot, setReposRoot } from './agent/copilot-app/settings'
 import type { ProjectPatch, ProjectTodoPatch, ProjectLinkPatch, SnoozeMode, SyncIntervalMinutes, MaxSyncDays, CreateRoutingRulePayload, LaunchAgentTaskPayload, ResourceInput, ResourcePatch, ProjectCardPatch, McpServerInput, McpServerPatch, McpConnectInput, DelegatePayload } from '../shared/ipc-channels'
 import { SYNC_INTERVAL_OPTIONS, MAX_SYNC_DAYS_OPTIONS } from '../shared/ipc-channels'
@@ -349,6 +351,13 @@ app.whenReady().then(async () => {
     if (deepLink === null) throw new Error('Invalid session id')
     await shell.openExternal(deepLink)
   })
+  ipcMain.handle('todos:link-session', (_event, todoId: number, sessionId: string) => {
+    linkTodoSession(todoId, sessionId)
+    broadcast('projects:updated')
+  })
+  ipcMain.handle('copilot:app-sessions-for-project', (_event, projectId: number) =>
+    refreshTodoAppSessionsForProject(projectId)
+  )
 
   // Desktop-app delegate settings.
   ipcMain.handle('settings:get-app-delegate-enabled', () => getAppDelegateEnabled())

--- a/src/renderer/src/components/TodoSessionChip.module.css
+++ b/src/renderer/src/components/TodoSessionChip.module.css
@@ -1,0 +1,68 @@
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin: 2px 0 4px 26px;
+  padding: 2px 8px;
+  font-size: 11px;
+  color: var(--text-2);
+  background: var(--bg-inset);
+  border: 1px solid var(--border-muted);
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: background 150ms, border-color 150ms;
+}
+
+.chip:hover {
+  background: var(--bg-hover, var(--bg-inset));
+  border-color: var(--text-3);
+}
+
+.icon {
+  color: var(--text-3);
+}
+
+.dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--text-3);
+  flex-shrink: 0;
+}
+
+.arrow {
+  color: var(--text-3);
+}
+
+/* is_running = 1 — actively working */
+.in_progress .dot {
+  background: var(--accent);
+  animation: pulse 1.6s ease-in-out infinite;
+}
+.in_progress {
+  color: var(--text);
+}
+
+/* is_running = 0 — idle */
+.waiting .dot {
+  background: var(--text-3);
+}
+
+.completed .dot {
+  background: var(--success, #2da44e);
+}
+
+.unknown .dot {
+  background: var(--text-3);
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .in_progress .dot {
+    animation: none;
+  }
+}

--- a/src/renderer/src/components/TodoSessionChip.test.tsx
+++ b/src/renderer/src/components/TodoSessionChip.test.tsx
@@ -1,0 +1,39 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import type { CopilotAppSession } from '@shared/ipc-channels'
+import { TodoSessionChip } from './TodoSessionChip'
+
+const invoke = vi.fn()
+
+beforeEach(() => {
+  invoke.mockReset()
+  invoke.mockResolvedValue(undefined)
+  ;(globalThis as unknown as { window: Window }).window.electron = {
+    ipc: { invoke },
+  } as unknown as Window['electron']
+})
+
+function session(overrides: Partial<CopilotAppSession> = {}): CopilotAppSession {
+  return {
+    id: 'app-1', projectId: 1, cwd: '/x', title: 't', status: 'in_progress',
+    repoOwner: null, repoName: null, createdAt: '', updatedAt: '', ...overrides,
+  }
+}
+
+describe('TodoSessionChip', () => {
+  it('shows honest copy per status', () => {
+    const { rerender } = render(<TodoSessionChip session={session({ status: 'in_progress' })} />)
+    expect(screen.getByText('Copilot working on this')).toBeTruthy()
+    rerender(<TodoSessionChip session={session({ status: 'waiting' })} />)
+    expect(screen.getByText('Copilot idle')).toBeTruthy() // not "needs you"
+    rerender(<TodoSessionChip session={session({ status: 'unknown' })} />)
+    expect(screen.getByText('Copilot session')).toBeTruthy()
+  })
+
+  it('opens the session in the app on click', () => {
+    render(<TodoSessionChip session={session({ id: 'abc-123' })} />)
+    fireEvent.click(screen.getByRole('button'))
+    expect(invoke).toHaveBeenCalledWith('copilot:open-app-session', 'abc-123')
+  })
+})

--- a/src/renderer/src/components/TodoSessionChip.tsx
+++ b/src/renderer/src/components/TodoSessionChip.tsx
@@ -14,7 +14,7 @@ import styles from './TodoSessionChip.module.css'
 const LABEL: Record<CopilotAppSessionStatus, string> = {
   in_progress: 'Copilot working on this',
   waiting: 'Copilot idle',
-  completed: 'Copilot finished',
+  completed: 'Copilot session',
   unknown: 'Copilot session',
 }
 

--- a/src/renderer/src/components/TodoSessionChip.tsx
+++ b/src/renderer/src/components/TodoSessionChip.tsx
@@ -1,0 +1,38 @@
+import type { CopilotAppSession, CopilotAppSessionStatus } from '@shared/ipc-channels'
+import { Sparkles } from 'lucide-react'
+import { Icon } from './Icon'
+import { fire } from '../ipc'
+import styles from './TodoSessionChip.module.css'
+
+/**
+ * A small chip on a todo showing the status of the Copilot desktop-app session
+ * it was delegated to (#87). Clicking opens that session in the app. Copy is
+ * deliberately honest: is_running=0 is "idle", not "needs you"; an unreadable
+ * status ("unknown") stays neutral. Only sessions Focus created reach here.
+ */
+
+const LABEL: Record<CopilotAppSessionStatus, string> = {
+  in_progress: 'Copilot working on this',
+  waiting: 'Copilot idle',
+  completed: 'Copilot finished',
+  unknown: 'Copilot session',
+}
+
+export function TodoSessionChip({ session }: { session: CopilotAppSession }): JSX.Element {
+  const open = (): void => {
+    fire(window.electron.ipc.invoke('copilot:open-app-session', session.id), 'copilot:open-app-session')
+  }
+  return (
+    <button
+      type="button"
+      className={`${styles.chip} ${styles[session.status]}`}
+      onClick={open}
+      title="Open this session in the Copilot app"
+    >
+      <span className={styles.dot} aria-hidden />
+      <Icon icon={Sparkles} size={11} className={styles.icon} />
+      <span className={styles.label}>{LABEL[session.status]}</span>
+      <span className={styles.arrow} aria-hidden>→</span>
+    </button>
+  )
+}

--- a/src/renderer/src/components/WorkingColumn.module.css
+++ b/src/renderer/src/components/WorkingColumn.module.css
@@ -94,6 +94,11 @@
   color: var(--text-3);
 }
 
+.todoItem {
+  display: flex;
+  flex-direction: column;
+}
+
 .todoRow {
   display: flex;
   align-items: center;

--- a/src/renderer/src/components/WorkingColumn.tsx
+++ b/src/renderer/src/components/WorkingColumn.tsx
@@ -16,10 +16,11 @@ import {
   Trash2,
   Sparkles,
 } from 'lucide-react'
-import type { NotificationThread, NotificationType, ProjectDetail, ProjectTodo, LaunchTarget } from '@shared/ipc-channels'
+import type { NotificationThread, NotificationType, ProjectDetail, ProjectTodo, LaunchTarget, CopilotAppSession } from '@shared/ipc-channels'
 import type { LucideIcon } from 'lucide-react'
 import { Icon } from './Icon'
 import { ResourcePanel } from './ResourcePanel'
+import { TodoSessionChip } from './TodoSessionChip'
 import { fire, openExternal } from '../ipc'
 import styles from './WorkingColumn.module.css'
 
@@ -31,8 +32,10 @@ interface WorkingColumnProps {
   onToggleTodo: (todo: ProjectTodo) => void
   onDeleteTodo: (todo: ProjectTodo) => void
   onSaveNotes: (notes: string) => void
-  /** Hand a todo or notification to a cloud Copilot agent task. */
-  onDelegate: (prompt: string, fixedRepo?: LaunchTarget) => void
+  /** Hand a todo or notification to Copilot. `todoId` is set when it came from a todo. */
+  onDelegate: (prompt: string, fixedRepo?: LaunchTarget, todoId?: number) => void
+  /** Delegated Copilot desktop-app sessions per todo id (#87). */
+  appSessionsByTodo: Map<number, CopilotAppSession[]>
   /** Undo toast used by the Resources tab's destructive actions. */
   showUndo: (message: string, onUndo: () => void, actionLabel?: string) => void
 }
@@ -53,7 +56,8 @@ function TodosPanel({
   onToggleTodo,
   onDeleteTodo,
   onDelegate,
-}: Pick<WorkingColumnProps, 'detail' | 'onCreateTodo' | 'onToggleTodo' | 'onDeleteTodo' | 'onDelegate'>): JSX.Element {
+  appSessionsByTodo,
+}: Pick<WorkingColumnProps, 'detail' | 'onCreateTodo' | 'onToggleTodo' | 'onDeleteTodo' | 'onDelegate' | 'appSessionsByTodo'>): JSX.Element {
   const [text, setText] = useState('')
   const active = detail.todos.filter((t) => !t.done)
   const done = detail.todos.filter((t) => t.done)
@@ -78,15 +82,20 @@ function TodosPanel({
         />
       </div>
       {active.map((t) => (
-        <div key={t.id} className={styles.todoRow}>
-          <button type="button" className={styles.checkbox} onClick={() => onToggleTodo(t)} aria-label="Mark done" />
-          <span className={styles.todoText}>{t.text}</span>
-          <button type="button" className={styles.rowAction} onClick={() => onDelegate(t.text)} aria-label="Delegate to Copilot" title="Delegate to Copilot">
-            <Icon icon={Sparkles} size={13} />
-          </button>
-          <button type="button" className={styles.rowAction} onClick={() => onDeleteTodo(t)} aria-label="Delete todo">
-            <Icon icon={Trash2} size={13} />
-          </button>
+        <div key={t.id} className={styles.todoItem}>
+          <div className={styles.todoRow}>
+            <button type="button" className={styles.checkbox} onClick={() => onToggleTodo(t)} aria-label="Mark done" />
+            <span className={styles.todoText}>{t.text}</span>
+            <button type="button" className={styles.rowAction} onClick={() => onDelegate(t.text, undefined, t.id)} aria-label="Delegate to Copilot" title="Delegate to Copilot">
+              <Icon icon={Sparkles} size={13} />
+            </button>
+            <button type="button" className={styles.rowAction} onClick={() => onDeleteTodo(t)} aria-label="Delete todo">
+              <Icon icon={Trash2} size={13} />
+            </button>
+          </div>
+          {(appSessionsByTodo.get(t.id) ?? []).map((s) => (
+            <TodoSessionChip key={s.id} session={s} />
+          ))}
         </div>
       ))}
       {done.length > 0 && <div className={styles.divider} />}
@@ -233,6 +242,7 @@ export function WorkingColumn(props: WorkingColumnProps): JSX.Element {
             onToggleTodo={props.onToggleTodo}
             onDeleteTodo={props.onDeleteTodo}
             onDelegate={props.onDelegate}
+            appSessionsByTodo={props.appSessionsByTodo}
           />
         )}
         {tab === 'notes' && <NotesPanel detail={props.detail} onSaveNotes={props.onSaveNotes} />}

--- a/src/renderer/src/pages/FocusPage.tsx
+++ b/src/renderer/src/pages/FocusPage.tsx
@@ -1,6 +1,6 @@
-import { useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { MoreHorizontal, Moon, Trash2, Sun, BellRing } from 'lucide-react'
-import type { LaunchTarget, Project, ProjectTodo } from '@shared/ipc-channels'
+import type { CopilotAppSession, LaunchTarget, Project, ProjectTodo, TodoAppSession } from '@shared/ipc-channels'
 import { Icon } from '../components/Icon'
 import { ReentryDigest } from '../components/ReentryDigest'
 import { NextAction } from '../components/NextAction'
@@ -38,8 +38,51 @@ export function FocusPage(props: FocusPageProps): JSX.Element {
   } = useProjectDetail(props.projectId, props.onProjectChanged)
   const { digest, dismiss } = useDigest(props.projectId)
   const [menuOpen, setMenuOpen] = useState(false)
-  const [delegate, setDelegate] = useState<{ prompt: string; fixedRepo?: LaunchTarget } | null>(null)
+  const [delegate, setDelegate] = useState<{ prompt: string; fixedRepo?: LaunchTarget; todoId?: number } | null>(null)
+  const [appSessions, setAppSessions] = useState<TodoAppSession[]>([])
   const menuRef = useRef<HTMLDivElement>(null)
+
+  // Load + refresh the delegated app sessions on this project's todos (#87): on
+  // project change, on window focus, and on a light interval while mounted.
+  const projectId = props.projectId
+  useEffect(() => {
+    let active = true
+    const load = async (): Promise<void> => {
+      try {
+        const list = await window.electron.ipc.invoke('copilot:app-sessions-for-project', projectId)
+        if (active) setAppSessions(list)
+      } catch (err) {
+        console.error('[FocusPage] Failed to load app sessions:', err)
+      }
+    }
+    void load()
+    const onFocus = (): void => { void load() }
+    window.addEventListener('focus', onFocus)
+    const timer = window.setInterval(() => { void load() }, 20000)
+    return () => {
+      active = false
+      window.removeEventListener('focus', onFocus)
+      window.clearInterval(timer)
+    }
+  }, [projectId])
+
+  const appSessionsByTodo = useMemo(() => {
+    const map = new Map<number, CopilotAppSession[]>()
+    for (const { todoId, session } of appSessions) {
+      const list = map.get(todoId)
+      if (list) list.push(session)
+      else map.set(todoId, [session])
+    }
+    return map
+  }, [appSessions])
+
+  const reloadAppSessions = async (): Promise<void> => {
+    try {
+      setAppSessions(await window.electron.ipc.invoke('copilot:app-sessions-for-project', projectId))
+    } catch (err) {
+      console.error('[FocusPage] Failed to reload app sessions:', err)
+    }
+  }
 
   if (isLoading || detail === null) {
     return <main className={styles.main} />
@@ -152,7 +195,8 @@ export function FocusPage(props: FocusPageProps): JSX.Element {
         onToggleTodo={(todo) => fire(updateTodo(todo.id, { done: !todo.done }))}
         onDeleteTodo={handleDeleteTodo}
         onSaveNotes={(notes) => fire(updateProject({ notes }))}
-        onDelegate={(prompt, fixedRepo) => setDelegate({ prompt, fixedRepo })}
+        onDelegate={(prompt, fixedRepo, todoId) => setDelegate({ prompt, fixedRepo, todoId })}
+        appSessionsByTodo={appSessionsByTodo}
         showUndo={props.showUndo}
       />
 
@@ -172,6 +216,19 @@ export function FocusPage(props: FocusPageProps): JSX.Element {
                 'Open'
               )
             } else {
+              // App session: link it to the originating todo (#87) so its live
+              // status shows there, then refresh the todo chips.
+              const todoId = delegate.todoId
+              if (todoId !== undefined) {
+                void (async () => {
+                  try {
+                    await window.electron.ipc.invoke('todos:link-session', todoId, result.session.id)
+                    await reloadAppSessions()
+                  } catch (err) {
+                    console.error('[FocusPage] Failed to link app session to todo:', err)
+                  }
+                })()
+              }
               const message =
                 result.kind === 'app-send-failed'
                   ? 'Opened a Copilot session, but I couldn’t hand off the task — open it to retry.'

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -139,6 +139,12 @@ export type AppDelegateSkipReason =
 /** Default "repos root" used to resolve local checkouts (`~` expanded in main). */
 export const DEFAULT_REPOS_ROOT = '~/repos'
 
+/** A delegated app session paired with the todo it was launched from (#87). */
+export interface TodoAppSession {
+  todoId: number
+  session: CopilotAppSession
+}
+
 
 export interface Project {
   id: number
@@ -930,6 +936,26 @@ export type IpcChannels = {
   'copilot:open-app-session': {
     args: [sessionId: string]
     result: void
+  }
+
+  /**
+   * Links a delegated desktop-app session to the todo it was launched from (#87).
+   * Validated + transactional in main: the todo and session must exist and their
+   * projects must match. Idempotent per (todo, session) pair.
+   */
+  'todos:link-session': {
+    args: [todoId: number, sessionId: string]
+    result: void
+  }
+
+  /**
+   * Returns the delegated app sessions linked to a project's todos, each paired
+   * with its todo id, after refreshing their live status from the app's local
+   * store (read-only). Only surfaces sessions Focus created.
+   */
+  'copilot:app-sessions-for-project': {
+    args: [projectId: number]
+    result: TodoAppSession[]
   }
 
   /** Reads the app-delegate feature flag (default false). */


### PR DESCRIPTION
Part of epic #71. Implements **B (#87)** of the Copilot-app integration reframe. Builds on A (#90) and the docs reframe (#89).

## What

Once a task is delegated to the installed Copilot desktop app (#86), this shows it on the todo it came from: a small chip with **live status** and a link that reopens the session in the app. Only surfaces sessions Focus created; cloud agent-tasks are unchanged.

## How

- **Migration 018** - a join table `todo_copilot_app_sessions(todo_id, session_id)` (not a single column) so a todo can carry multiple delegated sessions over time; re-delegating never hides a still-running prior one. Both sides `ON DELETE CASCADE`.
- **`store.linkTodoSession`** - transactional + validated in main: the todo exists (not soft-deleted), the session exists, and their `project_id`s match **exactly** (a null-project/unassigned session can't attach). Idempotent per pair. `getTodoAppSessionsForProject` joins through the project's visible todos with a defense-in-depth project-match guard.
- **`status.ts`** - reads the app's own `~/.copilot/data.db` **read-only** for our session ids only (`SELECT id, is_running WHERE id IN (...)`, chunked, handle closed in `finally`). Mapping (verified against the live schema, where sessions persist after finishing): `is_running=1` → working, `0` → idle, **absent → unknown** (absence ≠ completed). App closed/locked → keep last-known; schema drift → unknown. `better-sqlite3` is loaded lazily so the pure mapping + refresh are unit-testable.
- **IPC** - `todos:link-session`, `copilot:app-sessions-for-project` (refreshes status from `data.db`).
- **UI** - a `TodoSessionChip` (status dot + deliberately honest copy: "Copilot working on this" / "Copilot idle", not "needs you") that opens the session in the app. `FocusPage` links an app-session result to its todo and refreshes on project load, window focus, a 20s interval, and after a delegation.

## Privacy

The status query only ever touches the ids Focus created (`WHERE id IN (...)`), selects only `id, is_running`, and logs nothing. No other session's row or content is read.

## Verification

- **20 new tests**: the pure status mapping (running/idle/absent), the refresh orchestration with an injected reader (updates stored status; keeps last-known on a transient read failure), and the link functions (idempotent, multi-session per todo, rejects missing todo / missing session / project mismatch / null-project session, hides a soft-deleted todo's link).
- **Full suite green** (443 tests), typecheck, lint, production build.
- **Real end-to-end**: delegated a real session against the running app, read its `is_running` from `data.db` with the exact read-only SQL, then deleted it and confirmed it becomes absent (→ `unknown`, honestly not "completed"). Cleaned up.
- Reviewed via GPT-5.5 (plan + implementation; fixed a null-project link-integrity hole it caught).

## Scope note

App sessions surface only via their (visible) todo, so no project rail/digest union is needed and the project soft-delete-detach concern is moot for this scope.