### PR TITLE
fix(copilot): tell the user why a delegate fell back to cloud

### DIFF
--- a/src/main/agent/copilot-app/delegate.test.ts
+++ b/src/main/agent/copilot-app/delegate.test.ts
@@ -63,34 +63,34 @@ describe('delegateTask — app path', () => {
 })
 
 describe('delegateTask — cloud fallback (pre-create only)', () => {
-  it('falls back to cloud when the flag is off', async () => {
+  it('falls back to cloud when the flag is off (reason=flag_disabled)', async () => {
     const res = await delegateTask(payload, makeDeps({ appEnabled: () => false }))
-    expect(res).toEqual({ kind: 'cloud', session: cloudSession })
+    expect(res).toEqual({ kind: 'cloud', session: cloudSession, appFallbackReason: 'flag_disabled' })
   })
 
-  it('falls back to cloud when the app is not running', async () => {
+  it('falls back to cloud when the app is not running (reason=app_not_running)', async () => {
     const res = await delegateTask(payload, makeDeps({ discover: () => null }))
-    expect(res.kind).toBe('cloud')
+    expect(res).toEqual({ kind: 'cloud', session: cloudSession, appFallbackReason: 'app_not_running' })
   })
 
-  it('falls back to cloud when no trusted local checkout resolves', async () => {
+  it('falls back to cloud when no trusted local checkout resolves (reason=no_local_cwd)', async () => {
     const res = await delegateTask(payload, makeDeps({ resolveCwd: async () => ({ ok: false, reason: 'no_local_cwd' }) }))
-    expect(res.kind).toBe('cloud')
+    expect(res).toEqual({ kind: 'cloud', session: cloudSession, appFallbackReason: 'no_local_cwd' })
   })
 
-  it('falls back to cloud when a base branch is requested (app WS has no branch concept)', async () => {
+  it('falls back to cloud when a base branch is requested (reason=base_branch, app WS has no branch concept)', async () => {
     const ws = vi.fn(async () => ({ sessionId: 'x', sendOk: true }))
     const res = await delegateTask({ ...payload, baseBranch: 'main' }, makeDeps({ wsDelegate: ws }))
-    expect(res.kind).toBe('cloud')
+    expect(res).toEqual({ kind: 'cloud', session: cloudSession, appFallbackReason: 'base_branch' })
     expect(ws).not.toHaveBeenCalled()
   })
 
-  it('falls back to cloud on a pre-create AppUnavailableError', async () => {
+  it('falls back to cloud on a pre-create AppUnavailableError (reason=app_unavailable)', async () => {
     const res = await delegateTask(
       payload,
       makeDeps({ wsDelegate: async () => { throw new AppUnavailableError('handshake timeout') } })
     )
-    expect(res.kind).toBe('cloud')
+    expect(res).toEqual({ kind: 'cloud', session: cloudSession, appFallbackReason: 'app_unavailable' })
   })
 })
 

--- a/src/main/agent/copilot-app/delegate.ts
+++ b/src/main/agent/copilot-app/delegate.ts
@@ -12,6 +12,7 @@
  */
 
 import type {
+  AppDelegateFallbackReason,
   AppDelegateSkipReason,
   CopilotAppSession,
   CopilotSession,
@@ -75,30 +76,43 @@ function validatePayload(payload: DelegatePayload): { prompt: string } {
 }
 
 /**
- * Attempt the desktop-app path. Returns a `DelegateResult` when the app handled
- * it, `'skip'` when the app path isn't taken (fall back to cloud), or throws a
- * DELEGATE_FAILED error when the create was ambiguous (must NOT fall back).
+ * The outcome of the desktop-app attempt: either an app-path `DelegateResult`
+ * (the app handled it), or a `skip` carrying WHY the app path wasn't taken so
+ * the cloud fallback can report it. `tryAppDelegate` never produces a cloud
+ * result itself — narrowing the type here keeps the reason plumbing airtight.
+ */
+type AppDelegateOutcome =
+  | Extract<DelegateResult, { kind: 'app' | 'app-send-failed' }>
+  | { kind: 'skip'; reason: AppDelegateFallbackReason }
+
+/**
+ * Attempt the desktop-app path. Returns an app-path `DelegateResult` when the
+ * app handled it, `{ kind: 'skip', reason }` when the app path isn't taken (fall
+ * back to cloud), or throws a DELEGATE_FAILED error when the create was ambiguous
+ * (must NOT fall back).
  */
 async function tryAppDelegate(
   payload: DelegatePayload,
   prompt: string,
   deps: DelegateDeps
-): Promise<DelegateResult | 'skip'> {
-  if (!deps.appEnabled()) return 'skip'
+): Promise<AppDelegateOutcome> {
+  if (!deps.appEnabled()) return { kind: 'skip', reason: 'flag_disabled' }
   // A base-branch request can only be honored by the cloud path (`gh agent-task
   // -b`); the desktop app runs in whatever branch the local checkout is on. So
   // an explicit base branch routes to cloud rather than silently ignoring it.
-  if (payload.baseBranch !== undefined && payload.baseBranch.trim().length > 0) return 'skip'
+  if (payload.baseBranch !== undefined && payload.baseBranch.trim().length > 0) {
+    return { kind: 'skip', reason: 'base_branch' }
+  }
   const endpoint = deps.discover()
-  if (endpoint === null) return 'skip' // app not running
+  if (endpoint === null) return { kind: 'skip', reason: 'app_not_running' } // app not running
   const cwd = await deps.resolveCwd(payload.repoOwner.trim(), payload.repoName.trim(), payload.projectId)
-  if (!cwd.ok) return 'skip' // no trusted local checkout → cloud
+  if (!cwd.ok) return { kind: 'skip', reason: 'no_local_cwd' } // no trusted local checkout → cloud
 
   let ws: DelegateOverWsResult
   try {
     ws = await deps.wsDelegate(endpoint, cwd.cwd, prompt, undefined)
   } catch (err) {
-    if (err instanceof AppUnavailableError) return 'skip' // pre-create → cloud is safe
+    if (err instanceof AppUnavailableError) return { kind: 'skip', reason: 'app_unavailable' } // pre-create → cloud is safe
     if (err instanceof CreateAmbiguousError) {
       // The app may have opened a session we can't see. Never start a cloud task
       // too (that would double-delegate); tell the user to check the app.
@@ -127,10 +141,30 @@ export async function delegateTask(payload: DelegatePayload, deps: DelegateDeps)
   const { prompt } = validatePayload(payload)
 
   const appResult = await tryAppDelegate(payload, prompt, deps)
-  if (appResult !== 'skip') return appResult
+  if (appResult.kind !== 'skip') return appResult
 
-  const session = await deps.cloudDelegate(payload)
-  return { kind: 'cloud', session }
+  // Record WHY the desktop app was bypassed BEFORE the cloud call, so a cloud
+  // failure still leaves a trace of the fallback reason for later diagnosis.
+  const owner = payload.repoOwner.trim()
+  const name = payload.repoName.trim()
+  const baseBranchRequested = payload.baseBranch?.trim() ? 'yes' : 'no'
+  console.warn(
+    `[copilot] Desktop-app delegate bypassed (reason=${appResult.reason}); falling back to cloud for ` +
+      `${owner}/${name} (projectId=${payload.projectId ?? 'none'}, baseBranch=${baseBranchRequested})`
+  )
+
+  let session: CopilotSession
+  try {
+    session = await deps.cloudDelegate(payload)
+  } catch (err) {
+    console.error(
+      `[copilot] Cloud fallback failed after desktop-app bypass (reason=${appResult.reason}) for ${owner}/${name}:`,
+      err
+    )
+    throw err
+  }
+  console.warn(`[copilot] Cloud fallback session created id=${session.id} url=${session.htmlUrl ?? 'none'}`)
+  return { kind: 'cloud', session, appFallbackReason: appResult.reason }
 }
 
 /** Diagnose whether the app path would be taken for a repo (for a UI hint). */

--- a/src/renderer/src/components/DelegateComposer.test.tsx
+++ b/src/renderer/src/components/DelegateComposer.test.tsx
@@ -18,7 +18,7 @@ const session: CopilotSession = {
   htmlUrl: 'https://x/pull/1', startedAt: '', updatedAt: '', repoOwner: 'o', repoName: 'r',
   branch: null, linkedPrUrl: 'https://x/pull/1', pinnedProjectId: 1,
 }
-const cloudResult: DelegateResult = { kind: 'cloud', session }
+const cloudResult: DelegateResult = { kind: 'cloud', session, appFallbackReason: 'no_local_cwd' }
 
 describe('DelegateComposer', () => {
   it('pre-fills the prompt and delegates with the fixed repo', async () => {

--- a/src/renderer/src/pages/FocusPage.tsx
+++ b/src/renderer/src/pages/FocusPage.tsx
@@ -8,6 +8,7 @@ import { WorkingColumn } from '../components/WorkingColumn'
 import { DelegateComposer } from '../components/DelegateComposer'
 import { ResurfaceStrip } from '../components/ResurfaceStrip'
 import { fire, openExternal } from '../ipc'
+import { cloudFallbackMessage } from './cloudFallbackMessage'
 import { useProjectDetail } from '../hooks/useProjectDetail'
 import { useDigest } from '../hooks/useDigest'
 import styles from './FocusPage.module.css'
@@ -211,7 +212,7 @@ export function FocusPage(props: FocusPageProps): JSX.Element {
           onLaunched={(result) => {
             if (result.kind === 'cloud') {
               props.showUndo(
-                'Copilot is on it — I’ll fold the result into your digest.',
+                cloudFallbackMessage(result.appFallbackReason, result.session),
                 () => { if (result.session.htmlUrl) openExternal(result.session.htmlUrl) },
                 'Open'
               )

--- a/src/renderer/src/pages/cloudFallbackMessage.test.ts
+++ b/src/renderer/src/pages/cloudFallbackMessage.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from 'vitest'
+import type { AppDelegateFallbackReason, CopilotSession } from '@shared/ipc-channels'
+import { cloudFallbackMessage } from './cloudFallbackMessage'
+
+const session: CopilotSession = {
+  id: 's1', projectId: 1, source: 'github', status: 'in_progress', title: 'Fix it',
+  htmlUrl: null, startedAt: '', updatedAt: '', repoOwner: 'me', repoName: 'foo',
+  branch: null, linkedPrUrl: null, pinnedProjectId: 1,
+}
+
+describe('cloudFallbackMessage', () => {
+  // Every reason must produce a distinct, honest, non-empty message — the whole
+  // point of the fix is that the cloud fallback never hides why the app was
+  // bypassed.
+  const reasons: AppDelegateFallbackReason[] = [
+    'flag_disabled',
+    'app_not_running',
+    'app_unavailable',
+    'no_local_cwd',
+    'base_branch',
+  ]
+
+  it('returns a distinct, non-empty message for every fallback reason', () => {
+    const messages = reasons.map((r) => cloudFallbackMessage(r, session))
+    for (const m of messages) expect(m.trim().length).toBeGreaterThan(0)
+    expect(new Set(messages).size).toBe(reasons.length)
+  })
+
+  it('names the repo when the checkout could not be resolved', () => {
+    expect(cloudFallbackMessage('no_local_cwd', session)).toContain('me/foo')
+  })
+
+  it('falls back to a generic repo phrase when owner/name are missing', () => {
+    const anon = { ...session, repoOwner: null, repoName: null }
+    expect(cloudFallbackMessage('no_local_cwd', anon)).toContain('this repo')
+  })
+
+  it('frames a base-branch fallback as intentional routing, not a failure', () => {
+    expect(cloudFallbackMessage('base_branch', session).toLowerCase()).toContain('base branch')
+  })
+
+  it('warns and stays safe on an unexpected reason from the IPC boundary', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    // Simulate a future/unknown reason arriving across the untyped IPC boundary.
+    const msg = cloudFallbackMessage('mystery' as AppDelegateFallbackReason, session)
+    expect(msg.trim().length).toBeGreaterThan(0)
+    expect(warn).toHaveBeenCalled()
+    warn.mockRestore()
+  })
+})

--- a/src/renderer/src/pages/cloudFallbackMessage.ts
+++ b/src/renderer/src/pages/cloudFallbackMessage.ts
@@ -1,0 +1,33 @@
+import type { AppDelegateFallbackReason, CopilotSession } from '@shared/ipc-channels'
+
+/** Exhaustiveness guard: adding a fallback reason forces a copy update here. */
+function unhandledFallback(reason: never): string {
+  console.warn('[FocusPage] Unhandled delegate fallback reason:', reason)
+  return "The desktop app couldn't take this, so I sent it to the cloud."
+}
+
+/**
+ * Honest, per-reason copy for a delegate that landed in the cloud instead of the
+ * desktop app. Every reason is surfaced (no silent generic hide) so the user
+ * always knows the desktop app was bypassed and why.
+ */
+export function cloudFallbackMessage(reason: AppDelegateFallbackReason, session: CopilotSession): string {
+  const repo = session.repoOwner && session.repoName ? `${session.repoOwner}/${session.repoName}` : 'this repo'
+  switch (reason) {
+    case 'flag_disabled':
+      return 'Desktop handoff is disabled, so I sent this to the cloud.'
+    case 'app_not_running':
+      return "The Copilot app isn't running, so I sent this to the cloud instead."
+    case 'app_unavailable':
+      return "Couldn't reach the Copilot app, so I sent this to the cloud instead."
+    case 'no_local_cwd':
+      return (
+        `I couldn't resolve a trusted local checkout for ${repo}, so I sent it to the cloud. ` +
+        'Clone it under your configured repos root (default ~/repos) to hand off to the desktop app.'
+      )
+    case 'base_branch':
+      return "I used the cloud agent because this task specifies a base branch - desktop handoff doesn't support that yet."
+    default:
+      return unhandledFallback(reason)
+  }
+}

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -128,13 +128,24 @@ export interface DelegatePayload {
 export type DelegateResult =
   | { kind: 'app'; session: CopilotAppSession }
   | { kind: 'app-send-failed'; session: CopilotAppSession }
-  | { kind: 'cloud'; session: CopilotSession }
+  | { kind: 'cloud'; session: CopilotSession; appFallbackReason: AppDelegateFallbackReason }
 
 /** Why the desktop-app path wasn't taken for a delegate (diagnostic, non-fatal). */
 export type AppDelegateSkipReason =
   | 'flag_disabled'   // the app-delegate feature flag is off
   | 'app_not_running' // WS discovery files (ws.port/ws.token) absent — no connection is attempted
   | 'no_local_cwd'    // no trusted local checkout resolved for the repo
+
+/**
+ * Why a delegate landed in the cloud instead of the desktop app. A superset of
+ * `AppDelegateSkipReason`: the availability pre-check (`appDelegateAvailability`)
+ * can only report the three static reasons above, but the live delegate can also
+ * bypass the app for a requested base branch or a transient WS failure.
+ */
+export type AppDelegateFallbackReason =
+  | AppDelegateSkipReason
+  | 'base_branch'     // an explicit base branch was requested — the app WS has no branch concept
+  | 'app_unavailable' // pre-create WS handshake/connect failure (transient)
 
 /** Default "repos root" used to resolve local checkouts (`~` expanded in main). */
 export const DEFAULT_REPOS_ROOT = '~/repos'


### PR DESCRIPTION
## What & why

The "Delegate to Copilot" ladder tries the installed Copilot **desktop app** over its local WebSocket, then falls back to a cloud `gh agent-task`. That fallback was **silent**: `tryAppDelegate` collapsed five distinct skip reasons into a bare `'skip'`, and the cloud `DelegateResult` carried no reason. So the UI could only show a generic "Copilot is on it" toast - the user had no way to know the desktop app was bypassed, or why.

This came from a report: *"The handoff to Copilot desktop app did not work. It created a cloud session. The app's link for the session opened the desktop app."*

## How I verified the root cause (real evidence, not a hypothesis)

- **Live WS probe against the running desktop app** (port from `~/.copilot/run/ws.port`): handshake OK, and `create_session` for `~/repos/gh-notifier` returned:
  ```json
  {"session_type":"project","is_remote":false,"execution_location":"local"}
  ```
  A local project session - never cloud. I deleted the probe session immediately after. So the desktop-app path is healthy when reached.
- The feature flag is on (`copilot_app_delegate_enabled=true`) and the app was running, yet the failed handoff left **no** new `copilot_app_sessions` row - so `tryAppDelegate` returned `skip` and it fell back to cloud.
- `resolveLocalCwd` is the fragile trigger: it only accepts a checkout whose git remote normalizes to the exact `owner/repo`. It resolves fine with the correct owner, but any owner mismatch / missing `~/repos/<repo>` checkout yields `no_local_cwd` -> silent cloud, with zero signal to the user.

So the defect is the reasonless, silent fallback - not the WS path, and not the cwd match (which is deliberately strict for security). The fix belongs in the delegate result **contract** + the UI that consumes it.

## Changes

- **Shared contract** (`ipc-channels.ts`): add `AppDelegateFallbackReason` - a superset of the availability-only `AppDelegateSkipReason`, adding `base_branch` (explicit base branch -> cloud by design) and `app_unavailable` (transient pre-create WS failure). The cloud `DelegateResult` variant now carries a **required** `appFallbackReason`.
- **Delegate** (`delegate.ts`): `tryAppDelegate` returns `{ kind: 'skip'; reason }` (narrowed to app-only outcomes + skip) so each of the five bypass points reports its specific reason. `delegateTask` threads it into the cloud result and logs the bypass **decision before** the cloud call (so a cloud failure still records why), plus the resulting session id/url after success. No prompts/tokens logged.
- **Renderer** (`FocusPage.tsx` + new `cloudFallbackMessage.ts`): honest, per-reason copy via an exhaustive helper, with a runtime-safe default for an unexpected reason crossing the IPC boundary.

The idempotency boundary is unchanged: an ambiguous create still throws `DELEGATE_FAILED` and never falls back (no double-delegation).

## How I verified the fix

- `bun run typecheck` clean; `bun run lint` clean.
- Full suite green: **471 tests / 51 files** (run under the Bun runtime so the `bun:sqlite` integration tests execute).
- New/updated tests:
  - `delegate.test.ts`: each of the five cloud-fallback paths asserts the exact `appFallbackReason`; app-path + idempotency tests unchanged.
  - `cloudFallbackMessage.test.ts`: every reason yields a distinct non-empty message; `no_local_cwd` names the repo; null owner/name -> "this repo"; unknown reason warns + stays safe.
  - `DelegateComposer.test.tsx`: cloud fixture updated for the required field.
- I could **not** reproduce the user's exact failing handoff (the synced cloud-sessions table carries no owner/repo, so a delegate-launched cloud session is indistinguishable from a direct `gh agent-task`). The new bypass logging is specifically there to close that diagnosis gap next time.

## Out of scope (follow-ups)

- Wiring the pre-existing per-project checkout override (`get/setProjectOverridePath` exist in the data layer, no IPC/UI) so non-`~/repos/<repo>` layouts can hand off to the desktop app.
- A pre-launch availability hint in `DelegateComposer` (the `copilot:delegate-availability` IPC already exists).