### PR TITLE
Make URLs clickable in todos, next action, and resources

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,5 +1,6 @@
 import { app, BrowserWindow, ipcMain, shell } from 'electron'
 import { join } from 'path'
+import { parseSafeExternalUrl } from '../shared/safe-url'
 import { initDb } from './db'
 import { initAuth, getAuthStatus, savePat, logout, getOctokit } from './auth'
 import {
@@ -152,9 +153,22 @@ app.whenReady().then(async () => {
   })
   ipcMain.handle('auth:logout', () => { logout() })
 
-  // External URL handler (security: controlled via main process)
-  ipcMain.handle('app:open-external', async (_event, url: string) => {
-    await shell.openExternal(url)
+  // External URL handler (security: controlled via main process). Only open
+  // absolute http/https URLs, and open the parser-normalized href rather than
+  // the raw renderer string. Renderer calls are fire-and-forget, so an unsafe
+  // input is dropped with a warning rather than thrown back.
+  ipcMain.handle('app:open-external', async (_event, url: unknown) => {
+    const safe = parseSafeExternalUrl(url)
+    if (safe === null) {
+      // Avoid logging the full value — it may carry tokens or query secrets.
+      console.warn('[app:open-external] Refused to open non-http(s) or invalid URL')
+      return
+    }
+    try {
+      await shell.openExternal(safe)
+    } catch (err) {
+      console.error('[app:open-external] openExternal failed:', err)
+    }
   })
 
   // Project handlers

--- a/src/renderer/src/components/LinkifiedText.module.css
+++ b/src/renderer/src/components/LinkifiedText.module.css
@@ -1,0 +1,19 @@
+/* Inline link rendered as a button, styled to sit inside surrounding text.
+   `font: inherit` makes it match whatever surface it's used in (todo list, next
+   action, resource answer), so the link is the same size as its neighbours. */
+.link {
+  font: inherit;
+  color: var(--accent-text);
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  word-break: break-word;
+}
+
+.link:hover {
+  text-decoration-thickness: 2px;
+}

--- a/src/renderer/src/components/LinkifiedText.test.tsx
+++ b/src/renderer/src/components/LinkifiedText.test.tsx
@@ -1,0 +1,45 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { LinkifiedText } from './LinkifiedText'
+
+const openExternal = vi.fn(() => Promise.resolve())
+
+beforeEach(() => {
+  openExternal.mockClear()
+  ;(globalThis as unknown as { window: Window }).window.electron = {
+    openExternal,
+  } as unknown as Window['electron']
+})
+
+describe('LinkifiedText', () => {
+  it('renders plain text with no link button', () => {
+    render(<LinkifiedText text="no links here" />)
+    expect(screen.getByText('no links here')).toBeTruthy()
+    expect(screen.queryByRole('button')).toBeNull()
+  })
+
+  it('renders a URL as a button and opens it on click', () => {
+    render(<LinkifiedText text="see https://example.com/x now" />)
+    const link = screen.getByRole('button', { name: 'https://example.com/x' })
+    fireEvent.click(link)
+    expect(openExternal).toHaveBeenCalledWith('https://example.com/x')
+  })
+
+  it('keeps a click on the link from bubbling to a clickable ancestor', () => {
+    const onParentClick = vi.fn()
+    render(
+      <div onClick={onParentClick}>
+        <LinkifiedText text="open https://example.com" />
+      </div>
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'https://example.com' }))
+    expect(openExternal).toHaveBeenCalledWith('https://example.com')
+    expect(onParentClick).not.toHaveBeenCalled()
+  })
+
+  it('does not linkify a non-http(s) scheme', () => {
+    render(<LinkifiedText text="run javascript:alert(1)" />)
+    expect(screen.queryByRole('button')).toBeNull()
+  })
+})

--- a/src/renderer/src/components/LinkifiedText.tsx
+++ b/src/renderer/src/components/LinkifiedText.tsx
@@ -1,0 +1,41 @@
+import { tokenizeLinks } from './linkify'
+import { openExternal } from '../ipc'
+import styles from './LinkifiedText.module.css'
+
+interface LinkifiedTextProps {
+  text: string
+}
+
+/**
+ * Render a plain string, turning any http/https URLs into clickable links.
+ *
+ * Links are `<button>`s (not `<a href>`) that call `openExternal` — matching the
+ * app's convention for external links and sidestepping in-window navigation.
+ * `stopPropagation` keeps a click on the link from also triggering a clickable
+ * ancestor (e.g. a click-to-edit region).
+ */
+export function LinkifiedText({ text }: LinkifiedTextProps): JSX.Element {
+  const tokens = tokenizeLinks(text)
+  return (
+    <>
+      {tokens.map((token) =>
+        token.kind === 'url' ? (
+          <button
+            key={`u-${token.start}`}
+            type="button"
+            className={styles.link}
+            title={token.value}
+            onClick={(e) => {
+              e.stopPropagation()
+              openExternal(token.value)
+            }}
+          >
+            {token.value}
+          </button>
+        ) : (
+          <span key={`t-${token.start}`}>{token.value}</span>
+        )
+      )}
+    </>
+  )
+}

--- a/src/renderer/src/components/NextAction.module.css
+++ b/src/renderer/src/components/NextAction.module.css
@@ -43,6 +43,17 @@
   font-weight: 400;
 }
 
