### PR TITLE
Provision embedding model offline + real-MCP verify harness (#77 items 4, 3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,7 @@ Thumbs.db
 dist/
 *.tsbuildinfo
 backups
+
+# Provisioned local embedding model (bundled into the packaged app at build time;
+# never committed — ~90 MB. Run `bun run provision-model` to populate.)
+.model-cache/

--- a/build/afterpack-verify-model.cjs
+++ b/build/afterpack-verify-model.cjs
@@ -1,0 +1,48 @@
+// electron-builder afterPack hook (build tooling — must be require()-able by the
+// electron-builder node process, hence CommonJS .cjs rather than app TS source).
+//
+// The bundle-before-flip build gate: the packaged app forces the embedding model
+// offline (`allowRemoteModels: false`), so a build that ships WITHOUT the bundled
+// model would silently degrade to lexical-only forever. This hook FAILS the build
+// if the provisioned model files didn't land under the app's Resources, so such a
+// build can never be produced.
+//
+// The required-files list mirrors REQUIRED_MODEL_FILES / MODEL_CACHE_SUBPATH in
+// src/main/context/embed.ts — keep them in sync.
+
+const path = require('node:path')
+const fs = require('node:fs')
+
+const MODEL_CACHE_SUBPATH = 'Xenova/all-MiniLM-L6-v2'
+const REQUIRED_MODEL_FILES = [
+  'config.json',
+  'tokenizer.json',
+  'tokenizer_config.json',
+  'onnx/model.onnx',
+]
+
+exports.default = async function afterPackVerifyModel(context) {
+  const { appOutDir, packager, electronPlatformName } = context
+
+  // Resources layout differs per platform; this app targets macOS.
+  let resourcesDir
+  if (electronPlatformName === 'darwin' || electronPlatformName === 'mas') {
+    const appName = `${packager.appInfo.productFilename}.app`
+    resourcesDir = path.join(appOutDir, appName, 'Contents', 'Resources')
+  } else {
+    resourcesDir = path.join(appOutDir, 'resources')
+  }
+
+  const modelDir = path.join(resourcesDir, 'model-cache', MODEL_CACHE_SUBPATH)
+  const missing = REQUIRED_MODEL_FILES.filter((f) => !fs.existsSync(path.join(modelDir, f)))
+
+  if (missing.length > 0) {
+    throw new Error(
+      `[afterPack] bundle-before-flip gate FAILED: the embedding model is missing from the ` +
+        `packaged app. Missing under ${modelDir}: ${missing.join(', ')}. ` +
+        'Run `bun run provision-model` before packaging (dist/dist:dir do this automatically).'
+    )
+  }
+
+  console.log(`[afterPack] embedding model present under Resources/model-cache (${REQUIRED_MODEL_FILES.length} files).`)
+}

--- a/build/afterpack-verify-model.cjs
+++ b/build/afterpack-verify-model.cjs
@@ -44,10 +44,17 @@ exports.default = async function afterPackVerifyModel(context) {
   let requiredFiles = REQUIRED_MODEL_FILES
   try {
     const provenance = JSON.parse(fs.readFileSync(path.join(modelCacheDir, 'PROVENANCE.json'), 'utf8'))
-    if (typeof provenance.modelId === 'string' && provenance.modelId.length > 0) {
-      subpath = provenance.modelId
+    // Only trust provenance that is actually usable. A blank modelId or an empty
+    // files array would otherwise make this gate a no-op and let a model-less
+    // build ship, so fall back to the hardcoded safe defaults in those cases.
+    if (typeof provenance.modelId === 'string' && provenance.modelId.trim().length > 0) {
+      subpath = provenance.modelId.trim()
     }
-    if (Array.isArray(provenance.files) && provenance.files.every((f) => typeof f === 'string')) {
+    if (
+      Array.isArray(provenance.files) &&
+      provenance.files.length > 0 &&
+      provenance.files.every((f) => typeof f === 'string' && f.trim().length > 0)
+    ) {
       requiredFiles = provenance.files
     }
   } catch {

--- a/build/afterpack-verify-model.cjs
+++ b/build/afterpack-verify-model.cjs
@@ -7,8 +7,10 @@
 // if the provisioned model files didn't land under the app's Resources, so such a
 // build can never be produced.
 //
-// The required-files list mirrors REQUIRED_MODEL_FILES / MODEL_CACHE_SUBPATH in
-// src/main/context/embed.ts — keep them in sync.
+// The gate prefers the bundled PROVENANCE.json (written by provision-model.ts) as
+// the source of truth for what should be present. The constants below are only a
+// FALLBACK when provenance is missing/unreadable; they mirror REQUIRED_MODEL_FILES
+// / MODEL_CACHE_SUBPATH in src/main/context/embed.ts.
 
 const path = require('node:path')
 const fs = require('node:fs')
@@ -33,8 +35,27 @@ exports.default = async function afterPackVerifyModel(context) {
     resourcesDir = path.join(appOutDir, 'resources')
   }
 
-  const modelDir = path.join(resourcesDir, 'model-cache', MODEL_CACHE_SUBPATH)
-  const missing = REQUIRED_MODEL_FILES.filter((f) => !fs.existsSync(path.join(modelDir, f)))
+  const modelCacheDir = path.join(resourcesDir, 'model-cache')
+
+  // Prefer the bundled PROVENANCE.json (written by provision-model.ts) as the
+  // single source of truth for what should be present, so this gate can't drift
+  // if the model id / file list changes. Fall back to the mirrored constants.
+  let subpath = MODEL_CACHE_SUBPATH
+  let requiredFiles = REQUIRED_MODEL_FILES
+  try {
+    const provenance = JSON.parse(fs.readFileSync(path.join(modelCacheDir, 'PROVENANCE.json'), 'utf8'))
+    if (typeof provenance.modelId === 'string' && provenance.modelId.length > 0) {
+      subpath = provenance.modelId
+    }
+    if (Array.isArray(provenance.files) && provenance.files.every((f) => typeof f === 'string')) {
+      requiredFiles = provenance.files
+    }
+  } catch {
+    // No/invalid provenance — fall back to the hardcoded list below.
+  }
+
+  const modelDir = path.join(modelCacheDir, subpath)
+  const missing = requiredFiles.filter((f) => !fs.existsSync(path.join(modelDir, f)))
 
   if (missing.length > 0) {
     throw new Error(
@@ -44,5 +65,5 @@ exports.default = async function afterPackVerifyModel(context) {
     )
   }
 
-  console.log(`[afterPack] embedding model present under Resources/model-cache (${REQUIRED_MODEL_FILES.length} files).`)
+  console.log(`[afterPack] embedding model present under Resources/model-cache (${requiredFiles.length} files).`)
 }

--- a/build/afterpack-verify-model.cjs
+++ b/build/afterpack-verify-model.cjs
@@ -15,6 +15,16 @@
 const path = require('node:path')
 const fs = require('node:fs')
 
+// True only when `p` exists AND is a regular file (existsSync is also true for
+// directories, which would let a broken bundle pass the gate).
+function isFile(p) {
+  try {
+    return fs.statSync(p).isFile()
+  } catch {
+    return false
+  }
+}
+
 const MODEL_CACHE_SUBPATH = 'Xenova/all-MiniLM-L6-v2'
 const REQUIRED_MODEL_FILES = [
   'config.json',
@@ -62,7 +72,7 @@ exports.default = async function afterPackVerifyModel(context) {
   }
 
   const modelDir = path.join(modelCacheDir, subpath)
-  const missing = requiredFiles.filter((f) => !fs.existsSync(path.join(modelDir, f)))
+  const missing = requiredFiles.filter((f) => !isFile(path.join(modelDir, f)))
 
   if (missing.length > 0) {
     throw new Error(

--- a/package.json
+++ b/package.json
@@ -12,12 +12,14 @@
     "test": "bun run typecheck && bun run lint && vitest run",
     "test:watch": "vitest",
     "eval:live": "bun --bun run src/main/context/eval/live-eval.ts",
+    "provision-model": "bun --bun run scripts/provision-model.ts",
+    "verify-mcp": "bun --bun run scripts/verify-mcp.ts",
     "prepackage": "bun install --frozen-lockfile && bun run rebuild",
-    "dist": "bun run prepackage && bun run build && electron-builder --mac",
-    "dist:dir": "bun run prepackage && bun run build && electron-builder --dir --mac",
+    "dist": "bun run prepackage && bun run provision-model && bun run build && electron-builder --mac",
+    "dist:dir": "bun run prepackage && bun run provision-model && bun run build && electron-builder --dir --mac",
     "db:copy-prod": "bash scripts/copy-prod-db.sh",
     "rebuild": "electron-rebuild -f -w better-sqlite3",
-    "setup": "bun install && bun run rebuild",
+    "setup": "bun install && bun run rebuild && bun --bun run scripts/provision-model.ts --best-effort",
     "install-app": "bash scripts/install-app.sh"
   },
   "keywords": [],
@@ -68,14 +70,24 @@
   "build": {
     "appId": "com.robertcrandall.gh-projects",
     "productName": "GH Projects",
+    "afterPack": "./build/afterpack-verify-model.cjs",
     "mac": {
       "category": "public.app-category.productivity",
       "target": "dmg"
     },
+    "asarUnpack": [
+      "**/node_modules/onnxruntime-node/**",
+      "**/node_modules/sharp/**",
+      "**/node_modules/@img/**"
+    ],
     "extraResources": [
       {
         "from": "db/migrations",
         "to": "db/migrations"
+      },
+      {
+        "from": ".model-cache",
+        "to": "model-cache"
       }
     ],
     "files": [

--- a/requirements/pre-release-owner-checklist.md
+++ b/requirements/pre-release-owner-checklist.md
@@ -1,12 +1,12 @@
 # Pre-release owner checklist (#77 items 4 + 3)
 
 Most of items 4 and 3 are done + verified headlessly (see the PR). This file is the
-short list of steps that genuinely need **you** — your machine, your signing
+short list of steps that genuinely need **you** - your machine, your signing
 identity, and your SSO credentials. Everything else is already proven.
 
 ## What's already verified (no action needed)
 
-- **Item 4 — offline model provisioning:** the MiniLM model is provisioned into
+- **Item 4 - offline model provisioning:** the MiniLM model is provisioned into
   `.model-cache/` at build time and bundled into the packaged app under
   `Resources/model-cache/`. Verified on an **unsigned `--dir` build**:
   - the electron-builder `afterPack` gate confirms the 4 model files are present
@@ -14,13 +14,13 @@ identity, and your SSO credentials. Everything else is already proven.
   - `@huggingface/transformers`, `onnxruntime-node`, `better-sqlite3`, and `sharp`
     all ship in the package (native binaries unpacked from the asar);
   - the packaged app loads the model **fully offline** (`allowRemoteModels=false`)
-    and produces a 384-dim embedding — confirmed by running the packaged binary's
+    and produces a 384-dim embedding - confirmed by running the packaged binary's
     `--embedding-smoke` mode.
-- **Item 3 — app-owned MCP read:** the `verify-mcp` harness drives the app's real
+- **Item 3 - app-owned MCP read:** the `verify-mcp` harness drives the app's real
   `listMcpTools` + `createMcpRunner` and was confirmed end-to-end against the
   synthetic echo MCP server (live value pulled, failure classes correct).
 
-## Owner-only step 1 — confirm offline load on the SIGNED build (item 4)
+## Owner-only step 1 - confirm offline load on the SIGNED build (item 4)
 
 The unsigned build is proven; the only thing I can't do is sign/notarize. After a
 real signed build:
@@ -41,16 +41,16 @@ Expect:
 `packaged=true` + `allowRemoteModels=false` + `OK` means the signed app loads the
 model offline. Treat **"every distributable `.app` passes `--embedding-smoke`"** as
 a required release step. (Optional: launch the app normally, ask the brain a
-question, and confirm the resolve logs `retrievalMode:'semantic'` — not
-`'lexical-fallback'` — on first use with the network off.)
+question, and confirm the resolve logs `retrievalMode:'semantic'` - not
+`'lexical-fallback'` - on first use with the network off.)
 
-## Owner-only step 2 — pull a real SSO-gated MCP value (item 3)
+## Owner-only step 2 - pull a real SSO-gated MCP value (item 3)
 
 This needs your real Datadog/Splunk/Kusto MCP server + SSO credentials, which
 can't live in the sandbox. Two ways, either is fine:
 
 **A. One command (no GUI):** write a local config file (secrets stay on your
-machine — never commit it):
+machine - never commit it):
 
 ```jsonc
 // ~/datadog-mcp.json

--- a/requirements/pre-release-owner-checklist.md
+++ b/requirements/pre-release-owner-checklist.md
@@ -1,0 +1,79 @@
+# Pre-release owner checklist (#77 items 4 + 3)
+
+Most of items 4 and 3 are done + verified headlessly (see the PR). This file is the
+short list of steps that genuinely need **you** — your machine, your signing
+identity, and your SSO credentials. Everything else is already proven.
+
+## What's already verified (no action needed)
+
+- **Item 4 — offline model provisioning:** the MiniLM model is provisioned into
+  `.model-cache/` at build time and bundled into the packaged app under
+  `Resources/model-cache/`. Verified on an **unsigned `--dir` build**:
+  - the electron-builder `afterPack` gate confirms the 4 model files are present
+    (a build without them **fails**);
+  - `@huggingface/transformers`, `onnxruntime-node`, `better-sqlite3`, and `sharp`
+    all ship in the package (native binaries unpacked from the asar);
+  - the packaged app loads the model **fully offline** (`allowRemoteModels=false`)
+    and produces a 384-dim embedding — confirmed by running the packaged binary's
+    `--embedding-smoke` mode.
+- **Item 3 — app-owned MCP read:** the `verify-mcp` harness drives the app's real
+  `listMcpTools` + `createMcpRunner` and was confirmed end-to-end against the
+  synthetic echo MCP server (live value pulled, failure classes correct).
+
+## Owner-only step 1 — confirm offline load on the SIGNED build (item 4)
+
+The unsigned build is proven; the only thing I can't do is sign/notarize. After a
+real signed build:
+
+```bash
+bun run dist            # signed + notarized .dmg (needs your Developer ID)
+# then run the packaged binary's headless smoke mode:
+"dist/mac-arm64/GH Projects.app/Contents/MacOS/GH Projects" --embedding-smoke
+```
+
+Expect:
+
+```
+[embedding-smoke] packaged=true cacheDir=…/Resources/model-cache allowRemoteModels=false
+[embedding-smoke] OK: loaded model and produced a 384-dim embedding
+```
+
+`packaged=true` + `allowRemoteModels=false` + `OK` means the signed app loads the
+model offline. Treat **"every distributable `.app` passes `--embedding-smoke`"** as
+a required release step. (Optional: launch the app normally, ask the brain a
+question, and confirm the resolve logs `retrievalMode:'semantic'` — not
+`'lexical-fallback'` — on first use with the network off.)
+
+## Owner-only step 2 — pull a real SSO-gated MCP value (item 3)
+
+This needs your real Datadog/Splunk/Kusto MCP server + SSO credentials, which
+can't live in the sandbox. Two ways, either is fine:
+
+**A. One command (no GUI):** write a local config file (secrets stay on your
+machine — never commit it):
+
+```jsonc
+// ~/datadog-mcp.json
+{
+  "label": "datadog",
+  "command": "npx",
+  "args": ["-y", "@datadog/mcp-server"],   // your real server command
+  "env": { "DD_API_KEY": "…", "DD_APP_KEY": "…" },
+  "tool": "search_logs",                     // a real read-only tool
+  "toolArgs": { "query": "service:web", "from": "now-15m" }
+}
+```
+
+```bash
+bun run verify-mcp ~/datadog-mcp.json
+```
+
+Expect a non-empty `value:` and `✅ live value pulled through the app's real MCP
+client.` A `failure` of `auth_missing`/`connector_down`/`timeout` points at
+infra/creds; `query_invalid`/`no_data` points at the tool/args.
+
+**B. In the app:** Settings → Connect a tool → enter the same server, then trigger
+a resolve on a resource wired to it and confirm the live value renders.
+
+Because the harness imports the app's *own* client code (not a reimplementation),
+a green run in **A** proves the running app can pull the same value.

--- a/scripts/provision-model.ts
+++ b/scripts/provision-model.ts
@@ -18,7 +18,7 @@
  * integrity problems (incomplete files, wrong dims, corrupt cache) so a real
  * provisioning bug is never masked.
  */
-import { existsSync, mkdirSync, writeFileSync } from 'fs'
+import { statSync, mkdirSync, writeFileSync } from 'fs'
 import { join } from 'path'
 import { fileURLToPath } from 'url'
 import {
@@ -35,9 +35,18 @@ const CACHE_DIR = join(REPO_ROOT, '.model-cache')
 /** A local-integrity failure that must fail even in best-effort mode. */
 class IntegrityError extends Error {}
 
+/** True when `p` exists AND is a regular file (existsSync is also true for dirs). */
+function isFile(p: string): boolean {
+  try {
+    return statSync(p).isFile()
+  } catch {
+    return false
+  }
+}
+
 function modelFilesPresent(): boolean {
   const modelDir = join(CACHE_DIR, MODEL_CACHE_SUBPATH)
-  return REQUIRED_MODEL_FILES.every((f) => existsSync(join(modelDir, f)))
+  return REQUIRED_MODEL_FILES.every((f) => isFile(join(modelDir, f)))
 }
 
 /**

--- a/scripts/provision-model.ts
+++ b/scripts/provision-model.ts
@@ -83,13 +83,17 @@ async function assertEmbeds(allowRemoteModels: boolean): Promise<void> {
 async function writeProvenance(): Promise<void> {
   let sha: string | null = null
   try {
-    const res = await fetch(`https://huggingface.co/api/models/${EMBEDDING_MODEL_ID}/revision/main`)
+    // Short timeout so an offline/SSO-restricted environment can't hang the whole
+    // provisioning step (and therefore `dist` / `setup`) on this best-effort fetch.
+    const res = await fetch(`https://huggingface.co/api/models/${EMBEDDING_MODEL_ID}/revision/main`, {
+      signal: AbortSignal.timeout(5000),
+    })
     if (res.ok) {
       const body = (await res.json()) as { sha?: unknown }
       if (typeof body.sha === 'string') sha = body.sha
     }
   } catch {
-    // Provenance is informational — never fail provisioning over it.
+    // Provenance is informational — never fail (or hang) provisioning over it.
   }
   const provenance = {
     modelId: EMBEDDING_MODEL_ID,

--- a/scripts/provision-model.ts
+++ b/scripts/provision-model.ts
@@ -40,10 +40,33 @@ function modelFilesPresent(): boolean {
   return REQUIRED_MODEL_FILES.every((f) => existsSync(join(modelDir, f)))
 }
 
-/** True when ANY required model file already exists (a partial/possibly-corrupt cache). */
-function anyModelFilesPresent(): boolean {
-  const modelDir = join(CACHE_DIR, MODEL_CACHE_SUBPATH)
-  return REQUIRED_MODEL_FILES.some((f) => existsSync(join(modelDir, f)))
+/**
+ * Heuristic: does this error (or anything in its `cause` chain) look like a
+ * connectivity failure, versus a load/inference/integrity problem? Best-effort
+ * mode swallows ONLY connectivity failures — that's the whole contract, so we
+ * classify by cause rather than by which files happen to be on disk (a partial or
+ * empty cache dir is an unreliable proxy, and a fetched-but-broken model would be
+ * masked). An IntegrityError never matches, so it always surfaces.
+ */
+function isLikelyNetworkError(err: unknown): boolean {
+  if (err instanceof IntegrityError) return false
+  const signals = [
+    'fetch failed', 'failed to fetch', 'network', 'enotfound', 'econnrefused',
+    'eai_again', 'etimedout', 'econnreset', 'enetunreach', 'ehostunreach',
+    'getaddrinfo', 'socket hang up', 'und_err', 'request to', 'timed out',
+    'timeout', 'dns', 'offline', 'certificate', 'tls', 'ssl',
+  ]
+  const seen = new Set<unknown>()
+  let cur: unknown = err
+  while (cur !== null && cur !== undefined && !seen.has(cur)) {
+    seen.add(cur)
+    const asErr = cur instanceof Error ? cur : null
+    const code = asErr ? (asErr as { code?: unknown }).code : undefined
+    const hay = `${asErr ? `${asErr.name} ${asErr.message}` : String(cur)} ${code ?? ''}`.toLowerCase()
+    if (signals.some((s) => hay.includes(s))) return true
+    cur = asErr ? (asErr as { cause?: unknown }).cause : undefined
+  }
+  return false
 }
 
 /** Loads the model with the given remote policy and asserts it yields 384 dims. */
@@ -91,28 +114,21 @@ async function main(): Promise<void> {
   }
 
   console.log(`[provision] downloading ${EMBEDDING_MODEL_ID} into ${CACHE_DIR}…`)
-  // A partial cache present here (some but not all required files) is suspect: a
-  // corrupt/interrupted file can make transformers throw on the local copy before
-  // it repairs. Only a truly pristine dir is safe to treat a failure as "just
-  // offline" in best-effort mode; otherwise fail loudly so it gets re-provisioned.
-  const partialCache = anyModelFilesPresent()
   try {
     await assertEmbeds(true)
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err)
-    if (bestEffort && !partialCache) {
-      // Truly pristine + can't download → offline/network. Dev self-heals later.
+    // Best-effort (used by `setup`) tolerates ONLY a connectivity failure, so a
+    // fresh offline checkout still succeeds — the app self-heals on first use (a
+    // partial/absent cache is treated as unprovisioned at runtime and re-fetched).
+    // Any non-network failure (bad dims, corrupt/incomplete file, inference or
+    // runtime error) is a real breakage and surfaces even in best-effort.
+    if (bestEffort && isLikelyNetworkError(err)) {
       console.warn(
-        `[provision] could not download the model (${msg}). ` +
+        `[provision] could not download the model - looks like a network issue (${msg}). ` +
           'Continuing (best-effort): dev will fetch it on first use. Run `bun run provision-model` when online.'
       )
       return
-    }
-    if (partialCache) {
-      throw new IntegrityError(
-        `partial/corrupt model cache at ${CACHE_DIR} and (re)provisioning failed (${msg}). ` +
-          'Delete .model-cache and rerun `bun run provision-model`.'
-      )
     }
     throw err
   }

--- a/scripts/provision-model.ts
+++ b/scripts/provision-model.ts
@@ -1,0 +1,132 @@
+/**
+ * Provisions the local embedding model so the packaged app can run fully offline.
+ *
+ * Downloads the exact MiniLM model transformers.js loads by default into a
+ * gitignored `.model-cache/` at the repo root (same `cacheDir` layout the runtime
+ * reads), verifies completeness + a fully-offline reload, and records provenance.
+ * electron-builder bundles `.model-cache` into the packaged app's Resources.
+ *
+ * Reuses the app's REAL embedder (`createLocalEmbedder`) — no reimplementation.
+ *
+ * Run:
+ *   bun --bun run scripts/provision-model.ts               # strict (used by dist)
+ *   bun --bun run scripts/provision-model.ts --best-effort # used by `setup`
+ *
+ * Strict mode fails on any error. Best-effort mode warns + exits 0 ONLY when the
+ * model can't be downloaded (offline/network), so a fresh `bun run setup` without
+ * network still succeeds (dev self-heals at runtime). It still FAILS on local
+ * integrity problems (incomplete files, wrong dims, corrupt cache) so a real
+ * provisioning bug is never masked.
+ */
+import { existsSync, mkdirSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { fileURLToPath } from 'url'
+import {
+  createLocalEmbedder,
+  EMBEDDING_DIMS,
+  EMBEDDING_MODEL_ID,
+  MODEL_CACHE_SUBPATH,
+  REQUIRED_MODEL_FILES,
+} from '../src/main/context/embed'
+
+const REPO_ROOT = fileURLToPath(new URL('..', import.meta.url))
+const CACHE_DIR = join(REPO_ROOT, '.model-cache')
+
+/** A local-integrity failure that must fail even in best-effort mode. */
+class IntegrityError extends Error {}
+
+function modelFilesPresent(): boolean {
+  const modelDir = join(CACHE_DIR, MODEL_CACHE_SUBPATH)
+  return REQUIRED_MODEL_FILES.every((f) => existsSync(join(modelDir, f)))
+}
+
+/** True when ANY required model file already exists (a partial/possibly-corrupt cache). */
+function anyModelFilesPresent(): boolean {
+  const modelDir = join(CACHE_DIR, MODEL_CACHE_SUBPATH)
+  return REQUIRED_MODEL_FILES.some((f) => existsSync(join(modelDir, f)))
+}
+
+/** Loads the model with the given remote policy and asserts it yields 384 dims. */
+async function assertEmbeds(allowRemoteModels: boolean): Promise<void> {
+  const embedder = createLocalEmbedder({ cacheDir: CACHE_DIR, allowRemoteModels })
+  const vectors = await embedder.embed(['provisioning check'])
+  const dims = vectors[0]?.length ?? 0
+  if (dims !== EMBEDDING_DIMS) {
+    throw new IntegrityError(`expected ${EMBEDDING_DIMS} dims, got ${dims}`)
+  }
+}
+
+/** Records the resolved upstream commit for traceability (best-effort). */
+async function writeProvenance(): Promise<void> {
+  let sha: string | null = null
+  try {
+    const res = await fetch(`https://huggingface.co/api/models/${EMBEDDING_MODEL_ID}/revision/main`)
+    if (res.ok) {
+      const body = (await res.json()) as { sha?: unknown }
+      if (typeof body.sha === 'string') sha = body.sha
+    }
+  } catch {
+    // Provenance is informational — never fail provisioning over it.
+  }
+  const provenance = {
+    modelId: EMBEDDING_MODEL_ID,
+    resolvedSha: sha,
+    provisionedAt: new Date().toISOString(),
+    files: REQUIRED_MODEL_FILES,
+  }
+  writeFileSync(join(CACHE_DIR, 'PROVENANCE.json'), `${JSON.stringify(provenance, null, 2)}\n`, 'utf8')
+}
+
+async function main(): Promise<void> {
+  const bestEffort = process.argv.includes('--best-effort')
+  mkdirSync(CACHE_DIR, { recursive: true })
+
+  if (modelFilesPresent()) {
+    console.log(`[provision] model already present at ${CACHE_DIR}; verifying offline load…`)
+    // Files exist → any failure here is a local-integrity problem, never network.
+    await assertEmbeds(false)
+    await writeProvenance()
+    console.log('[provision] OK: existing model loads offline (384 dims).')
+    return
+  }
+
+  console.log(`[provision] downloading ${EMBEDDING_MODEL_ID} into ${CACHE_DIR}…`)
+  // A partial cache present here (some but not all required files) is suspect: a
+  // corrupt/interrupted file can make transformers throw on the local copy before
+  // it repairs. Only a truly pristine dir is safe to treat a failure as "just
+  // offline" in best-effort mode; otherwise fail loudly so it gets re-provisioned.
+  const partialCache = anyModelFilesPresent()
+  try {
+    await assertEmbeds(true)
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    if (bestEffort && !partialCache) {
+      // Truly pristine + can't download → offline/network. Dev self-heals later.
+      console.warn(
+        `[provision] could not download the model (${msg}). ` +
+          'Continuing (best-effort): dev will fetch it on first use. Run `bun run provision-model` when online.'
+      )
+      return
+    }
+    if (partialCache) {
+      throw new IntegrityError(
+        `partial/corrupt model cache at ${CACHE_DIR} and (re)provisioning failed (${msg}). ` +
+          'Delete .model-cache and rerun `bun run provision-model`.'
+      )
+    }
+    throw err
+  }
+
+  // Downloaded — now integrity checks that must fail even in best-effort mode.
+  if (!modelFilesPresent()) {
+    throw new IntegrityError('download completed but required model files are missing')
+  }
+  await assertEmbeds(false)
+  await writeProvenance()
+  console.log('[provision] OK: model downloaded and loads fully offline (384 dims).')
+}
+
+main().catch((err: unknown) => {
+  console.error('[provision] FAILED:', err instanceof Error ? err.message : err)
+  process.exit(1)
+})

--- a/scripts/verify-focus.ts
+++ b/scripts/verify-focus.ts
@@ -10,6 +10,7 @@
 import { Database } from 'bun:sqlite'
 import { readFileSync, readdirSync } from 'node:fs'
 import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { computeDigestItems, type DigestNotificationRow, type DigestSessionRow } from '../src/main/digest/compute'
 import { classifyDrift } from '../src/main/digest/classify'
 
@@ -23,7 +24,7 @@ const db = new Database(':memory:')
 db.exec('PRAGMA foreign_keys = ON')
 
 // Apply migrations from disk (bypasses the electron-dependent runMigrations).
-const migrationsDir = join(import.meta.dir, '..', 'db', 'migrations')
+const migrationsDir = join(fileURLToPath(new URL('..', import.meta.url)), 'db', 'migrations')
 for (const file of readdirSync(migrationsDir).filter((f) => f.endsWith('.sql')).sort()) {
   const sql = readFileSync(join(migrationsDir, file), 'utf8')
   const stripped = sql.replace(/--[^\n]*/g, '').trim()

--- a/scripts/verify-mcp.ts
+++ b/scripts/verify-mcp.ts
@@ -110,6 +110,9 @@ async function main(): Promise<void> {
 }
 
 main().catch((err: unknown) => {
+  // Exit-code scheme: 0 = live value pulled, 1 = bad input/usage (via die), 2 =
+  // runtime failure (handshake/read). An unexpected throw here is a runtime
+  // failure, not bad input, so it exits 2 - not 1.
   console.error('[verify-mcp] unexpected error:', err instanceof Error ? err.message : err)
-  process.exit(1)
+  process.exit(2)
 })

--- a/scripts/verify-mcp.ts
+++ b/scripts/verify-mcp.ts
@@ -12,7 +12,10 @@
  * — never self-reported — so a green run genuinely proves the server answered.
  *
  * Usage:
- *   bun --bun run scripts/verify-mcp.ts <server-config.json> [toolName] [toolArgsJson]
+ *   bun --bun run scripts/verify-mcp.ts <server-config.json> [toolName] [toolArgsJson] [--full]
+ *
+ * By default the live value is previewed (first 200 chars) so sensitive output
+ * doesn't dump into terminal/CI history; pass --full to print the whole value.
  *
  * <server-config.json> is a JSON object:
  *   {
@@ -35,9 +38,11 @@ function die(message: string): never {
 }
 
 async function main(): Promise<void> {
-  const [configPath, toolArg, toolArgsArg] = process.argv.slice(2)
+  const argv = process.argv.slice(2)
+  const full = argv.includes('--full')
+  const [configPath, toolArg, toolArgsArg] = argv.filter((a) => a !== '--full')
   if (configPath === undefined) {
-    die('usage: bun --bun run scripts/verify-mcp.ts <server-config.json> [toolName] [toolArgsJson]')
+    die('usage: bun --bun run scripts/verify-mcp.ts <server-config.json> [toolName] [toolArgsJson] [--full]')
   }
 
   let raw: unknown
@@ -74,7 +79,9 @@ async function main(): Promise<void> {
   if (!toolArgs.ok) die(`invalid tool args: ${toolArgs.error}`)
 
   // ── 1. Handshake: does the server start + list tools? ───────────────────────
-  console.log(`[verify-mcp] connecting to "${server.command} ${server.args.join(' ')}" and listing tools…`)
+  // Log only the command + arg count — args can carry credentials (e.g. a token),
+  // which shouldn't leak into terminal history / CI logs.
+  console.log(`[verify-mcp] connecting to "${server.command}" (${server.args.length} arg(s)) and listing tools…`)
   const tools = await listMcpTools(server)
   if (!tools.ok) {
     // A handshake failure is an infra/auth/timeout problem, not bad CLI input, so
@@ -96,7 +103,17 @@ async function main(): Promise<void> {
   console.log(`  ok:       ${result.ok}`)
   console.log(`  failure:  ${result.failure ?? '(none)'}`)
   console.log(`  reason:   ${result.reason ?? '(none)'}`)
-  console.log(`  value:    ${result.ok ? JSON.stringify(result.value) : '(no value)'}`)
+  // The tool value can contain sensitive data (logs, account info). Show only a
+  // short preview by default so it doesn't dump into terminal history / CI logs;
+  // pass --full to print the whole value.
+  if (result.ok) {
+    const serialized = JSON.stringify(result.value)
+    const PREVIEW = 200
+    const shown = full || serialized.length <= PREVIEW ? serialized : `${serialized.slice(0, PREVIEW)}… (${serialized.length} chars; pass --full to show all)`
+    console.log(`  value:    ${shown}`)
+  } else {
+    console.log('  value:    (no value)')
+  }
 
   if (result.ok) {
     console.log('\n[verify-mcp] ✅ live value pulled through the app’s real MCP client.')

--- a/scripts/verify-mcp.ts
+++ b/scripts/verify-mcp.ts
@@ -1,0 +1,110 @@
+/**
+ * Real SSO-gated MCP verification harness (issue #77 item 3).
+ *
+ * Drives the app's OWN MCP client code path — `listMcpTools` + `createMcpRunner`
+ * from src/main/context/mcp-client.ts, plus the real config/tool validation from
+ * mcp-config.ts — against a real MCP server config the owner supplies. It does a
+ * `listTools` handshake and ONE tool read, then prints the live value and its
+ * provenance (ok / failure class). No Electron, no GUI: this is the ~2-minute
+ * owner task that proves a live SSO-gated value can be pulled end-to-end.
+ *
+ * The printed `value` is produced ONLY by the app-owned MCP read (createMcpRunner)
+ * — never self-reported — so a green run genuinely proves the server answered.
+ *
+ * Usage:
+ *   bun --bun run scripts/verify-mcp.ts <server-config.json> [toolName] [toolArgsJson]
+ *
+ * <server-config.json> is a JSON object:
+ *   {
+ *     "label":   "datadog",
+ *     "command": "npx",
+ *     "args":    ["-y", "@datadog/mcp-server"],
+ *     "env":     { "DD_API_KEY": "…", "DD_APP_KEY": "…" },
+ *     "tool":    "search_logs",            // optional; or pass as argv[2]
+ *     "toolArgs": { "query": "service:web" } // optional; or pass JSON as argv[3]
+ *   }
+ * Secrets live only in that local file / the owner's env — nothing is committed.
+ */
+import { readFileSync } from 'fs'
+import { listMcpTools, createMcpRunner } from '../src/main/context/mcp-client'
+import { validateMcpServerInput, validateToolName, validateToolArgs } from '../src/main/context/mcp-config'
+
+function die(message: string): never {
+  console.error(`[verify-mcp] ${message}`)
+  process.exit(1)
+}
+
+async function main(): Promise<void> {
+  const [configPath, toolArg, toolArgsArg] = process.argv.slice(2)
+  if (configPath === undefined) {
+    die('usage: bun --bun run scripts/verify-mcp.ts <server-config.json> [toolName] [toolArgsJson]')
+  }
+
+  let raw: unknown
+  try {
+    raw = JSON.parse(readFileSync(configPath, 'utf8'))
+  } catch (err) {
+    die(`could not read/parse ${configPath}: ${err instanceof Error ? err.message : String(err)}`)
+  }
+  const file = raw as Record<string, unknown>
+
+  // Reuse the app's REAL config validation so this exercises the same seam the app does.
+  const validated = validateMcpServerInput(file.label ?? 'verify-mcp', file)
+  if (!validated.ok) die(`invalid server config: ${validated.error}`)
+  const server = validated.value.config
+
+  const toolNameRaw = toolArg ?? file.tool
+  const toolName = validateToolName(toolNameRaw)
+  if (!toolName.ok) die(`invalid/missing tool name: ${toolName.error} (pass as argv[2] or "tool" in the config)`)
+
+  let toolArgsRaw: unknown = file.toolArgs ?? {}
+  if (toolArgsArg !== undefined) {
+    try {
+      toolArgsRaw = JSON.parse(toolArgsArg)
+    } catch (err) {
+      die(`toolArgsJson is not valid JSON: ${err instanceof Error ? err.message : String(err)}`)
+    }
+  }
+  const toolArgs = validateToolArgs(toolArgsRaw)
+  if (!toolArgs.ok) die(`invalid tool args: ${toolArgs.error}`)
+
+  // ── 1. Handshake: does the server start + list tools? ───────────────────────
+  console.log(`[verify-mcp] connecting to "${server.command} ${server.args.join(' ')}" and listing tools…`)
+  const tools = await listMcpTools(server)
+  if (!tools.ok) {
+    // A handshake failure is an infra/auth/timeout problem, not bad CLI input, so
+    // it exits 2 (runtime failure) — not 1 (which is reserved for bad input).
+    console.error(`[verify-mcp] ❌ listTools failed (server didn't start / auth / timeout): ${tools.error}`)
+    process.exit(2)
+  }
+  console.log(`[verify-mcp] handshake OK: ${tools.tools.length} tool(s) advertised`)
+  const found = tools.tools.some((t) => t.name === toolName.value)
+  console.log(
+    `[verify-mcp] target tool "${toolName.value}" ${found ? 'is advertised' : 'NOT in the advertised list (attempting anyway)'}`
+  )
+
+  // ── 2. Real read: the app-owned MCP client pulls a live value ───────────────
+  console.log(`[verify-mcp] calling ${toolName.value}(${JSON.stringify(toolArgs.value)})…`)
+  const result = await createMcpRunner().run(server, toolName.value, toolArgs.value)
+
+  console.log('\n[verify-mcp] ── result (app-owned; produced only by createMcpRunner) ──')
+  console.log(`  ok:       ${result.ok}`)
+  console.log(`  failure:  ${result.failure ?? '(none)'}`)
+  console.log(`  reason:   ${result.reason ?? '(none)'}`)
+  console.log(`  value:    ${result.ok ? JSON.stringify(result.value) : '(no value)'}`)
+
+  if (result.ok) {
+    console.log('\n[verify-mcp] ✅ live value pulled through the app’s real MCP client.')
+    process.exit(0)
+  }
+  console.log(
+    `\n[verify-mcp] ❌ no live value. failure="${result.failure}". ` +
+      '(auth_missing/connector_down/timeout = infra/creds; query_invalid/no_data = the tool/args.)'
+  )
+  process.exit(2)
+}
+
+main().catch((err: unknown) => {
+  console.error('[verify-mcp] unexpected error:', err instanceof Error ? err.message : err)
+  process.exit(1)
+})

--- a/scripts/verify-mcp.ts
+++ b/scripts/verify-mcp.ts
@@ -49,7 +49,7 @@ async function main(): Promise<void> {
   // Guard the shape before treating it as a config object, so a file containing
   // null / an array / a primitive gives a clear message instead of a raw TypeError.
   if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) {
-    die(`${configPath} must contain a JSON object with command/args/env (and optional tool/toolArgs)`)
+    die(`${configPath} must contain a JSON object with a "command" (plus optional args, env, tool, toolArgs)`)
   }
   const file = raw as Record<string, unknown>
 

--- a/scripts/verify-mcp.ts
+++ b/scripts/verify-mcp.ts
@@ -46,6 +46,11 @@ async function main(): Promise<void> {
   } catch (err) {
     die(`could not read/parse ${configPath}: ${err instanceof Error ? err.message : String(err)}`)
   }
+  // Guard the shape before treating it as a config object, so a file containing
+  // null / an array / a primitive gives a clear message instead of a raw TypeError.
+  if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) {
+    die(`${configPath} must contain a JSON object with command/args/env (and optional tool/toolArgs)`)
+  }
   const file = raw as Record<string, unknown>
 
   // Reuse the app's REAL config validation so this exercises the same seam the app does.

--- a/scripts/verify-mcp.ts
+++ b/scripts/verify-mcp.ts
@@ -96,7 +96,11 @@ async function main(): Promise<void> {
   )
 
   // ── 2. Real read: the app-owned MCP client pulls a live value ───────────────
-  console.log(`[verify-mcp] calling ${toolName.value}(${JSON.stringify(toolArgs.value)})…`)
+  // Tool args can carry sensitive values (tokens, ids, filters), so log only the
+  // arg key count by default; --full prints the actual args.
+  const argKeys = Object.keys(toolArgs.value)
+  const argsLabel = full ? JSON.stringify(toolArgs.value) : `${argKeys.length} arg(s): ${argKeys.join(', ')}`
+  console.log(`[verify-mcp] calling ${toolName.value}(${argsLabel})…`)
   const result = await createMcpRunner().run(server, toolName.value, toolArgs.value)
 
   console.log('\n[verify-mcp] ── result (app-owned; produced only by createMcpRunner) ──')

--- a/src/main/context/embed.ts
+++ b/src/main/context/embed.ts
@@ -73,16 +73,15 @@ export function createLocalEmbedder(options: EmbedderOptions = {}): Embedder {
     if (pipelinePromise === null) {
       // Import lazily so merely importing this module doesn't pull the runtime in.
       pipelinePromise = import('@huggingface/transformers').then(({ pipeline, env }) => {
-        // transformers.js `env` is process-global mutable state. Set both fields
-        // explicitly whenever a cacheDir is given so a value left over from an
-        // earlier call (e.g. an online provisioning run) can't leak in and, say,
-        // silently re-enable remote fetches in a load meant to be offline.
-        if (options.cacheDir !== undefined) {
-          env.cacheDir = options.cacheDir
-          env.allowRemoteModels = options.allowRemoteModels ?? true
-        } else if (options.allowRemoteModels !== undefined) {
-          env.allowRemoteModels = options.allowRemoteModels
-        }
+        // transformers.js `env` is process-global mutable state. Set the remote
+        // policy DETERMINISTICALLY every time (defaulting to the library default,
+        // `true`) so a prior configured load — e.g. an offline provisioning run —
+        // can't leave a later default caller unexpectedly offline (or vice versa).
+        env.allowRemoteModels = options.allowRemoteModels ?? true
+        // cacheDir only changes WHERE the model is read/written, not the network
+        // policy, so it's set only when provided (default callers use the library
+        // default cache location).
+        if (options.cacheDir !== undefined) env.cacheDir = options.cacheDir
         return pipeline('feature-extraction', MODEL_ID)
       })
       // Don't cache a transient load failure forever — reset so later calls retry.

--- a/src/main/context/embed.ts
+++ b/src/main/context/embed.ts
@@ -3,8 +3,14 @@ import type { FeatureExtractionPipeline } from '@huggingface/transformers'
 /**
  * Local text embedder for semantic retrieval. Wraps transformers.js running a
  * small sentence-transformer (all-MiniLM-L6-v2, 384-dim, mean-pooled + L2
- * normalized). Fully local: the model downloads once to the transformers.js
- * cache and then runs offline. Off the render thread (main process only).
+ * normalized). Off the render thread (main process only).
+ *
+ * Model provisioning is the CALLER's concern (this module stays electron-free so
+ * it's unit-testable without an Electron env): pass a `cacheDir` pointing at a
+ * provisioned model and `allowRemoteModels: false` for a fully-offline load, or
+ * leave both unset to keep transformers.js defaults (download-on-first-use), which
+ * is what the dev eval/golden scripts rely on. See `model-path.ts` for the
+ * packaged-vs-dev resolution that decides those options.
  *
  * The model is loaded lazily on first use and reused. Any load/inference failure
  * is surfaced to the caller so the retriever can fall back to lexical scoring.
@@ -20,9 +26,43 @@ const MODEL_ID = 'Xenova/all-MiniLM-L6-v2'
 /** The model id used for embeddings (also stamped into golden vectors). */
 export const EMBEDDING_MODEL_ID = MODEL_ID
 
+/**
+ * The model's repo-relative directory under a transformers.js cache dir, i.e.
+ * files live at `<cacheDir>/<MODEL_CACHE_SUBPATH>/...`. Same string as the model
+ * id by construction; named separately so path-building code reads clearly.
+ */
+export const MODEL_CACHE_SUBPATH = MODEL_ID
+
+/** Dimensionality of the embedding vectors this model produces. */
+export const EMBEDDING_DIMS = 384
+
+/**
+ * Files that must ALL be present (under `<cacheDir>/<MODEL_CACHE_SUBPATH>/`) for a
+ * fully-offline load to succeed. Used by the provisioning completeness check, the
+ * dev presence probe, and the packaged afterPack gate. Kept here (electron-free)
+ * so every consumer shares one list.
+ */
+export const REQUIRED_MODEL_FILES = [
+  'config.json',
+  'tokenizer.json',
+  'tokenizer_config.json',
+  'onnx/model.onnx',
+] as const
+
 export interface EmbedderOptions {
-  /** Writable dir for the downloaded model cache (required in a packaged app). */
+  /**
+   * Writable/read-only dir holding the transformers.js model cache (required in a
+   * packaged app, whose bundle is read-only so the default node_modules cache
+   * would fail). The model resolves under `<cacheDir>/Xenova/all-MiniLM-L6-v2/...`.
+   */
   cacheDir?: string
+  /**
+   * Whether transformers.js may fetch the model from the HuggingFace Hub. Leave
+   * unset for the library default (`true`). Set `false` to force a fully-offline
+   * load: if the model isn't present in `cacheDir` the load throws (and the
+   * retriever falls back to lexical) rather than touching the network.
+   */
+  allowRemoteModels?: boolean
 }
 
 /** Creates a lazily-initialized local embedder. */
@@ -33,9 +73,16 @@ export function createLocalEmbedder(options: EmbedderOptions = {}): Embedder {
     if (pipelinePromise === null) {
       // Import lazily so merely importing this module doesn't pull the runtime in.
       pipelinePromise = import('@huggingface/transformers').then(({ pipeline, env }) => {
-        // Point the model cache at a writable location (a packaged app bundle is
-        // read-only, so the default node_modules cache would fail).
-        if (options.cacheDir !== undefined) env.cacheDir = options.cacheDir
+        // transformers.js `env` is process-global mutable state. Set both fields
+        // explicitly whenever a cacheDir is given so a value left over from an
+        // earlier call (e.g. an online provisioning run) can't leak in and, say,
+        // silently re-enable remote fetches in a load meant to be offline.
+        if (options.cacheDir !== undefined) {
+          env.cacheDir = options.cacheDir
+          env.allowRemoteModels = options.allowRemoteModels ?? true
+        } else if (options.allowRemoteModels !== undefined) {
+          env.allowRemoteModels = options.allowRemoteModels
+        }
         return pipeline('feature-extraction', MODEL_ID)
       })
       // Don't cache a transient load failure forever — reset so later calls retry.

--- a/src/main/context/embed.ts
+++ b/src/main/context/embed.ts
@@ -79,8 +79,11 @@ export function createLocalEmbedder(options: EmbedderOptions = {}): Embedder {
         // can't leave a later default caller unexpectedly offline (or vice versa).
         env.allowRemoteModels = options.allowRemoteModels ?? true
         // cacheDir only changes WHERE the model is read/written, not the network
-        // policy, so it's set only when provided (default callers use the library
-        // default cache location).
+        // policy, so it's set only when provided. Note `env` is process-global, so
+        // a call that omits cacheDir keeps whatever a prior call set (NOT necessarily
+        // the library default). That's fine in practice: the app always passes a
+        // cacheDir (via resolveModelProvisioning), and the only no-cacheDir callers
+        // (golden/eval scripts) run in their own fresh process.
         if (options.cacheDir !== undefined) env.cacheDir = options.cacheDir
         return pipeline('feature-extraction', MODEL_ID)
       })

--- a/src/main/context/embedding-smoke.ts
+++ b/src/main/context/embedding-smoke.ts
@@ -1,0 +1,40 @@
+import type { App } from 'electron'
+import { createLocalEmbedder, EMBEDDING_DIMS } from './embed'
+import { resolveModelProvisioning } from './model-path'
+
+/** CLI flag that triggers the headless embedding smoke test. */
+export const EMBEDDING_SMOKE_FLAG = '--embedding-smoke'
+
+/**
+ * Headless packaged-runtime verifier. Loads the embedding model exactly as
+ * production would (same `resolveModelProvisioning` → in a packaged app that's
+ * the bundled model under `process.resourcesPath` with `allowRemoteModels:false`)
+ * and asserts it produces a real 384-dim embedding. No window is created.
+ *
+ * This is the ONLY way to exercise the *packaged* node_modules + resourcesPath +
+ * main-process runtime without a GUI: run `Focus.app/Contents/MacOS/Focus
+ * --embedding-smoke` against a built app. Returns an exit code (0 = ok).
+ */
+export async function runEmbeddingSmoke(
+  app: Pick<App, 'isPackaged' | 'getAppPath'>
+): Promise<number> {
+  const options = resolveModelProvisioning(app)
+  console.log(
+    `[embedding-smoke] packaged=${app.isPackaged} cacheDir=${options.cacheDir} ` +
+      `allowRemoteModels=${options.allowRemoteModels}`
+  )
+  try {
+    const embedder = createLocalEmbedder(options)
+    const vectors = await embedder.embed(['embedding smoke test'])
+    const dims = vectors[0]?.length ?? 0
+    if (dims !== EMBEDDING_DIMS) {
+      console.error(`[embedding-smoke] FAIL: expected ${EMBEDDING_DIMS} dims, got ${dims}`)
+      return 1
+    }
+    console.log(`[embedding-smoke] OK: loaded model and produced a ${dims}-dim embedding`)
+    return 0
+  } catch (err) {
+    console.error('[embedding-smoke] FAIL: model load/inference threw:', err)
+    return 1
+  }
+}

--- a/src/main/context/embedding-smoke.ts
+++ b/src/main/context/embedding-smoke.ts
@@ -12,8 +12,8 @@ export const EMBEDDING_SMOKE_FLAG = '--embedding-smoke'
  * and asserts it produces a real 384-dim embedding. No window is created.
  *
  * This is the ONLY way to exercise the *packaged* node_modules + resourcesPath +
- * main-process runtime without a GUI: run `Focus.app/Contents/MacOS/Focus
- * --embedding-smoke` against a built app. Returns an exit code (0 = ok).
+ * main-process runtime without a GUI: run `"GH Projects.app/Contents/MacOS/GH
+ * Projects" --embedding-smoke` against a built app. Returns an exit code (0 = ok).
  */
 export async function runEmbeddingSmoke(
   app: Pick<App, 'isPackaged' | 'getAppPath'>

--- a/src/main/context/model-path.test.ts
+++ b/src/main/context/model-path.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { mkdtempSync, mkdirSync, writeFileSync } from 'fs'
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs'
 import { tmpdir } from 'os'
 import { join, dirname } from 'path'
 import { isModelProvisioned, resolveModelProvisioning } from './model-path'
@@ -45,6 +45,17 @@ describe('model-path resolution', () => {
       const dir = tmp('mp-full-')
       provision(dir)
       expect(isModelProvisioned(dir)).toBe(true)
+    })
+
+    it('is false when a required path is a directory, not a file', () => {
+      // A stray directory named like a model file must NOT count as provisioned
+      // (existsSync would say yes; the runtime needs a real file).
+      const dir = tmp('mp-dirfile-')
+      provision(dir)
+      const modelDir = join(dir, MODEL_CACHE_SUBPATH)
+      rmSync(join(modelDir, 'config.json'))
+      mkdirSync(join(modelDir, 'config.json'))
+      expect(isModelProvisioned(dir)).toBe(false)
     })
   })
 

--- a/src/main/context/model-path.test.ts
+++ b/src/main/context/model-path.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { mkdtempSync, mkdirSync, writeFileSync } from 'fs'
 import { tmpdir } from 'os'
-import { join } from 'path'
+import { join, dirname } from 'path'
 import { isModelProvisioned, resolveModelProvisioning } from './model-path'
 import { MODEL_CACHE_SUBPATH, REQUIRED_MODEL_FILES } from './embed'
 
@@ -20,7 +20,7 @@ describe('model-path resolution', () => {
     const modelDir = join(cacheDir, MODEL_CACHE_SUBPATH)
     for (const f of REQUIRED_MODEL_FILES) {
       const full = join(modelDir, f)
-      mkdirSync(join(full, '..'), { recursive: true })
+      mkdirSync(dirname(full), { recursive: true })
       writeFileSync(full, 'x')
     }
   }

--- a/src/main/context/model-path.test.ts
+++ b/src/main/context/model-path.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, mkdirSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { isModelProvisioned, resolveModelProvisioning } from './model-path'
+import { MODEL_CACHE_SUBPATH, REQUIRED_MODEL_FILES } from './embed'
+
+/**
+ * The packaged-vs-dev model-path resolution is the crux of offline loading, so
+ * its branching (prod always-offline, dev present→offline, dev absent→remote) is
+ * covered directly.
+ */
+describe('model-path resolution', () => {
+  function tmp(prefix: string): string {
+    return mkdtempSync(join(tmpdir(), prefix))
+  }
+
+  /** Writes all required model files into <cacheDir>/<subpath>/. */
+  function provision(cacheDir: string): void {
+    const modelDir = join(cacheDir, MODEL_CACHE_SUBPATH)
+    for (const f of REQUIRED_MODEL_FILES) {
+      const full = join(modelDir, f)
+      mkdirSync(join(full, '..'), { recursive: true })
+      writeFileSync(full, 'x')
+    }
+  }
+
+  describe('isModelProvisioned', () => {
+    it('is false when the dir is empty', () => {
+      expect(isModelProvisioned(tmp('mp-empty-'))).toBe(false)
+    })
+
+    it('is false when only some required files exist', () => {
+      const dir = tmp('mp-partial-')
+      const modelDir = join(dir, MODEL_CACHE_SUBPATH)
+      mkdirSync(modelDir, { recursive: true })
+      // Only the onnx present — the weak-probe trap: a single-file check would
+      // wrongly call this provisioned.
+      mkdirSync(join(modelDir, 'onnx'), { recursive: true })
+      writeFileSync(join(modelDir, 'onnx', 'model.onnx'), 'x')
+      expect(isModelProvisioned(dir)).toBe(false)
+    })
+
+    it('is true only when every required file exists', () => {
+      const dir = tmp('mp-full-')
+      provision(dir)
+      expect(isModelProvisioned(dir)).toBe(true)
+    })
+  })
+
+  describe('resolveModelProvisioning', () => {
+    it('dev + model present → offline, cacheDir under the app path', () => {
+      const appPath = tmp('mp-dev-present-')
+      provision(join(appPath, '.model-cache'))
+      const opts = resolveModelProvisioning({ isPackaged: false, getAppPath: () => appPath })
+      expect(opts.allowRemoteModels).toBe(false)
+      expect(opts.cacheDir).toBe(join(appPath, '.model-cache'))
+    })
+
+    it('dev + model absent → remote allowed (self-heal) with a warning', () => {
+      const appPath = tmp('mp-dev-absent-')
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const opts = resolveModelProvisioning({ isPackaged: false, getAppPath: () => appPath })
+      expect(opts.allowRemoteModels).toBe(true)
+      expect(opts.cacheDir).toBe(join(appPath, '.model-cache'))
+      expect(warn).toHaveBeenCalledOnce()
+      warn.mockRestore()
+    })
+
+    describe('packaged', () => {
+      const original = process.resourcesPath
+      beforeEach(() => {
+        // process.resourcesPath is read-only-ish in some runtimes; define it for the test.
+        Object.defineProperty(process, 'resourcesPath', { value: '/Applications/App.app/Contents/Resources', configurable: true })
+      })
+      afterEach(() => {
+        Object.defineProperty(process, 'resourcesPath', { value: original, configurable: true })
+      })
+
+      it('always offline, cacheDir under resourcesPath — even if the model is absent (never touch the network)', () => {
+        const opts = resolveModelProvisioning({ isPackaged: true, getAppPath: () => '/unused' })
+        expect(opts.allowRemoteModels).toBe(false)
+        expect(opts.cacheDir).toBe('/Applications/App.app/Contents/Resources/model-cache')
+      })
+    })
+  })
+})

--- a/src/main/context/model-path.ts
+++ b/src/main/context/model-path.ts
@@ -1,4 +1,4 @@
-import { existsSync } from 'fs'
+import { statSync } from 'fs'
 import { join } from 'path'
 import type { App } from 'electron'
 import { MODEL_CACHE_SUBPATH, REQUIRED_MODEL_FILES } from './embed'
@@ -27,10 +27,22 @@ const PACKAGED_MODEL_DIR = 'model-cache'
 /** Where `provision-model` writes the dev model cache (gitignored, repo root). */
 const DEV_MODEL_DIR = '.model-cache'
 
-/** True when every required model file exists under `<cacheDir>/<subpath>/`. */
+/** True when `p` exists AND is a regular file (not a directory). */
+function isFile(p: string): boolean {
+  try {
+    return statSync(p).isFile()
+  } catch {
+    return false
+  }
+}
+
+/** True when every required model file exists as a real file under `<cacheDir>/<subpath>/`. */
 export function isModelProvisioned(cacheDir: string): boolean {
   const modelDir = join(cacheDir, MODEL_CACHE_SUBPATH)
-  return REQUIRED_MODEL_FILES.every((f) => existsSync(join(modelDir, f)))
+  // Require actual files — `existsSync` is true for directories too, so a stray
+  // dir named like a model file could otherwise be mistaken for a provisioned
+  // model and wrongly force offline mode.
+  return REQUIRED_MODEL_FILES.every((f) => isFile(join(modelDir, f)))
 }
 
 /**

--- a/src/main/context/model-path.ts
+++ b/src/main/context/model-path.ts
@@ -1,0 +1,63 @@
+import { existsSync } from 'fs'
+import { join } from 'path'
+import type { App } from 'electron'
+import { MODEL_CACHE_SUBPATH, REQUIRED_MODEL_FILES } from './embed'
+import type { EmbedderOptions } from './embed'
+
+/**
+ * Resolves how the local embedding model is provisioned for the current
+ * environment — the packaged-vs-dev crux of offline model loading.
+ *
+ * Strategy: transformers.js `cacheDir` semantics. The download layout and the
+ * offline-read layout are identical (`<cacheDir>/Xenova/all-MiniLM-L6-v2/...`),
+ * so one dir serves both. With `allowRemoteModels: false` and the model present,
+ * transformers.js performs zero writes, so pointing `cacheDir` at a read-only
+ * bundled dir in a packaged app is safe.
+ *
+ * Bundle-before-flip: the offline flag is only forced `false` where the model is
+ * guaranteed present — a packaged build (whose model presence is enforced by the
+ * electron-builder afterPack gate) or a dev checkout we've probed as complete.
+ * A fresh `bun run dev` with no provisioned model keeps remote fetches enabled so
+ * it can self-heal, never silently degrading to lexical-only forever.
+ */
+
+/** Where the bundled model lives inside a packaged app's Resources. */
+const PACKAGED_MODEL_DIR = 'model-cache'
+
+/** Where `provision-model` writes the dev model cache (gitignored, repo root). */
+const DEV_MODEL_DIR = '.model-cache'
+
+/** True when every required model file exists under `<cacheDir>/<subpath>/`. */
+export function isModelProvisioned(cacheDir: string): boolean {
+  const modelDir = join(cacheDir, MODEL_CACHE_SUBPATH)
+  return REQUIRED_MODEL_FILES.every((f) => existsSync(join(modelDir, f)))
+}
+
+/**
+ * Computes the embedder options for the current environment.
+ *
+ * - Packaged (prod): the bundled model under `resourcesPath`, `allowRemoteModels`
+ *   ALWAYS `false` — production must never reach the network. If the model were
+ *   somehow missing, the load fails cleanly and the retriever falls back to
+ *   lexical (still offline); shipping a model-less build is separately blocked at
+ *   build time by the afterPack gate.
+ * - Dev, model present (all required files): mirror prod — offline.
+ * - Dev, model absent/incomplete: allow remote (one-time self-heal) and warn, so
+ *   a fresh dev environment still brings up semantic retrieval.
+ */
+export function resolveModelProvisioning(app: Pick<App, 'isPackaged' | 'getAppPath'>): EmbedderOptions {
+  if (app.isPackaged) {
+    return { cacheDir: join(process.resourcesPath, PACKAGED_MODEL_DIR), allowRemoteModels: false }
+  }
+
+  const cacheDir = join(app.getAppPath(), DEV_MODEL_DIR)
+  if (isModelProvisioned(cacheDir)) {
+    return { cacheDir, allowRemoteModels: false }
+  }
+
+  console.warn(
+    `[model-path] embedding model not provisioned at ${cacheDir}; allowing a one-time ` +
+      `remote fetch so dev keeps working. Run \`bun run provision-model\` to make it offline.`
+  )
+  return { cacheDir, allowRemoteModels: true }
+}

--- a/src/main/context/resolve-deps.test.ts
+++ b/src/main/context/resolve-deps.test.ts
@@ -19,7 +19,7 @@ describe('createResolveDeps (production composition root)', () => {
   }
 
   it('wires a retriever that is NOT the plain lexical retriever, plus decide + MCP runners', () => {
-    const deps = createResolveDeps(tmp('resolve-deps-guard-'))
+    const deps = createResolveDeps({ stateDir: tmp('resolve-deps-guard-') })
     expect(deps.assembleOptions?.retriever).toBeDefined()
     expect(deps.assembleOptions?.retriever).not.toBe(lexicalRetriever)
     expect(deps.decideRunner).toBeDefined()
@@ -53,7 +53,7 @@ describe('createResolveDeps (production composition root)', () => {
       },
     }
 
-    const deps = createResolveDeps(tmp('resolve-deps-sem-'), undefined, fakeEmbedder)
+    const deps = createResolveDeps({ stateDir: tmp('resolve-deps-sem-'), embedder: fakeEmbedder })
     const outcome = await deps.assembleOptions!.retriever!.retrieve(question, resources, 8)
     expect(outcome.mode).toBe('semantic')
     expect(stringIdByNumericId.get(outcome.candidates[0]?.resource.id)).toBe(targetStringId)

--- a/src/main/context/resolve-deps.ts
+++ b/src/main/context/resolve-deps.ts
@@ -3,7 +3,7 @@ import { join } from 'path'
 import { createCopilotDecideRunner } from './copilot-run'
 import { createMcpRunner } from './mcp-client'
 import { createDefaultRetriever } from './retrieve'
-import { createLocalEmbedder, type Embedder } from './embed'
+import { createLocalEmbedder, type Embedder, type EmbedderOptions } from './embed'
 import { FAST_RECOMMEND_MODEL, type RecommendDeps } from './recommend'
 import type { ResolveDeps } from './resolve'
 
@@ -26,24 +26,33 @@ export function ensureIsolatedCopilotHome(baseDir: string): string {
   return home
 }
 
+export interface ResolveDepsOptions {
+  /** Writable dir for the resolver's own state (the isolated Copilot home). */
+  stateDir: string
+  /**
+   * How the local embedding model is provisioned for this environment (from
+   * `resolveModelProvisioning`). Passed straight to the embedder. The model dir
+   * is NEVER created here — in a packaged app it lives under a read-only
+   * Resources path; dev provisioning is the `provision-model` script's job.
+   */
+  embedderOptions?: EmbedderOptions
+  /** Optional decide-model override. */
+  model?: string
+  /**
+   * Injectable embedder — ONLY so the composition-root guard test can prove the
+   * wiring performs real semantic retrieval on a non-empty corpus with a
+   * deterministic fake. Production always uses the local MiniLM embedder.
+   */
+  embedder?: Embedder
+}
+
 /**
  * Builds the resolver's runtime dependencies.
- *
- * `embedder` is injectable ONLY so the composition-root guard test can prove the
- * wiring performs real semantic retrieval on a non-empty corpus with a
- * deterministic fake. Production always uses the local MiniLM embedder.
  */
-export function createResolveDeps(
-  baseDir: string,
-  model?: string,
-  embedder?: Embedder
-): ResolveDeps & RecommendDeps {
-  const home = ensureIsolatedCopilotHome(baseDir)
-  const cacheDir = join(baseDir, 'model-cache')
-  // Ensure the model cache dir exists — otherwise the embedder can fail to load
-  // and silently fall back to lexical retrieval in production.
-  mkdirSync(cacheDir, { recursive: true })
-  const resolvedEmbedder = embedder ?? createLocalEmbedder({ cacheDir })
+export function createResolveDeps(options: ResolveDepsOptions): ResolveDeps & RecommendDeps {
+  const { stateDir, embedderOptions, model, embedder } = options
+  const home = ensureIsolatedCopilotHome(stateDir)
+  const resolvedEmbedder = embedder ?? createLocalEmbedder(embedderOptions)
   return {
     decideRunner: createCopilotDecideRunner({ isolatedHome: home, cwd: home, model }),
     // Read-only recommendation ranking uses the SAME tool-less isolated runner

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -42,6 +42,8 @@ import { listMcpTools } from './context/mcp-client'
 import { resolveQuestion } from './context/resolve'
 import { recommendResources } from './context/recommend'
 import { createResolveDeps } from './context/resolve-deps'
+import { resolveModelProvisioning } from './context/model-path'
+import { runEmbeddingSmoke, EMBEDDING_SMOKE_FLAG } from './context/embedding-smoke'
 import { delegateTask, appDelegateAvailability, buildAppSessionDeepLink, createDefaultDelegateDeps } from './agent/copilot-app/delegate'
 import { linkTodoSession } from './agent/copilot-app/store'
 import { refreshTodoAppSessionsForProject } from './agent/copilot-app/status'
@@ -120,6 +122,15 @@ function createWindow(): void {
 }
 
 app.whenReady().then(async () => {
+  // Headless verifier: `--embedding-smoke` loads the model exactly as production
+  // would and exits, without creating a window or touching the DB. Runs first so
+  // it exercises the packaged runtime cleanly and never starts the real app.
+  if (process.argv.includes(EMBEDDING_SMOKE_FLAG)) {
+    const code = await runEmbeddingSmoke(app)
+    app.exit(code)
+    return
+  }
+
   initDb()
   await initAuth()
 
@@ -394,7 +405,10 @@ app.whenReady().then(async () => {
 
   // Resolver deps: an isolated Copilot home (no user MCP servers, no tools for
   // the decide call) + an app-owned MCP client for the actual read.
-  const resolveDeps = createResolveDeps(app.getPath('userData'))
+  const resolveDeps = createResolveDeps({
+    stateDir: app.getPath('userData'),
+    embedderOptions: resolveModelProvisioning(app),
+  })
 
   ipcMain.handle('resources:list', (_event, projectId: number) => listResources(projectId))
   ipcMain.handle('resources:groups', (_event, projectId: number) => groupResources(listResources(projectId)))

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -15,5 +15,5 @@
       "@shared/*": ["src/shared/*"]
     }
   },
-  "include": ["src/main", "src/preload", "src/shared"]
+  "include": ["src/main", "src/preload", "src/shared", "scripts"]
 }


### PR DESCRIPTION
Closes the pre-release packaging batch from #77 - items **4** (bundle the local embedding model so production runs fully offline) and **3** (a real SSO-gated MCP verification harness). Off `main`.

## Honest framing

These items end in a **signed/notarized build** and a **real SSO-gated MCP pull**, which need the owner's machine + credentials. This PR does all the code + build config and verifies as much as possible headlessly. I actually got further than expected: the packaged offline load is **proven headlessly** (see below). The remaining owner-only steps are in `requirements/pre-release-owner-checklist.md`.

## Item 4 - offline model provisioning (bundle-before-flip)

Today `embed.ts` uses transformers.js defaults (`allowRemoteModels=true`), so the MiniLM model downloads from HuggingFace on first use. Goal: ship the model with the app and never touch the network in production. **Ordering matters** - bundle first, then flip the flag, or fresh installs silently degrade to lexical-only forever.

- **`embed.ts`** (stays electron-free): `EmbedderOptions` gains `allowRemoteModels`; sets the process-global transformers `env` explicitly; new shared constants (`MODEL_CACHE_SUBPATH`, `EMBEDDING_DIMS`, `REQUIRED_MODEL_FILES`).
- **`model-path.ts`**: `resolveModelProvisioning(app)` -> `{cacheDir, allowRemoteModels}`.
  - Packaged: `resourcesPath/model-cache`, `allowRemoteModels=false` **always** (never touches the network).
  - Dev, model present (all 4 files): offline, mirrors prod.
  - Dev, model absent/incomplete: remote + warn (one-time self-heal, so a fresh `bun run dev` never breaks).
- **`resolve-deps.ts`**: options-object signature; splits the writable `stateDir` from the read-only model dir; no longer mkdirs the model cache (prod `resourcesPath` is read-only).
- **`scripts/provision-model.ts`**: populates gitignored `.model-cache/` (strict for `dist`, best-effort for `setup`), verifies completeness + an offline reload, records the resolved upstream SHA in `PROVENANCE.json`. Best-effort swallows only a clean network failure - a corrupt/partial cache always fails loudly.
- **electron-builder**: `extraResources .model-cache -> model-cache`; `asarUnpack` for `onnxruntime-node` **and** `sharp`/`@img` (transformers imports sharp eagerly even for text; its `.node` was trapped inside the asar); an **`afterPack` gate** that fails the build if the model isn't bundled.
- **`--embedding-smoke`**: a hidden no-window mode in `index.ts` that loads the model exactly as production would and asserts 384 dims - the headless packaged-runtime verifier (and the owner's one-command check on the signed build).

### Note on model size

The transformers.js default for this model in v4.2.0 loads `onnx/model.onnx` (fp32, **~90 MB**), not the ~23 MB quantized variant #77 assumed. I kept the exact current default on purpose - switching to quantized would change the measured eval numbers and invalidate the committed `golden-vectors.json`. Bigger bundle, but it bundles cleanly and the behavior/golden vectors are unchanged.

### Dropped: model-revision pin

I tried pinning the model revision for reproducibility but it **breaks the offline load** (a revision-scoped cache subtree fails to resolve the tokenizer offline: `this.tokenizer is not a function`). Dropped it; provisioning records the resolved SHA in `PROVENANCE.json` for traceability instead. There's exactly one `pipeline()` call site.

## Item 3 - real SSO-gated MCP verification

- **`scripts/verify-mcp.ts`** drives the app's OWN client code path (`listMcpTools` + `createMcpRunner`, plus the real config/tool validation) against a real server config the owner supplies. `listTools` handshake + one read, prints the live value + provenance (`ok`/failure class). No GUI. The printed value is produced only by the app-owned read, so a green run genuinely proves the server answered.
- **`requirements/pre-release-owner-checklist.md`**: the owner-only steps for both items.

## How I verified it

Headless, all green:
- `bun run provision-model`: download + completeness + offline reload (384 dims); idempotent present-path; negative controls (empty dir throws offline; corrupt/partial cache fails even in best-effort).
- Full `bun run dist:dir` (unsigned): the afterPack gate passed; asserted the model files, `onnxruntime-node` + `@img/sharp` native binaries, and `@huggingface/transformers`/`onnxruntime-node`/`better-sqlite3` all land in the package (so `files:["out/**"]` did **not** drop `node_modules`).
- The packaged binary's `--embedding-smoke` prints `packaged=true ... allowRemoteModels=false ... OK: 384-dim` and exits 0 - **packaged offline load proven headlessly**. (This is what caught the sharp-in-asar bug, which I then fixed.)
- `verify-mcp` green against the synthetic echo server (live value pulled; failure classes correct; exit codes 0/1/2 correct).
- `typecheck` + `eslint` + **465 vitest tests** pass, including the golden-vector tests (embeddings unperturbed) and new `model-path.test.ts` (prod/dev/present/absent matrix incl. the partial-cache trap).
- Plan and both scripts were reviewed by GPT-5.5 to "sound"/"ready to merge".

### What I did NOT verify (owner-only)
- Running `--embedding-smoke` on the **signed/notarized** build (I proved the unsigned packaged runtime; signing needs the owner's Developer ID).
- A **real SSO-gated MCP pull** - needs the owner's Datadog/Splunk/Kusto credentials. One command: `bun run verify-mcp <config.json>`.

Both are in the owner checklist.