+/* Static (non-editable) rendering of the next action, used when it contains a
+   link. Same typography as .text but without the click-to-edit affordances. */
+.staticText {
+  font-size: 20px;
+  font-weight: 500;
+  letter-spacing: -0.2px;
+  line-height: 1.35;
+  color: var(--text);
+  min-width: 0;
+}
+
 .editIcon {
   background: none;
   border: none;

--- a/src/renderer/src/components/NextAction.tsx
+++ b/src/renderer/src/components/NextAction.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useRef, useState } from 'react'
 import { Pencil, Check, Sparkles } from 'lucide-react'
 import { Icon } from './Icon'
+import { LinkifiedText } from './LinkifiedText'
+import { hasLink } from './linkify'
 import styles from './NextAction.module.css'
 
 interface NextActionProps {
@@ -57,12 +59,22 @@ export function NextAction({ value, onSave, onDone, onDelegate }: NextActionProp
         />
       ) : (
         <div className={styles.line}>
-          <button type="button"
-            className={`${styles.text} ${hasValue ? '' : styles.placeholder}`}
-            onClick={() => setEditing(true)}
-          >
-            {hasValue ? value : 'Set your next action…'}
-          </button>
+          {hasLink(value) ? (
+            // When the next action contains a link, the text must not be a
+            // <button> (a link <button> can't nest inside it). Render it as a
+            // static, linkified line; editing stays available via the pencil and
+            // "Edit" buttons.
+            <div className={styles.staticText}>
+              <LinkifiedText text={value} />
+            </div>
+          ) : (
+            <button type="button"
+              className={`${styles.text} ${hasValue ? '' : styles.placeholder}`}
+              onClick={() => setEditing(true)}
+            >
+              {hasValue ? value : 'Set your next action…'}
+            </button>
+          )}
           <button type="button" className={styles.editIcon} onClick={() => setEditing(true)} aria-label="Edit next action">
             <Icon icon={Pencil} size={14} />
           </button>

--- a/src/renderer/src/components/ResourcePanel.tsx
+++ b/src/renderer/src/components/ResourcePanel.tsx
@@ -21,6 +21,7 @@ import type {
   McpServerSummary,
 } from '@shared/ipc-channels'
 import { Icon } from './Icon'
+import { LinkifiedText } from './LinkifiedText'
 import { fire, openExternal } from '../ipc'
 import { McpServersSection, ConnectResourceDialog } from './McpTools'
 import styles from './ResourcePanel.module.css'
@@ -57,14 +58,14 @@ function AnswerCard({ result, onDismiss }: { result: ResolveResult; onDismiss: (
 
       {result.verdict === 'confident' && (
         <>
-          <div className={styles.liveValue}>{result.liveValue}</div>
+          <div className={styles.liveValue}><LinkifiedText text={result.liveValue ?? ''} /></div>
           {result.citation && <Citation {...result.citation} />}
         </>
       )}
 
       {result.verdict === 'source_available_no_live_value' && (
         <>
-          <div className={styles.answerText}>{result.answer}</div>
+          <div className={styles.answerText}><LinkifiedText text={result.answer} /></div>
           {result.citation && <Citation {...result.citation} />}
         </>
       )}
@@ -73,7 +74,7 @@ function AnswerCard({ result, onDismiss }: { result: ResolveResult; onDismiss: (
         <>
           <div className={styles.clarifyRow}>
             <Icon icon={CircleHelp} size={14} className={styles.clarifyIcon} />
-            <span className={styles.answerText}>{result.answer}</span>
+            <span className={styles.answerText}><LinkifiedText text={result.answer} /></span>
           </div>
           {result.candidates.length > 0 && (
             <div className={styles.candidateChips}>
@@ -86,7 +87,7 @@ function AnswerCard({ result, onDismiss }: { result: ResolveResult; onDismiss: (
       )}
 
       {result.verdict === 'none' && (
-        <div className={`${styles.answerText} ${styles.muted}`}>{result.answer}</div>
+        <div className={`${styles.answerText} ${styles.muted}`}><LinkifiedText text={result.answer} /></div>
       )}
 
       {result.retrievalMode === 'lexical-fallback' && (
@@ -111,7 +112,7 @@ function RecommendationCard({ result, onDismiss }: { result: RecommendationResul
         <Icon icon={X} size={13} />
       </button>
 
-      <div className={`${styles.answerText} ${result.items.length === 0 ? styles.muted : ''}`}>{result.summary}</div>
+      <div className={`${styles.answerText} ${result.items.length === 0 ? styles.muted : ''}`}><LinkifiedText text={result.summary} /></div>
 
       {result.items.length > 0 && (
         <ul className={styles.recommendList}>

--- a/src/renderer/src/components/WorkingColumn.tsx
+++ b/src/renderer/src/components/WorkingColumn.tsx
@@ -21,6 +21,7 @@ import type { LucideIcon } from 'lucide-react'
 import { Icon } from './Icon'
 import { ResourcePanel } from './ResourcePanel'
 import { TodoSessionChip } from './TodoSessionChip'
+import { LinkifiedText } from './LinkifiedText'
 import { fire, openExternal } from '../ipc'
 import styles from './WorkingColumn.module.css'
 
@@ -85,7 +86,7 @@ function TodosPanel({
         <div key={t.id} className={styles.todoItem}>
           <div className={styles.todoRow}>
             <button type="button" className={styles.checkbox} onClick={() => onToggleTodo(t)} aria-label="Mark done" />
-            <span className={styles.todoText}>{t.text}</span>
+            <span className={styles.todoText}><LinkifiedText text={t.text} /></span>
             <button type="button" className={styles.rowAction} onClick={() => onDelegate(t.text, undefined, t.id)} aria-label="Delegate to Copilot" title="Delegate to Copilot">
               <Icon icon={Sparkles} size={13} />
             </button>
@@ -104,7 +105,7 @@ function TodosPanel({
           <button type="button" className={`${styles.checkbox} ${styles.checkboxDone}`} onClick={() => onToggleTodo(t)} aria-label="Mark not done">
             <Icon icon={Check} size={11} strokeWidth={3} />
           </button>
-          <span className={`${styles.todoText} ${styles.struck}`}>{t.text}</span>
+          <span className={`${styles.todoText} ${styles.struck}`}><LinkifiedText text={t.text} /></span>
           <button type="button" className={styles.rowAction} onClick={() => onDeleteTodo(t)} aria-label="Delete todo">
             <Icon icon={Trash2} size={13} />
           </button>

--- a/src/renderer/src/components/linkify.test.ts
+++ b/src/renderer/src/components/linkify.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest'
+import { tokenizeLinks, hasLink } from './linkify'
+
+/** Compact helper: render tokens as an array of [kind, value] pairs. */
+function shape(text: string): Array<[string, string]> {
+  return tokenizeLinks(text).map((t) => [t.kind, t.value])
+}
+
+describe('tokenizeLinks', () => {
+  it('returns a single text token for plain text', () => {
+    expect(shape('just some text')).toEqual([['text', 'just some text']])
+  })
+
+  it('returns [] for an empty string', () => {
+    expect(tokenizeLinks('')).toEqual([])
+  })
+
+  it('linkifies a bare URL', () => {
+    expect(shape('https://example.com/foo')).toEqual([['url', 'https://example.com/foo']])
+  })
+
+  it('splits text around a URL', () => {
+    expect(shape('see https://example.com now')).toEqual([
+      ['text', 'see '],
+      ['url', 'https://example.com'],
+      ['text', ' now'],
+    ])
+  })
+
+  it('trims a trailing period into the following text token', () => {
+    expect(shape('see https://x.com.')).toEqual([
+      ['text', 'see '],
+      ['url', 'https://x.com'],
+      ['text', '.'],
+    ])
+  })
+
+  it('trims a trailing comma and keeps the offset of the comma', () => {
+    const tokens = tokenizeLinks('see https://x.com, then continue')
+    expect(tokens.map((t) => [t.kind, t.value])).toEqual([
+      ['text', 'see '],
+      ['url', 'https://x.com'],
+      ['text', ', then continue'],
+    ])
+    // The trailing text token starts at the comma, not the following space.
+    expect(tokens[2].start).toBe('see https://x.com'.length)
+  })
+
+  it('handles two space-separated URLs', () => {
+    expect(shape('https://a.com https://b.com')).toEqual([
+      ['url', 'https://a.com'],
+      ['text', ' '],
+      ['url', 'https://b.com'],
+    ])
+  })
+
+  it('trims an unbalanced closing paren', () => {
+    expect(shape('(https://x.com/foo)')).toEqual([
+      ['text', '('],
+      ['url', 'https://x.com/foo'],
+      ['text', ')'],
+    ])
+  })
+
+  it('keeps a balanced closing paren inside the URL', () => {
+    expect(shape('https://x.com/foo_(bar)')).toEqual([['url', 'https://x.com/foo_(bar)']])
+  })
+
+  it('trims only the surplus closing paren', () => {
+    expect(shape('https://x.com/foo(bar))')).toEqual([
+      ['url', 'https://x.com/foo(bar)'],
+      ['text', ')'],
+    ])
+  })
+
+  it('trims a trailing bracket', () => {
+    expect(shape('[https://x.com/foo]')).toEqual([
+      ['text', '['],
+      ['url', 'https://x.com/foo'],
+      ['text', ']'],
+    ])
+  })
+
+  it('strips angle brackets around a URL', () => {
+    expect(shape('<https://x.com>')).toEqual([
+      ['text', '<'],
+      ['url', 'https://x.com'],
+      ['text', '>'],
+    ])
+  })
+
+  it('keeps query and hash parts', () => {
+    expect(shape('https://x.com/p?q=1&r=2#frag')).toEqual([
+      ['url', 'https://x.com/p?q=1&r=2#frag'],
+    ])
+  })
+
+  it('does not linkify non-http(s) schemes', () => {
+    expect(shape('run javascript:alert(1) now')).toEqual([['text', 'run javascript:alert(1) now']])
+    expect(shape('open file:///etc/passwd')).toEqual([['text', 'open file:///etc/passwd']])
+  })
+
+  it('does not linkify a scheme with no host', () => {
+    expect(shape('broken https://) link')).toEqual([['text', 'broken https://) link']])
+  })
+
+  it('gives duplicate URLs distinct, offset-based keys', () => {
+    const tokens = tokenizeLinks('https://x.com https://x.com')
+    const urls = tokens.filter((t) => t.kind === 'url')
+    expect(urls).toHaveLength(2)
+    expect(urls[0].start).not.toBe(urls[1].start)
+  })
+})
+
+describe('hasLink', () => {
+  it('detects a link', () => {
+    expect(hasLink('go to https://x.com')).toBe(true)
+  })
+
+  it('is false for plain text', () => {
+    expect(hasLink('no links here')).toBe(false)
+  })
+
+  it('is false for an invalid candidate', () => {
+    expect(hasLink('https:// nope')).toBe(false)
+  })
+})

--- a/src/renderer/src/components/linkify.ts
+++ b/src/renderer/src/components/linkify.ts
@@ -1,0 +1,85 @@
+import { parseSafeExternalUrl } from '@shared/safe-url'
+
+export interface LinkToken {
+  kind: 'text' | 'url'
+  /** Displayed text (for a url token, the trimmed URL as it appears in the source). */
+  value: string
+  /** Offset of this token in the original string — a stable, unique React key. */
+  start: number
+}
+
+// Candidate URLs: an explicit http/https scheme followed by any run of
+// non-whitespace. Requiring a scheme keeps detection unambiguous and avoids
+// linkifying bare words like "example.com". Trailing punctuation is stripped
+// afterwards by `trimTrailing`, and the candidate is validated as a real
+// http/https URL before it's accepted as a link.
+const URL_RE = /https?:\/\/\S+/g
+
+// Characters that are almost always sentence/markup punctuation, never a
+// meaningful final character of a URL.
+const ALWAYS_TRIM = new Set(['.', ',', ';', ':', '!', '?', '"', "'", '<', '>'])
+
+/**
+ * Strip trailing characters that are punctuation rather than part of the URL.
+ * Closing brackets are only stripped when unbalanced within the candidate, so
+ * `…/foo_(bar)` keeps its `)` but `(…/foo)` sheds the trailing one.
+ */
+function trimTrailing(url: string): string {
+  let end = url.length
+  while (end > 0) {
+    const ch = url[end - 1]
+    if (ALWAYS_TRIM.has(ch)) {
+      end -= 1
+      continue
+    }
+    if (ch === ')' || ch === ']') {
+      const open = ch === ')' ? '(' : '['
+      const sub = url.slice(0, end)
+      let opens = 0
+      let closes = 0
+      for (const c of sub) {
+        if (c === open) opens += 1
+        else if (c === ch) closes += 1
+      }
+      if (closes > opens) {
+        end -= 1
+        continue
+      }
+    }
+    break
+  }
+  return url.slice(0, end)
+}
+
+/**
+ * Split `text` into an ordered list of plain-text and url tokens. Trailing
+ * punctuation trimmed off a URL (and any candidate that isn't a valid http/https
+ * URL) stays as text, so nothing from the original string is ever dropped.
+ */
+export function tokenizeLinks(text: string): LinkToken[] {
+  const tokens: LinkToken[] = []
+  let last = 0
+  for (const match of text.matchAll(URL_RE)) {
+    const rawStart = match.index ?? 0
+    const trimmed = trimTrailing(match[0])
+    // Only accept candidates that parse as real http/https URLs; otherwise leave
+    // the text alone so we never render a dead link.
+    if (trimmed.length === 0 || parseSafeExternalUrl(trimmed) === null) {
+      continue
+    }
+    if (rawStart > last) {
+      tokens.push({ kind: 'text', value: text.slice(last, rawStart), start: last })
+    }
+    tokens.push({ kind: 'url', value: trimmed, start: rawStart })
+    last = rawStart + trimmed.length
+  }
+  if (last < text.length) {
+    tokens.push({ kind: 'text', value: text.slice(last), start: last })
+  }
+  return tokens
+}
+
+/** True when `text` contains at least one linkifiable http/https URL. */
+export function hasLink(text: string): boolean {
+  return tokenizeLinks(text).some((t) => t.kind === 'url')
+}

--- a/src/shared/safe-url.test.ts
+++ b/src/shared/safe-url.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest'
+import { parseSafeExternalUrl, isSafeExternalUrl } from './safe-url'
+
+describe('parseSafeExternalUrl', () => {
+  it('accepts http and https and returns the normalized href', () => {
+    expect(parseSafeExternalUrl('https://example.com')).toBe('https://example.com/')
+    expect(parseSafeExternalUrl('http://example.com/path?q=1')).toBe('http://example.com/path?q=1')
+  })
+
+  it('rejects non-http(s) schemes', () => {
+    expect(parseSafeExternalUrl('javascript:alert(1)')).toBeNull()
+    expect(parseSafeExternalUrl('file:///etc/passwd')).toBeNull()
+    expect(parseSafeExternalUrl('mailto:a@b.com')).toBeNull()
+    expect(parseSafeExternalUrl('vscode://open')).toBeNull()
+    expect(parseSafeExternalUrl('ftp://host/file')).toBeNull()
+  })
+
+  it('rejects malformed / relative / non-string input', () => {
+    expect(parseSafeExternalUrl('not a url')).toBeNull()
+    expect(parseSafeExternalUrl('https://')).toBeNull()
+    expect(parseSafeExternalUrl('/relative/path')).toBeNull()
+    expect(parseSafeExternalUrl('')).toBeNull()
+    expect(parseSafeExternalUrl(null)).toBeNull()
+    expect(parseSafeExternalUrl(undefined)).toBeNull()
+    expect(parseSafeExternalUrl(42)).toBeNull()
+    expect(parseSafeExternalUrl({ href: 'https://x.com' })).toBeNull()
+  })
+})
+
+describe('isSafeExternalUrl', () => {
+  it('is a boolean mirror of parseSafeExternalUrl', () => {
+    expect(isSafeExternalUrl('https://example.com')).toBe(true)
+    expect(isSafeExternalUrl('javascript:alert(1)')).toBe(false)
+    expect(isSafeExternalUrl(null)).toBe(false)
+  })
+})

--- a/src/shared/safe-url.ts
+++ b/src/shared/safe-url.ts
@@ -1,0 +1,32 @@
+/**
+ * Single source of truth for "is this a URL we're willing to open externally?".
+ *
+ * Shared by the renderer (so free-form text never renders a dead/unsafe link)
+ * and the main process (so `app:open-external` never hands a non-http(s) or
+ * malformed URL to `shell.openExternal`). Keeping one implementation means the
+ * two sides can't drift.
+ */
+
+/**
+ * Parse a value as a safe external URL. Returns the normalized `href` when the
+ * input is a string that parses as an absolute `http:`/`https:` URL, else null.
+ *
+ * Only http/https are allowed — never `javascript:`, `file:`, `mailto:`, or any
+ * custom scheme.
+ */
+export function parseSafeExternalUrl(url: unknown): string | null {
+  if (typeof url !== 'string') return null
+  let parsed: URL
+  try {
+    parsed = new URL(url)
+  } catch {
+    return null
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null
+  return parsed.href
+}
+
+/** True when `url` is a string that parses as an absolute http/https URL. */
+export function isSafeExternalUrl(url: unknown): url is string {
+  return parseSafeExternalUrl(url) !== null
+}


### PR DESCRIPTION
## What & why

Free-form text in the Focus view rendered `https://…` URLs as plain, non-clickable text. If you typed or pasted a link into a todo, the next action, or asked a Resources question whose answer contained a URL, you couldn't click it. This makes those URLs clickable.

Three surfaces are covered (the request: "links in todo lists, next action, and resources should all be clickable"):

- **Todo list** - active and done todo text.
- **Next action** - the next-action line.
- **Resources** - the answer / live-value / recommendation free-text bodies. (Resource rows and citations already opened their URLs; only the answer bodies were plain text.)

## How

- **One shared primitive.** New pure `tokenizeLinks()` (`src/renderer/src/components/linkify.ts`) splits a string into text/url tokens, and `<LinkifiedText>` renders url tokens as clickable elements. Used in all three surfaces so the detection logic lives in one place.
- **Follows the app's link convention.** Links render as `<button>`s calling the existing `openExternal` IPC (same as citations, notification rows, digest rows). The main window already denies `window.open`, so using buttons (not raw `<a href>`) sidesteps any in-window navigation footgun.
- **Single source of truth for "safe URL".** New `src/shared/safe-url.ts` (`parseSafeExternalUrl` / `isSafeExternalUrl`) is shared by the renderer tokenizer (so it never renders a dead/unsafe link) and the main process.
- **Hardened `app:open-external`.** Now that user-entered text feeds the open path, the handler validates input and opens only the normalized `http`/`https` href; anything else is dropped with a warning. Existing callers all pass https URLs, so no regression.
- **Next action structure.** To avoid nesting interactive elements, the next-action text keeps its click-to-edit `<button>` when there's no link, and renders a static linkified line when there is one. Editing stays available via the pencil icon and the "Edit" button in both cases.
- Tokenizer details: only `http(s)` schemes match; trailing sentence punctuation is trimmed; closing brackets are only trimmed when unbalanced (so `…/foo_(bar)` keeps its `)` but `(…/foo)` sheds the outer one).

## How I verified it

- `bun run typecheck` - clean (renderer + node configs).
- `eslint src` - clean.
- Full vitest suite - **498 tests across 54 files pass** (run under the Bun runtime, which the repo's `bun:sqlite` integration tests require).
- New tests:
  - `src/shared/safe-url.test.ts` - accepts http/https, rejects `javascript:`/`file:`/`mailto:`/custom schemes/non-strings/malformed.
  - `src/renderer/src/components/linkify.test.ts` - trailing punctuation, balanced/unbalanced brackets, angle brackets, query/hash, back-to-back URLs, invalid candidates, duplicate-URL key stability, offset bookkeeping.
  - `src/renderer/src/components/LinkifiedText.test.tsx` - renders a link button, click opens via `openExternal`, `stopPropagation` keeps a link click from bubbling to a clickable ancestor, non-http schemes render no button.
- Existing `NextAction` tests still pass (no-link values stay on the click-to-edit path).

## Notes / trade-offs

- Links are `<button>`s, so screen readers announce them as buttons rather than links. This is a deliberate choice to match the app's existing external-link convention and avoid `<a href>` navigation concerns in Electron. Could revisit with `<a href>` + `preventDefault` later if link semantics matter.
- `www.`-only (no-scheme) URLs are intentionally not linkified, to keep detection unambiguous and safe.
- Out of scope: the Notes tab (a textarea, not rendered text) and notification titles (already open via row click).