### PR TITLE
Inbound MCP server foundation: loopback server + stdio shim

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@
 out/
 dist/
 
+# Generated, self-contained stdio-shim bundle (built by `bun run build:shim`,
+# shipped UNPACKED as an extraResource; never committed).
+build/mcp-shim.cjs
+
 # Dependencies
 node_modules/
 .pnp

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "//modelcontextprotocol-sdk": "@modelcontextprotocol/sdk is intentionally kept though currently unused: the app-as-MCP-client path was removed in #99, but the inbound MCP *server* (a later issue in epic #98) depends on it.",
   "scripts": {
     "dev": "electron-vite dev",
-    "build": "electron-vite build",
+    "build": "bun run build:shim && electron-vite build",
+    "build:shim": "bun build src/main/mcp-server/shim/entry.ts --target=node --format=cjs --outfile build/mcp-shim.cjs",
     "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.node.json",
     "lint": "eslint src",
     "test": "bun run typecheck && bun run lint && bun --bun run vitest run",
@@ -87,6 +88,10 @@
       {
         "from": ".model-cache",
         "to": "model-cache"
+      },
+      {
+        "from": "build/mcp-shim.cjs",
+        "to": "mcp-shim.cjs"
       }
     ],
     "files": [

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -44,6 +44,8 @@ import { delegateTask, appDelegateAvailability, buildAppSessionDeepLink, createD
 import { linkTodoSession } from './agent/copilot-app/store'
 import { refreshTodoAppSessionsForProject } from './agent/copilot-app/status'
 import { getAppDelegateEnabled, setAppDelegateEnabled, getReposRoot, setReposRoot } from './agent/copilot-app/settings'
+import { enableMcpServer, disableMcpServer, shutdownMcpServer } from './mcp-server/lifecycle'
+import { getMcpServerEnabled, setMcpServerEnabled } from './mcp-server/settings'
 import type { ProjectPatch, ProjectTodoPatch, ProjectLinkPatch, SnoozeMode, SyncIntervalMinutes, MaxSyncDays, CreateRoutingRulePayload, LaunchAgentTaskPayload, ResourceInput, ResourcePatch, ProjectCardPatch, DelegatePayload } from '../shared/ipc-channels'
 import { SYNC_INTERVAL_OPTIONS, MAX_SYNC_DAYS_OPTIONS } from '../shared/ipc-channels'
 
@@ -376,6 +378,17 @@ app.whenReady().then(async () => {
     setReposRoot(root)
   })
 
+  // Inbound MCP server (loopback + stdio shim). Enabled by default.
+  ipcMain.handle('settings:get-mcp-server-enabled', () => getMcpServerEnabled())
+  ipcMain.handle('settings:set-mcp-server-enabled', async (_event, enabled: boolean) => {
+    setMcpServerEnabled(enabled)
+    if (enabled) {
+      await enableMcpServer()
+    } else {
+      await disableMcpServer()
+    }
+  })
+
   // Focus: re-entry digest + drift handlers
   ipcMain.handle('digest:get', (_event, projectId: number) => getDigest(projectId))
   ipcMain.handle('projects:mark-focused', (_event, projectId: number) => {
@@ -439,6 +452,14 @@ app.whenReady().then(async () => {
   startSnoozeWatcher()
   startDriftWatcher()
 
+  // Inbound MCP server: expose the app as an MCP server the Copilot app can call.
+  // Off the render thread; failures here must not block the window coming up.
+  if (getMcpServerEnabled()) {
+    void enableMcpServer().catch((err: unknown) => {
+      console.error('[mcp] Failed to start inbound MCP server:', err instanceof Error ? err.message : 'error')
+    })
+  }
+
   createWindow()
 
   app.on('activate', () => {
@@ -450,4 +471,13 @@ app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') {
     app.quit()
   }
+})
+
+// Stop the loopback server and remove its run files on quit. We leave the
+// ~/.mcp.json entry in place (quit != disable); the shim degrades gracefully to
+// "app not running" when the run files are gone.
+app.on('will-quit', () => {
+  void shutdownMcpServer().catch((err: unknown) => {
+    console.error('[mcp] Shutdown failed:', err instanceof Error ? err.message : 'error')
+  })
 })

--- a/src/main/mcp-server/lifecycle.test.ts
+++ b/src/main/mcp-server/lifecycle.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Keep the electron + native module graph out of these tests; we only exercise
+// the serialization/guard logic with fakes.
+vi.mock('electron', () => ({
+  app: { isPackaged: false, getAppPath: () => '/tmp/gh-mcp-nonexistent-shim-dir' },
+}))
+vi.mock('../auth/storage', () => ({ loadToken: () => null }))
+
+const startMcpServer = vi.fn()
+const enableMcpJsonEntry = vi.fn()
+const disableMcpJsonEntry = vi.fn()
+const cleanupRunFiles = vi.fn()
+
+vi.mock('./server', () => ({ startMcpServer: (...a: unknown[]) => startMcpServer(...a) }))
+vi.mock('./mcp-json', () => ({
+  enableMcpJsonEntry: (...a: unknown[]) => enableMcpJsonEntry(...a),
+  disableMcpJsonEntry: (...a: unknown[]) => disableMcpJsonEntry(...a),
+  MANAGED_MARKER_ENV: 'GH_PROJECTS_MCP_MANAGED',
+  MANAGED_MARKER_VALUE: '1',
+}))
+vi.mock('./runfiles', () => ({ cleanupRunFiles: (...a: unknown[]) => cleanupRunFiles(...a) }))
+
+type Lifecycle = typeof import('./lifecycle')
+
+async function freshLifecycle(): Promise<Lifecycle> {
+  vi.resetModules()
+  return import('./lifecycle')
+}
+
+const tick = (): Promise<void> => new Promise((r) => setTimeout(r, 5))
+
+beforeEach(() => {
+  startMcpServer.mockReset()
+  enableMcpJsonEntry.mockReset()
+  disableMcpJsonEntry.mockReset()
+  cleanupRunFiles.mockReset()
+})
+
+describe('lifecycle serialization', () => {
+  it('two concurrent enables start the loopback server exactly once', async () => {
+    let closeCount = 0
+    startMcpServer.mockImplementation(async () => {
+      await tick() // simulate startup latency during which a second enable races
+      return { port: 1234, close: async () => { closeCount++ } }
+    })
+    const lifecycle = await freshLifecycle()
+
+    await Promise.all([lifecycle.enableMcpServer(), lifecycle.enableMcpServer()])
+
+    expect(startMcpServer).toHaveBeenCalledTimes(1)
+    expect(lifecycle.isMcpServerRunning()).toBe(true)
+    expect(closeCount).toBe(0)
+  })
+
+  it('enable then shutdown closes the server and leaves nothing running', async () => {
+    let closeCount = 0
+    startMcpServer.mockResolvedValue({ port: 1, close: async () => { closeCount++ } })
+    const lifecycle = await freshLifecycle()
+
+    await lifecycle.enableMcpServer()
+    await lifecycle.shutdownMcpServer()
+
+    expect(closeCount).toBe(1)
+    expect(lifecycle.isMcpServerRunning()).toBe(false)
+    // Shutdown leaves ~/.mcp.json alone (quit != disable).
+    expect(disableMcpJsonEntry).not.toHaveBeenCalled()
+  })
+
+  it('a shutdown queued during an in-flight start still closes that server', async () => {
+    let closeCount = 0
+    startMcpServer.mockImplementation(async () => {
+      await tick()
+      return { port: 2, close: async () => { closeCount++ } }
+    })
+    const lifecycle = await freshLifecycle()
+
+    // Fire enable and shutdown back-to-back without awaiting the enable first.
+    const enabling = lifecycle.enableMcpServer()
+    const shuttingDown = lifecycle.shutdownMcpServer()
+    await Promise.all([enabling, shuttingDown])
+
+    // Serialized: start completes, THEN shutdown closes it. No orphan server.
+    expect(startMcpServer).toHaveBeenCalledTimes(1)
+    expect(closeCount).toBe(1)
+    expect(lifecycle.isMcpServerRunning()).toBe(false)
+  })
+
+  it('disable removes the mcp.json entry', async () => {
+    startMcpServer.mockResolvedValue({ port: 3, close: async () => {} })
+    const lifecycle = await freshLifecycle()
+
+    await lifecycle.enableMcpServer()
+    await lifecycle.disableMcpServer()
+
+    expect(disableMcpJsonEntry).toHaveBeenCalledTimes(1)
+    expect(lifecycle.isMcpServerRunning()).toBe(false)
+  })
+})

--- a/src/main/mcp-server/lifecycle.ts
+++ b/src/main/mcp-server/lifecycle.ts
@@ -29,6 +29,24 @@ import { cleanupRunFiles } from './runfiles'
 
 let handle: McpServerHandle | null = null
 
+/**
+ * Serializes lifecycle transitions so concurrent enable/disable/shutdown calls
+ * (app-ready start racing an IPC toggle racing quit) can never overlap — which
+ * would otherwise start two servers, disable during an in-flight start, or write
+ * stale run files as the process exits. Each op runs strictly after the previous
+ * one settles; a failed op never poisons the chain.
+ */
+let chain: Promise<void> = Promise.resolve()
+
+function serialize(op: () => Promise<void>): Promise<void> {
+  const run = chain.then(op, op)
+  chain = run.then(
+    () => {},
+    () => {}
+  )
+  return run
+}
+
 /** Absolute path to the shipped, self-contained shim bundle. */
 export function shimPath(): string {
   // Packaged: extraResource at Contents/Resources/mcp-shim.cjs.
@@ -57,48 +75,54 @@ function extraSecrets(): readonly string[] {
 }
 
 /** Start the loopback server (if not already running) and register the shim. */
-export async function enableMcpServer(): Promise<void> {
-  if (handle === null) {
-    handle = await startMcpServer({ extraSecrets })
-  }
-  // Only register in ~/.mcp.json when the shim bundle actually exists, so we never
-  // point Copilot at a missing command (e.g. in dev before `bun run build:shim`).
-  const path = shimPath()
-  if (!existsSync(path)) {
-    console.warn(`[mcp] shim bundle missing at ${path}; skipping ~/.mcp.json registration`)
-    return
-  }
-  try {
-    enableMcpJsonEntry(buildShimCommand())
-  } catch (err) {
-    // A corrupt ~/.mcp.json must not take down app startup.
-    console.error('[mcp] failed to register shim in ~/.mcp.json:', err instanceof Error ? err.message : 'error')
-  }
+export function enableMcpServer(): Promise<void> {
+  return serialize(async () => {
+    if (handle === null) {
+      handle = await startMcpServer({ extraSecrets })
+    }
+    // Only register in ~/.mcp.json when the shim bundle actually exists, so we
+    // never point Copilot at a missing command (e.g. in dev before build:shim).
+    const path = shimPath()
+    if (!existsSync(path)) {
+      console.warn(`[mcp] shim bundle missing at ${path}; skipping ~/.mcp.json registration`)
+      return
+    }
+    try {
+      enableMcpJsonEntry(buildShimCommand())
+    } catch (err) {
+      // A corrupt ~/.mcp.json must not take down app startup.
+      console.error('[mcp] failed to register shim in ~/.mcp.json:', err instanceof Error ? err.message : 'error')
+    }
+  })
 }
 
 /** Stop the server and remove our mcp.json entry (explicit user disable). */
-export async function disableMcpServer(): Promise<void> {
-  if (handle !== null) {
-    await handle.close()
-    handle = null
-  } else {
-    cleanupRunFiles()
-  }
-  try {
-    disableMcpJsonEntry()
-  } catch (err) {
-    console.error('[mcp] failed to remove shim from ~/.mcp.json:', err instanceof Error ? err.message : 'error')
-  }
+export function disableMcpServer(): Promise<void> {
+  return serialize(async () => {
+    if (handle !== null) {
+      await handle.close()
+      handle = null
+    } else {
+      cleanupRunFiles()
+    }
+    try {
+      disableMcpJsonEntry()
+    } catch (err) {
+      console.error('[mcp] failed to remove shim from ~/.mcp.json:', err instanceof Error ? err.message : 'error')
+    }
+  })
 }
 
 /** Stop the server on app quit. Leaves the mcp.json entry in place. */
-export async function shutdownMcpServer(): Promise<void> {
-  if (handle !== null) {
-    await handle.close()
-    handle = null
-  } else {
-    cleanupRunFiles()
-  }
+export function shutdownMcpServer(): Promise<void> {
+  return serialize(async () => {
+    if (handle !== null) {
+      await handle.close()
+      handle = null
+    } else {
+      cleanupRunFiles()
+    }
+  })
 }
 
 /** Test/inspection helper: is the loopback server currently running? */

--- a/src/main/mcp-server/lifecycle.ts
+++ b/src/main/mcp-server/lifecycle.ts
@@ -1,0 +1,107 @@
+/**
+ * Lifecycle glue between `main/index.ts` and the inbound MCP server. Owns the
+ * single running server handle and the `~/.mcp.json` registration.
+ *
+ * - `enableMcpServer()`  — start the loopback server + register the shim in mcp.json.
+ * - `disableMcpServer()` — stop the server + remove our mcp.json entry.
+ * - `shutdownMcpServer()`— stop the server (deletes run files) but LEAVE mcp.json,
+ *   because app quit != user disable; the shim degrades gracefully when the run
+ *   files are gone.
+ *
+ * The shim command points at the Electron binary running as Node
+ * (`ELECTRON_RUN_AS_NODE=1`) against the UNPACKED, self-contained `mcp-shim.cjs`
+ * — no dependency on a system node/bun and no asar-script-execution.
+ */
+
+import { app } from 'electron'
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { loadToken } from '../auth/storage'
+import { startMcpServer, type McpServerHandle } from './server'
+import {
+  disableMcpJsonEntry,
+  enableMcpJsonEntry,
+  MANAGED_MARKER_ENV,
+  MANAGED_MARKER_VALUE,
+  type ShimCommand,
+} from './mcp-json'
+import { cleanupRunFiles } from './runfiles'
+
+let handle: McpServerHandle | null = null
+
+/** Absolute path to the shipped, self-contained shim bundle. */
+export function shimPath(): string {
+  // Packaged: extraResource at Contents/Resources/mcp-shim.cjs.
+  // Dev: the `build:shim` output under the repo root.
+  return app.isPackaged
+    ? join(process.resourcesPath, 'mcp-shim.cjs')
+    : join(app.getAppPath(), 'build', 'mcp-shim.cjs')
+}
+
+/** The `~/.mcp.json` command that spawns the shim via Electron-as-Node. */
+export function buildShimCommand(): ShimCommand {
+  return {
+    command: process.execPath,
+    args: [shimPath()],
+    env: {
+      ELECTRON_RUN_AS_NODE: '1',
+      [MANAGED_MARKER_ENV]: MANAGED_MARKER_VALUE,
+    },
+  }
+}
+
+/** Extra secrets to scrub from tool output beyond the rotating token (the PAT). */
+function extraSecrets(): readonly string[] {
+  const pat = loadToken()
+  return pat !== null && pat.length > 0 ? [pat] : []
+}
+
+/** Start the loopback server (if not already running) and register the shim. */
+export async function enableMcpServer(): Promise<void> {
+  if (handle === null) {
+    handle = await startMcpServer({ extraSecrets })
+  }
+  // Only register in ~/.mcp.json when the shim bundle actually exists, so we never
+  // point Copilot at a missing command (e.g. in dev before `bun run build:shim`).
+  const path = shimPath()
+  if (!existsSync(path)) {
+    console.warn(`[mcp] shim bundle missing at ${path}; skipping ~/.mcp.json registration`)
+    return
+  }
+  try {
+    enableMcpJsonEntry(buildShimCommand())
+  } catch (err) {
+    // A corrupt ~/.mcp.json must not take down app startup.
+    console.error('[mcp] failed to register shim in ~/.mcp.json:', err instanceof Error ? err.message : 'error')
+  }
+}
+
+/** Stop the server and remove our mcp.json entry (explicit user disable). */
+export async function disableMcpServer(): Promise<void> {
+  if (handle !== null) {
+    await handle.close()
+    handle = null
+  } else {
+    cleanupRunFiles()
+  }
+  try {
+    disableMcpJsonEntry()
+  } catch (err) {
+    console.error('[mcp] failed to remove shim from ~/.mcp.json:', err instanceof Error ? err.message : 'error')
+  }
+}
+
+/** Stop the server on app quit. Leaves the mcp.json entry in place. */
+export async function shutdownMcpServer(): Promise<void> {
+  if (handle !== null) {
+    await handle.close()
+    handle = null
+  } else {
+    cleanupRunFiles()
+  }
+}
+
+/** Test/inspection helper: is the loopback server currently running? */
+export function isMcpServerRunning(): boolean {
+  return handle !== null
+}

--- a/src/main/mcp-server/mcp-json.test.ts
+++ b/src/main/mcp-server/mcp-json.test.ts
@@ -97,6 +97,19 @@ describe('enableMcpJsonEntry', () => {
     // Original content untouched.
     expect(readFileSync(path, 'utf8')).toBe('{ not valid json')
   })
+
+  it('throws (does not clobber) when mcpServers is a non-object (array)', () => {
+    const path = tempConfigPath()
+    writeFileSync(path, JSON.stringify({ mcpServers: ['bogus'] }))
+    expect(() => enableMcpJsonEntry(command, path)).toThrow(/mcpServers/)
+    expect(JSON.parse(readFileSync(path, 'utf8'))).toEqual({ mcpServers: ['bogus'] })
+  })
+
+  it('throws when the top-level config is a JSON array', () => {
+    const path = tempConfigPath()
+    writeFileSync(path, JSON.stringify(['nope']))
+    expect(() => enableMcpJsonEntry(command, path)).toThrow(/not a JSON object/)
+  })
 })
 
 describe('disableMcpJsonEntry', () => {

--- a/src/main/mcp-server/mcp-json.test.ts
+++ b/src/main/mcp-server/mcp-json.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  enableMcpJsonEntry,
+  disableMcpJsonEntry,
+  MANAGED_MARKER_ENV,
+  MANAGED_MARKER_VALUE,
+  MCP_ENTRY_NAME,
+  type ShimCommand,
+} from './mcp-json'
+
+const dirs: string[] = []
+
+function tempConfigPath(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'gh-mcp-json-'))
+  dirs.push(dir)
+  return join(dir, '.mcp.json')
+}
+
+afterEach(() => {
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true })
+})
+
+const command: ShimCommand = {
+  command: '/path/to/electron',
+  args: ['/res/mcp-shim.cjs'],
+  env: { ELECTRON_RUN_AS_NODE: '1', [MANAGED_MARKER_ENV]: MANAGED_MARKER_VALUE },
+}
+
+function read(path: string): { mcpServers?: Record<string, unknown>; [k: string]: unknown } {
+  return JSON.parse(readFileSync(path, 'utf8'))
+}
+
+describe('enableMcpJsonEntry', () => {
+  it('creates the file + entry when absent', () => {
+    const path = tempConfigPath()
+    expect(enableMcpJsonEntry(command, path)).toBe('added')
+    const cfg = read(path)
+    expect(cfg.mcpServers?.[MCP_ENTRY_NAME]).toEqual(command)
+  })
+
+  it('writes a new file at mode 0600', () => {
+    const path = tempConfigPath()
+    enableMcpJsonEntry(command, path)
+    expect(statSync(path).mode & 0o777).toBe(0o600)
+  })
+
+  it('is idempotent (second enable updates, no duplicate)', () => {
+    const path = tempConfigPath()
+    enableMcpJsonEntry(command, path)
+    expect(enableMcpJsonEntry(command, path)).toBe('updated')
+    const cfg = read(path)
+    expect(Object.keys(cfg.mcpServers ?? {})).toEqual([MCP_ENTRY_NAME])
+  })
+
+  it('preserves unrelated servers and top-level keys', () => {
+    const path = tempConfigPath()
+    writeFileSync(
+      path,
+      JSON.stringify({ mcpServers: { other: { command: 'x' } }, somethingElse: 42 })
+    )
+    enableMcpJsonEntry(command, path)
+    const cfg = read(path)
+    expect(cfg.mcpServers?.other).toEqual({ command: 'x' })
+    expect(cfg.somethingElse).toBe(42)
+    expect(cfg.mcpServers?.[MCP_ENTRY_NAME]).toEqual(command)
+  })
+
+  it('refuses to clobber an UNMANAGED entry with our name', () => {
+    const path = tempConfigPath()
+    const userEntry = { command: 'user-owned', args: [] }
+    writeFileSync(path, JSON.stringify({ mcpServers: { [MCP_ENTRY_NAME]: userEntry } }))
+    expect(enableMcpJsonEntry(command, path)).toBe('skipped-unmanaged')
+    expect(read(path).mcpServers?.[MCP_ENTRY_NAME]).toEqual(userEntry)
+  })
+
+  it('updates an entry that already carries our marker', () => {
+    const path = tempConfigPath()
+    writeFileSync(
+      path,
+      JSON.stringify({
+        mcpServers: {
+          [MCP_ENTRY_NAME]: { command: 'old', args: [], env: { [MANAGED_MARKER_ENV]: MANAGED_MARKER_VALUE } },
+        },
+      })
+    )
+    expect(enableMcpJsonEntry(command, path)).toBe('updated')
+    expect(read(path).mcpServers?.[MCP_ENTRY_NAME]).toEqual(command)
+  })
+
+  it('throws (does not clobber) when the existing file is invalid JSON', () => {
+    const path = tempConfigPath()
+    writeFileSync(path, '{ not valid json')
+    expect(() => enableMcpJsonEntry(command, path)).toThrow(/not valid JSON/)
+    // Original content untouched.
+    expect(readFileSync(path, 'utf8')).toBe('{ not valid json')
+  })
+})
+
+describe('disableMcpJsonEntry', () => {
+  it('removes our managed entry', () => {
+    const path = tempConfigPath()
+    enableMcpJsonEntry(command, path)
+    expect(disableMcpJsonEntry(path)).toBe('removed')
+    expect(read(path).mcpServers?.[MCP_ENTRY_NAME]).toBeUndefined()
+  })
+
+  it('preserves other servers when removing ours', () => {
+    const path = tempConfigPath()
+    writeFileSync(path, JSON.stringify({ mcpServers: { other: { command: 'x' } } }))
+    enableMcpJsonEntry(command, path)
+    disableMcpJsonEntry(path)
+    expect(read(path).mcpServers?.other).toEqual({ command: 'x' })
+  })
+
+  it('is a no-op when the file is absent', () => {
+    expect(disableMcpJsonEntry(tempConfigPath())).toBe('absent')
+  })
+
+  it('is a no-op when our entry is absent', () => {
+    const path = tempConfigPath()
+    writeFileSync(path, JSON.stringify({ mcpServers: { other: {} } }))
+    expect(disableMcpJsonEntry(path)).toBe('absent')
+  })
+
+  it('refuses to remove an UNMANAGED entry with our name', () => {
+    const path = tempConfigPath()
+    const userEntry = { command: 'user-owned' }
+    writeFileSync(path, JSON.stringify({ mcpServers: { [MCP_ENTRY_NAME]: userEntry } }))
+    expect(disableMcpJsonEntry(path)).toBe('skipped-unmanaged')
+    expect(read(path).mcpServers?.[MCP_ENTRY_NAME]).toEqual(userEntry)
+  })
+})

--- a/src/main/mcp-server/mcp-json.ts
+++ b/src/main/mcp-server/mcp-json.ts
@@ -1,0 +1,128 @@
+/**
+ * App-managed registration of the stdio shim in the user's global `~/.mcp.json`,
+ * so the Copilot app can discover and spawn it. Idempotent and ownership-aware:
+ * we only ever touch OUR entry (`gh-projects`), and only when it carries our
+ * managed marker (or is absent). An unmanaged `gh-projects` entry that a user
+ * hand-added is left untouched — we never clobber someone's global config.
+ *
+ * Writes are atomic (temp file + same-directory rename). A present-but-unparseable
+ * file is a hard error, NOT an excuse to overwrite it. Unknown servers and other
+ * top-level keys are preserved.
+ */
+
+import { readFileSync, renameSync, statSync, writeFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+/** Our entry key in `mcpServers`. */
+export const MCP_ENTRY_NAME = 'gh-projects'
+
+/** Env marker stamped on our entry so we can prove ownership before mutating it. */
+export const MANAGED_MARKER_ENV = 'GH_PROJECTS_MCP_MANAGED'
+export const MANAGED_MARKER_VALUE = '1'
+
+/** The shim command shape written into `~/.mcp.json`. */
+export interface ShimCommand {
+  command: string
+  args: string[]
+  env: Record<string, string>
+}
+
+export type EnableOutcome = 'added' | 'updated' | 'skipped-unmanaged'
+export type DisableOutcome = 'removed' | 'absent' | 'skipped-unmanaged'
+
+/** Path to the user's global MCP config. */
+export function mcpJsonPath(): string {
+  return join(homedir(), '.mcp.json')
+}
+
+interface McpConfig {
+  mcpServers?: Record<string, unknown>
+  [key: string]: unknown
+}
+
+/**
+ * Read + parse the config. Returns null when the file is absent. THROWS when the
+ * file exists but can't be read or parsed — so a corrupt file is never clobbered.
+ */
+function readConfig(path: string): McpConfig | null {
+  let raw: string
+  try {
+    raw = readFileSync(path, 'utf8')
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null
+    throw err
+  }
+  if (raw.trim().length === 0) return {}
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    throw new Error(`~/.mcp.json exists but is not valid JSON; refusing to overwrite: ${path}`)
+  }
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error(`~/.mcp.json is not a JSON object; refusing to overwrite: ${path}`)
+  }
+  return parsed as McpConfig
+}
+
+/** Atomically write the config, preserving the file's mode (0600 for a new file). */
+function writeConfig(path: string, config: McpConfig): void {
+  let mode = 0o600
+  try {
+    mode = statSync(path).mode & 0o777
+  } catch {
+    /* new file → default 0600 */
+  }
+  const tmp = `${path}.tmp-${process.pid}-${Math.random().toString(36).slice(2)}`
+  writeFileSync(tmp, `${JSON.stringify(config, null, 2)}\n`, { encoding: 'utf8', mode })
+  renameSync(tmp, path)
+}
+
+/** Whether an existing entry is one WE manage (carries our marker). */
+function isManagedEntry(entry: unknown): boolean {
+  if (entry === null || typeof entry !== 'object') return false
+  const env = (entry as { env?: unknown }).env
+  if (env === null || typeof env !== 'object') return false
+  return (env as Record<string, unknown>)[MANAGED_MARKER_ENV] === MANAGED_MARKER_VALUE
+}
+
+/**
+ * Add or update our `gh-projects` entry, but ONLY when it is absent or already
+ * managed by us. Returns what happened. `command.env` must already carry the
+ * managed marker (see `lifecycle.ts`).
+ */
+export function enableMcpJsonEntry(command: ShimCommand, path: string = mcpJsonPath()): EnableOutcome {
+  const config = readConfig(path) ?? {}
+  const servers = (config.mcpServers ?? {}) as Record<string, unknown>
+  const existing = servers[MCP_ENTRY_NAME]
+
+  if (existing !== undefined && !isManagedEntry(existing)) {
+    // A user-authored entry with the same name — never clobber it.
+    console.warn(`[mcp-json] leaving unmanaged '${MCP_ENTRY_NAME}' entry untouched`)
+    return 'skipped-unmanaged'
+  }
+
+  const outcome: EnableOutcome = existing === undefined ? 'added' : 'updated'
+  servers[MCP_ENTRY_NAME] = { command: command.command, args: command.args, env: command.env }
+  config.mcpServers = servers
+  writeConfig(path, config)
+  return outcome
+}
+
+/** Remove our entry, but ONLY when it carries our marker. Returns what happened. */
+export function disableMcpJsonEntry(path: string = mcpJsonPath()): DisableOutcome {
+  const config = readConfig(path)
+  if (config === null) return 'absent'
+  const servers = (config.mcpServers ?? {}) as Record<string, unknown>
+  const existing = servers[MCP_ENTRY_NAME]
+  if (existing === undefined) return 'absent'
+  if (!isManagedEntry(existing)) {
+    console.warn(`[mcp-json] leaving unmanaged '${MCP_ENTRY_NAME}' entry untouched`)
+    return 'skipped-unmanaged'
+  }
+  delete servers[MCP_ENTRY_NAME]
+  config.mcpServers = servers
+  writeConfig(path, config)
+  return 'removed'
+}

--- a/src/main/mcp-server/mcp-json.ts
+++ b/src/main/mcp-server/mcp-json.ts
@@ -41,9 +41,20 @@ interface McpConfig {
   [key: string]: unknown
 }
 
+/** True for a plain (non-array, non-null) object. */
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
 /**
  * Read + parse the config. Returns null when the file is absent. THROWS when the
  * file exists but can't be read or parsed — so a corrupt file is never clobbered.
+ *
+ * NOTE: this is a read-modify-write against a file another process/user could also
+ * edit. The temp-file + rename makes each write atomic (never a partial file), but
+ * a concurrent external edit in the window between read and rename could be lost.
+ * In practice the app is the only writer of OUR entry and edits are rare, so we
+ * accept that rather than take a lock.
  */
 function readConfig(path: string): McpConfig | null {
   let raw: string
@@ -60,10 +71,15 @@ function readConfig(path: string): McpConfig | null {
   } catch {
     throw new Error(`~/.mcp.json exists but is not valid JSON; refusing to overwrite: ${path}`)
   }
-  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+  if (!isPlainObject(parsed)) {
     throw new Error(`~/.mcp.json is not a JSON object; refusing to overwrite: ${path}`)
   }
-  return parsed as McpConfig
+  const config = parsed as McpConfig
+  // A malformed `mcpServers` (e.g. an array) would silently drop on re-serialize.
+  if (config.mcpServers !== undefined && !isPlainObject(config.mcpServers)) {
+    throw new Error(`~/.mcp.json has a non-object "mcpServers"; refusing to overwrite: ${path}`)
+  }
+  return config
 }
 
 /** Atomically write the config, preserving the file's mode (0600 for a new file). */

--- a/src/main/mcp-server/runfiles.test.ts
+++ b/src/main/mcp-server/runfiles.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, statSync, writeFileSync, readFileSync, readdirSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { readRunFiles, writeRunFiles, cleanupRunFiles, runDir } from './runfiles'
+
+const dirs: string[] = []
+
+function tempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'gh-mcp-run-'))
+  dirs.push(dir)
+  return dir
+}
+
+afterEach(() => {
+  for (const dir of dirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+describe('runDir', () => {
+  it('points under ~/.gh-projects/run', () => {
+    expect(runDir().endsWith(join('.gh-projects', 'run'))).toBe(true)
+  })
+})
+
+describe('writeRunFiles / readRunFiles', () => {
+  it('round-trips port + token', () => {
+    const dir = tempDir()
+    writeRunFiles({ port: 54321, token: 'abc123token' }, dir)
+    expect(readRunFiles(dir)).toEqual({ port: 54321, token: 'abc123token' })
+  })
+
+  it('writes both files mode 0600', () => {
+    const dir = tempDir()
+    writeRunFiles({ port: 5, token: 'tok' }, dir)
+    expect(statSync(join(dir, 'port')).mode & 0o777).toBe(0o600)
+    expect(statSync(join(dir, 'token')).mode & 0o777).toBe(0o600)
+  })
+
+  it('returns null when files are absent (app not running)', () => {
+    expect(readRunFiles(tempDir())).toBeNull()
+  })
+
+  it('returns null when only one file is present (torn/partial)', () => {
+    const dir = tempDir()
+    writeFileSync(join(dir, 'port'), '5\n')
+    expect(readRunFiles(dir)).toBeNull()
+  })
+
+  it('rejects a non-numeric port', () => {
+    const dir = tempDir()
+    writeFileSync(join(dir, 'token'), 'tok\n')
+    writeFileSync(join(dir, 'port'), '0x10\n')
+    expect(readRunFiles(dir)).toBeNull()
+  })
+
+  it('rejects an out-of-range port', () => {
+    const dir = tempDir()
+    writeFileSync(join(dir, 'token'), 'tok\n')
+    writeFileSync(join(dir, 'port'), '70000\n')
+    expect(readRunFiles(dir)).toBeNull()
+  })
+
+  it('rejects an empty token', () => {
+    const dir = tempDir()
+    writeFileSync(join(dir, 'token'), '\n')
+    writeFileSync(join(dir, 'port'), '5\n')
+    expect(readRunFiles(dir)).toBeNull()
+  })
+
+  it('trims trailing whitespace/newlines from values', () => {
+    const dir = tempDir()
+    writeFileSync(join(dir, 'token'), '  spaced-token  \n\n')
+    writeFileSync(join(dir, 'port'), '  4242  \n')
+    expect(readRunFiles(dir)).toEqual({ port: 4242, token: 'spaced-token' })
+  })
+
+  it('does not leave temp files behind', () => {
+    const dir = tempDir()
+    writeRunFiles({ port: 1, token: 'x' }, dir)
+    const leftover = readdirSync(dir).filter((f) => f.includes('.tmp-'))
+    expect(leftover).toEqual([])
+  })
+})
+
+describe('cleanupRunFiles', () => {
+  it('removes both run files', () => {
+    const dir = tempDir()
+    writeRunFiles({ port: 1, token: 'x' }, dir)
+    cleanupRunFiles(dir)
+    expect(readRunFiles(dir)).toBeNull()
+  })
+
+  it('is a no-op when files are already absent', () => {
+    expect(() => cleanupRunFiles(tempDir())).not.toThrow()
+  })
+})
+
+describe('write ordering (token before port)', () => {
+  it('writes token content that is present alongside the port', () => {
+    // The atomicity of the two writes is what matters; assert both readable.
+    const dir = tempDir()
+    writeRunFiles({ port: 9, token: 'ordered' }, dir)
+    expect(readFileSync(join(dir, 'token'), 'utf8').trim()).toBe('ordered')
+    expect(readFileSync(join(dir, 'port'), 'utf8').trim()).toBe('9')
+  })
+})

--- a/src/main/mcp-server/runfiles.ts
+++ b/src/main/mcp-server/runfiles.ts
@@ -1,0 +1,123 @@
+/**
+ * Runtime discovery files for the INBOUND MCP server — the reverse of
+ * `agent/copilot-app/discover.ts`.
+ *
+ * The Projects app writes two files under `~/.gh-projects/run/` while it's
+ * running so the stdio shim (spawned by the Copilot app) can find and
+ * authenticate to the loopback MCP server:
+ *   - `token` — a base64url auth token (mode 0600). ROTATES on every app launch.
+ *   - `port`  — the localhost port the loopback server listens on (mode 0600).
+ *
+ * This module is deliberately dependency-free (node builtins only) so it can be
+ * imported by BOTH the Electron main process (writer) and the bundled stdio shim
+ * (reader) without dragging the app into the shim bundle. The token is a secret:
+ * it is never logged here.
+ *
+ * Write discipline (see the issue #103 plan): the app writes `token` FIRST, then
+ * `port` LAST, each via a same-directory temp file + atomic rename, and only
+ * AFTER the HTTP server's `listen()` has succeeded. A reader therefore never sees
+ * a `port` that isn't yet accepting, and observing a NEW port implies the NEW
+ * token is already on disk. The only possible torn read is (old port, new token)
+ * during a restart, which the shim heals by re-reading + retrying.
+ */
+
+import { mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+/** Directory the app writes its inbound-server runtime files to. */
+export function runDir(): string {
+  // `GH_PROJECTS_RUN_DIR` lets tests (and the spawned shim) point at an isolated
+  // dir instead of the real `~/.gh-projects/run`. Both the writer (server) and the
+  // reader (shim) honor it, so they always agree.
+  const override = process.env.GH_PROJECTS_RUN_DIR
+  if (override !== undefined && override.trim().length > 0) return override
+  return join(homedir(), '.gh-projects', 'run')
+}
+
+function tokenPath(dir: string): string {
+  return join(dir, 'token')
+}
+
+function portPath(dir: string): string {
+  return join(dir, 'port')
+}
+
+/** The validated runtime endpoint the shim connects to. */
+export interface RunEndpoint {
+  port: number
+  /** The auth token. Treat as a secret: never log or persist it. */
+  token: string
+}
+
+/** First non-empty, trimmed line of a file; null when unreadable/empty. */
+function firstLine(path: string): string | null {
+  let raw: string
+  try {
+    raw = readFileSync(path, 'utf8')
+  } catch {
+    return null // missing / unreadable → app not running
+  }
+  for (const line of raw.split(/\r?\n/)) {
+    const trimmed = line.trim()
+    if (trimmed.length > 0) return trimmed
+  }
+  return null
+}
+
+/**
+ * Atomically write `value` to `path` at mode 0600 via a same-directory temp file
+ * + rename. The temp name embeds pid + a random suffix so concurrent writers
+ * can't collide.
+ */
+function atomicWrite(path: string, value: string): void {
+  const tmp = `${path}.tmp-${process.pid}-${Math.random().toString(36).slice(2)}`
+  writeFileSync(tmp, value, { encoding: 'utf8', mode: 0o600 })
+  renameSync(tmp, path)
+}
+
+/**
+ * Publish the run files. MUST be called only after the loopback server's
+ * `listen()` has resolved. Writes `token` first, then `port` last (see the
+ * write-discipline note above). Creates the run dir at mode 0700 if needed.
+ * The token is never logged.
+ */
+export function writeRunFiles(endpoint: RunEndpoint, dir: string = runDir()): void {
+  mkdirSync(dir, { recursive: true, mode: 0o700 })
+  atomicWrite(tokenPath(dir), `${endpoint.token}\n`)
+  atomicWrite(portPath(dir), `${endpoint.port}\n`)
+}
+
+/**
+ * Read the current endpoint (port + token), validating shape before use. Returns
+ * null when the app isn't running (files absent) or the contents are malformed.
+ * Re-read on every attempt — the token rotates per app launch. Reads `port`
+ * first, then `token` (see the write-discipline note above).
+ */
+export function readRunFiles(dir: string = runDir()): RunEndpoint | null {
+  const portRaw = firstLine(portPath(dir))
+  const token = firstLine(tokenPath(dir))
+  if (portRaw === null || token === null) return null
+
+  // Digits-only: reject hex/exponent/other Number() quirks (port is decimal).
+  if (!/^\d+$/.test(portRaw)) return null
+  const port = Number.parseInt(portRaw, 10)
+  if (!Number.isInteger(port) || port <= 0 || port > 65535) return null
+  if (token.length === 0) return null
+
+  return { port, token }
+}
+
+/**
+ * Best-effort removal of the run files (on quit / disable). Never throws — a
+ * missing file is fine. Leaves the run dir in place.
+ */
+export function cleanupRunFiles(dir: string = runDir()): void {
+  for (const path of [portPath(dir), tokenPath(dir)]) {
+    try {
+      rmSync(path, { force: true })
+    } catch {
+      /* best-effort */
+    }
+  }
+}

--- a/src/main/mcp-server/sanitize.test.ts
+++ b/src/main/mcp-server/sanitize.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest'
+import { sanitizeMcpText, sanitizeMcpJson } from './sanitize'
+
+const TOKEN = 'super-secret-rotating-token'
+const PAT = 'ghp_exampleexampleexampleexample1234'
+
+describe('sanitizeMcpText', () => {
+  it('redacts a known secret value', () => {
+    expect(sanitizeMcpText(`token is ${TOKEN} ok`, [TOKEN])).toBe('token is [redacted] ok')
+  })
+
+  it('redacts multiple secrets', () => {
+    const msg = `t=${TOKEN} p=${PAT}`
+    expect(sanitizeMcpText(msg, [TOKEN, PAT])).toBe('t=[redacted] p=[redacted]')
+  })
+
+  it('ignores trivially short secrets (avoids mangling)', () => {
+    expect(sanitizeMcpText('a and b and c', ['a', 'b'])).toBe('a and b and c')
+  })
+
+  it('caps very long strings', () => {
+    const out = sanitizeMcpText('x'.repeat(5000), [])
+    expect(out.length).toBeLessThanOrEqual(2000)
+    expect(out.endsWith('…')).toBe(true)
+  })
+
+  it('leaves clean text untouched', () => {
+    expect(sanitizeMcpText('nothing to hide', [TOKEN])).toBe('nothing to hide')
+  })
+})
+
+describe('sanitizeMcpJson', () => {
+  it('redacts secrets in string leaves', () => {
+    expect(sanitizeMcpJson({ msg: `see ${TOKEN}` }, [TOKEN])).toEqual({ msg: 'see [redacted]' })
+  })
+
+  it('redacts secrets in arrays', () => {
+    expect(sanitizeMcpJson([`${TOKEN}`, 'clean'], [TOKEN])).toEqual(['[redacted]', 'clean'])
+  })
+
+  it('redacts secrets that appear in object KEYS', () => {
+    const out = sanitizeMcpJson({ [`k-${TOKEN}`]: 1 }, [TOKEN]) as Record<string, unknown>
+    expect(Object.keys(out)).toEqual(['k-[redacted]'])
+  })
+
+  it('passes through non-string leaves', () => {
+    expect(sanitizeMcpJson({ n: 5, b: true, z: null }, [TOKEN])).toEqual({ n: 5, b: true, z: null })
+  })
+
+  it('caps recursion depth (returns undefined past the cap)', () => {
+    // Build a chain deeper than the internal cap.
+    let deep: unknown = 'leaf'
+    for (let i = 0; i < 30; i++) deep = { next: deep }
+    // Should not throw and should terminate.
+    expect(() => sanitizeMcpJson(deep, [])).not.toThrow()
+  })
+
+  it('preserves a realistic CallToolResult shape', () => {
+    const result = { content: [{ type: 'text', text: 'pong' }], isError: false }
+    expect(sanitizeMcpJson(result, [TOKEN])).toEqual(result)
+  })
+})

--- a/src/main/mcp-server/sanitize.ts
+++ b/src/main/mcp-server/sanitize.ts
@@ -1,0 +1,56 @@
+/**
+ * Defense-in-depth scrub of app secrets from tool OUTPUT before it leaves the
+ * process toward the Copilot app. Reintroduced after #99 deleted the original
+ * `sanitizeMcpText`/`sanitizeMcpJson`.
+ *
+ * Trust model (unchanged from the original): this is NOT a hard boundary — it
+ * can't catch a secret a handler transforms/encodes. The hard guarantee is that
+ * handlers don't put secrets in their output in the first place. This scrub is
+ * hygiene on the way out: it redacts any known secret VALUE (the rotating
+ * loopback token, the GitHub PAT if present) that slips into a diagnostic string,
+ * plus a length cap. Dependency-free so it can also be used inside the shim.
+ */
+
+/** Minimum secret length to redact — avoids mangling text on trivial values. */
+const MIN_SECRET_LEN = 4
+
+/** Cap on any single sanitized string. */
+const MAX_TEXT_LEN = 2000
+
+/** Max recursion depth for `sanitizeMcpJson` (guards pathological structures). */
+const MAX_DEPTH = 24
+
+/**
+ * Redact every known secret value from `message` and cap its length. `secrets`
+ * is the list of raw secret strings to scrub (token, PAT, …); empty/short
+ * entries are ignored.
+ */
+export function sanitizeMcpText(message: string, secrets: readonly string[]): string {
+  let out = message
+  for (const secret of secrets) {
+    if (secret.length >= MIN_SECRET_LEN) out = out.split(secret).join('[redacted]')
+  }
+  return out.length > MAX_TEXT_LEN ? `${out.slice(0, MAX_TEXT_LEN - 1)}…` : out
+}
+
+/**
+ * Recursively scrub known secret values from every string leaf AND object KEY of
+ * a JSON value. Depth-capped so a deeply nested structure can't blow the stack.
+ */
+export function sanitizeMcpJson(
+  value: unknown,
+  secrets: readonly string[],
+  depth = 0
+): unknown {
+  if (depth > MAX_DEPTH) return undefined
+  if (typeof value === 'string') return sanitizeMcpText(value, secrets)
+  if (Array.isArray(value)) return value.map((v) => sanitizeMcpJson(v, secrets, depth + 1))
+  if (value !== null && typeof value === 'object') {
+    const out: Record<string, unknown> = {}
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      out[sanitizeMcpText(k, secrets)] = sanitizeMcpJson(v, secrets, depth + 1)
+    }
+    return out
+  }
+  return value
+}

--- a/src/main/mcp-server/security.test.ts
+++ b/src/main/mcp-server/security.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest'
+import { authorizeRequest, isLoopbackAddress, MCP_PATH, type RequestMeta } from './security'
+
+const PORT = 4242
+const TOKEN = 'the-secret-token'
+
+/** A fully-valid request; individual tests override single fields. */
+function okMeta(overrides: Partial<RequestMeta> = {}): RequestMeta {
+  return {
+    method: 'POST',
+    path: MCP_PATH,
+    host: `127.0.0.1:${PORT}`,
+    origin: undefined,
+    authorization: `Bearer ${TOKEN}`,
+    remoteAddress: '127.0.0.1',
+    ...overrides,
+  }
+}
+
+function authorize(meta: RequestMeta) {
+  return authorizeRequest(meta, { port: PORT, token: TOKEN })
+}
+
+describe('isLoopbackAddress', () => {
+  it.each(['127.0.0.1', '::1', '::ffff:127.0.0.1'])('accepts loopback %s', (addr) => {
+    expect(isLoopbackAddress(addr)).toBe(true)
+  })
+
+  it.each(['10.0.0.5', '192.168.1.2', '0.0.0.0', '', null, undefined])(
+    'rejects non-loopback %s',
+    (addr) => {
+      expect(isLoopbackAddress(addr as string | null | undefined)).toBe(false)
+    }
+  )
+})
+
+describe('authorizeRequest', () => {
+  it('passes a fully-valid request', () => {
+    expect(authorize(okMeta())).toEqual({ ok: true })
+  })
+
+  it('404s a wrong path', () => {
+    expect(authorize(okMeta({ path: '/other' }))).toMatchObject({ ok: false, status: 404 })
+  })
+
+  it('405s a non-POST method', () => {
+    expect(authorize(okMeta({ method: 'GET' }))).toMatchObject({ ok: false, status: 405 })
+  })
+
+  it('403s a mismatched Host (DNS-rebinding defense)', () => {
+    expect(authorize(okMeta({ host: 'evil.example.com' }))).toMatchObject({ ok: false, status: 403 })
+    expect(authorize(okMeta({ host: `127.0.0.1:${PORT + 1}` }))).toMatchObject({ ok: false, status: 403 })
+    expect(authorize(okMeta({ host: `localhost:${PORT}` }))).toMatchObject({ ok: false, status: 403 })
+  })
+
+  it('403s a non-loopback remote address', () => {
+    expect(authorize(okMeta({ remoteAddress: '10.0.0.9' }))).toMatchObject({ ok: false, status: 403 })
+  })
+
+  it('403s any request carrying an Origin header (browser gate)', () => {
+    expect(authorize(okMeta({ origin: 'http://localhost:3000' }))).toMatchObject({ ok: false, status: 403 })
+    expect(authorize(okMeta({ origin: 'null' }))).toMatchObject({ ok: false, status: 403 })
+  })
+
+  it('401s a missing Authorization header', () => {
+    expect(authorize(okMeta({ authorization: undefined }))).toMatchObject({ ok: false, status: 401 })
+  })
+
+  it('401s a wrong bearer token', () => {
+    expect(authorize(okMeta({ authorization: 'Bearer wrong-token' }))).toMatchObject({ ok: false, status: 401 })
+  })
+
+  it('401s a non-bearer Authorization scheme', () => {
+    expect(authorize(okMeta({ authorization: `Basic ${TOKEN}` }))).toMatchObject({ ok: false, status: 401 })
+  })
+
+  it('accepts a case-insensitive bearer scheme', () => {
+    expect(authorize(okMeta({ authorization: `bearer ${TOKEN}` }))).toEqual({ ok: true })
+  })
+
+  it('checks path/method before host/token (no info leak ordering)', () => {
+    // A wrong path with a bad token should still 404 (path is checked first).
+    expect(
+      authorize(okMeta({ path: '/nope', authorization: 'Bearer wrong', host: 'evil' }))
+    ).toMatchObject({ ok: false, status: 404 })
+  })
+})

--- a/src/main/mcp-server/security.ts
+++ b/src/main/mcp-server/security.ts
@@ -1,0 +1,84 @@
+/**
+ * Pure request gate for the inbound loopback MCP server. No I/O — takes the
+ * request metadata and the expected port/token and returns a verdict the HTTP
+ * layer maps to a status code. Keeping it pure makes every branch unit-testable.
+ *
+ * Layers (bearer token is the real boundary; the rest is defense-in-depth):
+ *   1. Method + path: only `POST /mcp`.
+ *   2. Host header must equal `127.0.0.1:<port>` (DNS-rebinding defense).
+ *   3. Remote address must be loopback.
+ *   4. Reject any request carrying an `Origin` header — browsers always send one;
+ *      the shim (Node `fetch`) does not. Mirrors the outbound-WS non-browser gate.
+ *   5. Bearer token must match (constant-time compare).
+ */
+
+import { timingSafeEqualToken } from './token'
+
+/** The single path the loopback MCP server serves. */
+export const MCP_PATH = '/mcp'
+
+/** Max accepted request body size (bytes). Oversized bodies are rejected pre-parse. */
+export const MAX_BODY_BYTES = 1_000_000
+
+/** A request's security-relevant metadata (all lower-cased header values). */
+export interface RequestMeta {
+  method: string | undefined
+  /** URL pathname only (no query string). */
+  path: string | undefined
+  host: string | undefined
+  origin: string | undefined
+  authorization: string | undefined
+  /** `req.socket.remoteAddress`. */
+  remoteAddress: string | null | undefined
+}
+
+export type Verdict = { ok: true } | { ok: false; status: number; reason: string }
+
+/** Loopback IPv4/IPv6 forms (incl. IPv4-mapped IPv6). */
+export function isLoopbackAddress(addr: string | null | undefined): boolean {
+  if (addr === null || addr === undefined) return false
+  return addr === '127.0.0.1' || addr === '::1' || addr === '::ffff:127.0.0.1'
+}
+
+/** Extract the bearer credential from an Authorization header, or null. */
+function bearerCredential(authorization: string | undefined): string | null {
+  if (authorization === undefined) return null
+  const match = /^Bearer[ ]+(.+)$/i.exec(authorization.trim())
+  return match !== null ? match[1] : null
+}
+
+/**
+ * Decide whether a request may reach the MCP transport. Returns `{ ok: true }`
+ * or a `{ ok: false, status, reason }` verdict. Never logs the token.
+ */
+export function authorizeRequest(
+  meta: RequestMeta,
+  expected: { port: number; token: string }
+): Verdict {
+  // 1. Method + path.
+  if (meta.path !== MCP_PATH) return { ok: false, status: 404, reason: 'not found' }
+  if (meta.method !== 'POST') return { ok: false, status: 405, reason: 'method not allowed' }
+
+  // 2. Host header (DNS-rebinding defense).
+  if (meta.host !== `127.0.0.1:${expected.port}`) {
+    return { ok: false, status: 403, reason: 'bad host' }
+  }
+
+  // 3. Loopback remote address.
+  if (!isLoopbackAddress(meta.remoteAddress)) {
+    return { ok: false, status: 403, reason: 'non-loopback' }
+  }
+
+  // 4. Origin gate: any Origin header means a browser is calling — reject.
+  if (meta.origin !== undefined) {
+    return { ok: false, status: 403, reason: 'origin not allowed' }
+  }
+
+  // 5. Bearer token (the real boundary).
+  const presented = bearerCredential(meta.authorization)
+  if (presented === null || !timingSafeEqualToken(presented, expected.token)) {
+    return { ok: false, status: 401, reason: 'unauthorized' }
+  }
+
+  return { ok: true }
+}

--- a/src/main/mcp-server/server.integration.test.ts
+++ b/src/main/mcp-server/server.integration.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { request as httpRequest } from 'node:http'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
+import { startMcpServer, type McpServerHandle } from './server'
+import { readRunFiles } from './runfiles'
+import { PING_TOOL_NAME } from './tool-manifest'
+
+/**
+ * Stand up the REAL loopback server and drive it with a REAL SDK client over
+ * Streamable HTTP. This proves the server end to end without needing the Copilot
+ * app. Uses a temp run dir so the developer's real ~/.gh-projects/run is untouched.
+ */
+
+const cleanups: Array<() => Promise<void> | void> = []
+
+afterEach(async () => {
+  for (const fn of cleanups.splice(0)) await fn()
+})
+
+async function startServer(): Promise<{ handle: McpServerHandle; dir: string; token: string }> {
+  const dir = mkdtempSync(join(tmpdir(), 'gh-mcp-srv-'))
+  const handle = await startMcpServer({ runDir: dir })
+  cleanups.push(async () => {
+    await handle.close()
+    rmSync(dir, { recursive: true, force: true })
+  })
+  const endpoint = readRunFiles(dir)
+  if (endpoint === null) throw new Error('run files were not published')
+  expect(endpoint.port).toBe(handle.port)
+  return { handle, dir, token: endpoint.token }
+}
+
+function connectClient(port: number, token: string): Promise<Client> {
+  const transport = new StreamableHTTPClientTransport(new URL(`http://127.0.0.1:${port}/mcp`), {
+    requestInit: { headers: { Authorization: `Bearer ${token}` } },
+  })
+  const client = new Client({ name: 'integration-test', version: '1.0.0' }, { capabilities: {} })
+  cleanups.push(async () => {
+    await client.close()
+  })
+  return client.connect(transport).then(() => client)
+}
+
+/** Raw request with full header control, for the negative security-gate tests. */
+function rawPost(
+  port: number,
+  headers: Record<string, string>,
+  body: string
+): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const req = httpRequest(
+      { host: '127.0.0.1', port, path: '/mcp', method: 'POST', headers },
+      (res) => {
+        res.resume()
+        res.on('end', () => resolve(res.statusCode ?? 0))
+      }
+    )
+    req.on('error', reject)
+    req.end(body)
+  })
+}
+
+const INIT_BODY = JSON.stringify({
+  jsonrpc: '2.0',
+  id: 1,
+  method: 'initialize',
+  params: { protocolVersion: '2025-06-18', capabilities: {}, clientInfo: { name: 'x', version: '1' } },
+})
+
+describe('loopback MCP server (real SDK client)', () => {
+  it('initialize advertises tool capability', async () => {
+    const { handle, token } = await startServer()
+    const client = await connectClient(handle.port, token)
+    expect(client.getServerCapabilities()?.tools).toBeDefined()
+  })
+
+  it('lists the ping tool', async () => {
+    const { handle, token } = await startServer()
+    const client = await connectClient(handle.port, token)
+    const { tools } = await client.listTools()
+    expect(tools.map((t) => t.name)).toContain(PING_TOOL_NAME)
+  })
+
+  it('calls ping and gets pong (separate POST from list — stateless)', async () => {
+    const { handle, token } = await startServer()
+    const client = await connectClient(handle.port, token)
+    await client.listTools()
+    const result = (await client.callTool({ name: PING_TOOL_NAME })) as CallToolResult
+    expect(result.content).toEqual([{ type: 'text', text: 'pong' }])
+  })
+
+  it('rotates the token per launch', async () => {
+    const first = await startServer()
+    const second = await startServer()
+    expect(first.token).not.toBe(second.token)
+  })
+})
+
+describe('loopback MCP server security gate (raw requests)', () => {
+  it('401s a missing/bad bearer token', async () => {
+    const { handle } = await startServer()
+    const status = await rawPost(
+      handle.port,
+      { host: `127.0.0.1:${handle.port}`, 'content-type': 'application/json' },
+      INIT_BODY
+    )
+    expect(status).toBe(401)
+    const badToken = await rawPost(
+      handle.port,
+      { host: `127.0.0.1:${handle.port}`, authorization: 'Bearer wrong', 'content-type': 'application/json' },
+      INIT_BODY
+    )
+    expect(badToken).toBe(401)
+  })
+
+  it('403s a request carrying an Origin header (browser gate)', async () => {
+    const { handle, token } = await startServer()
+    const status = await rawPost(
+      handle.port,
+      {
+        host: `127.0.0.1:${handle.port}`,
+        authorization: `Bearer ${token}`,
+        origin: 'http://localhost:3000',
+        'content-type': 'application/json',
+      },
+      INIT_BODY
+    )
+    expect(status).toBe(403)
+  })
+
+  it('403s a mismatched Host header (DNS-rebinding defense)', async () => {
+    const { handle, token } = await startServer()
+    const status = await rawPost(
+      handle.port,
+      { host: 'evil.example.com', authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+      INIT_BODY
+    )
+    expect(status).toBe(403)
+  })
+
+  it('404s a wrong path', async () => {
+    const { handle, token } = await startServer()
+    const status = await new Promise<number>((resolve, reject) => {
+      const req = httpRequest(
+        {
+          host: '127.0.0.1',
+          port: handle.port,
+          path: '/nope',
+          method: 'POST',
+          headers: { host: `127.0.0.1:${handle.port}`, authorization: `Bearer ${token}` },
+        },
+        (res) => {
+          res.resume()
+          res.on('end', () => resolve(res.statusCode ?? 0))
+        }
+      )
+      req.on('error', reject)
+      req.end(INIT_BODY)
+    })
+    expect(status).toBe(404)
+  })
+})

--- a/src/main/mcp-server/server.integration.test.ts
+++ b/src/main/mcp-server/server.integration.test.ts
@@ -164,4 +164,41 @@ describe('loopback MCP server security gate (raw requests)', () => {
     })
     expect(status).toBe(404)
   })
+
+  it('400s an authorized POST with an empty body', async () => {
+    const { handle, token } = await startServer()
+    const status = await rawPost(
+      handle.port,
+      { host: `127.0.0.1:${handle.port}`, authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+      ''
+    )
+    expect(status).toBe(400)
+  })
+
+  it('does not hang the server when a client aborts mid-request', async () => {
+    const { handle, token } = await startServer()
+    // Announce a body via Content-Length but destroy the socket before sending it.
+    await new Promise<void>((resolve) => {
+      const req = httpRequest({
+        host: '127.0.0.1',
+        port: handle.port,
+        path: '/mcp',
+        method: 'POST',
+        headers: {
+          host: `127.0.0.1:${handle.port}`,
+          authorization: `Bearer ${token}`,
+          'content-type': 'application/json',
+          'content-length': '100',
+        },
+      })
+      req.on('error', () => resolve()) // destroy → error, which is expected
+      req.write('{"partial":')
+      req.destroy()
+      setTimeout(resolve, 50)
+    })
+    // The server must still answer a fresh, well-formed request.
+    const client = await connectClient(handle.port, token)
+    const result = (await client.callTool({ name: PING_TOOL_NAME })) as CallToolResult
+    expect(result.content).toEqual([{ type: 'text', text: 'pong' }])
+  })
 })

--- a/src/main/mcp-server/server.ts
+++ b/src/main/mcp-server/server.ts
@@ -84,8 +84,10 @@ function readBody(
     })
     req.on('end', () => {
       const raw = Buffer.concat(chunks).toString('utf8')
+      // An empty/whitespace body is not a valid JSON-RPC message — reject cleanly
+      // rather than forwarding `undefined` (which the transport surfaces as a 500).
       if (raw.trim().length === 0) {
-        finish({ ok: true, body: undefined })
+        finish({ ok: false, status: 400 })
         return
       }
       try {
@@ -95,6 +97,10 @@ function readBody(
       }
     })
     req.on('error', () => finish({ ok: false, status: 400 }))
+    // If the client aborts/closes before 'end', 'close' fires without 'end' —
+    // resolve so the per-request handler never awaits forever. After a normal
+    // 'end' this is a no-op (finish is idempotent).
+    req.on('close', () => finish({ ok: false, status: 400 }))
   })
 }
 

--- a/src/main/mcp-server/server.ts
+++ b/src/main/mcp-server/server.ts
@@ -1,0 +1,199 @@
+/**
+ * The inbound loopback MCP server, hosted in the Electron main process. Bound to
+ * `127.0.0.1:<ephemeral>`, it speaks MCP over Streamable HTTP using the SDK's
+ * server transport. The stdio shim (spawned by the Copilot app) is the only
+ * intended client.
+ *
+ * Why Streamable HTTP (not WebSocket like the OUTBOUND path): the SDK ships a
+ * first-class server transport for Streamable HTTP but NONE for WebSocket, so WS
+ * would mean hand-rolling MCP-over-WS server framing. We own both ends here, so
+ * we use the SDK's supported transport — the protocol can only break in one seam.
+ *
+ * Stateless design: one local consumer doing tool calls needs no session state.
+ * For each `POST /mcp` we build a fresh `Server` + `StreamableHTTPServerTransport`
+ * (sessionIdGenerator undefined, enableJsonResponse), handle the one request, and
+ * tear both down. No session map / GET-SSE / DELETE lifecycle.
+ *
+ * Security is enforced by `authorizeRequest` BEFORE the body is parsed and BEFORE
+ * the SDK sees anything: POST /mcp only, Host == 127.0.0.1:port, loopback remote
+ * address, reject-if-Origin-present, and the rotating bearer token. The token is
+ * never logged.
+ */
+
+import { createServer, type IncomingMessage, type Server as HttpServer, type ServerResponse } from 'node:http'
+import type { AddressInfo } from 'node:net'
+import { Server } from '@modelcontextprotocol/sdk/server/index.js'
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js'
+import { registerTools, type ToolDeps } from './tools'
+import { authorizeRequest, MAX_BODY_BYTES, type RequestMeta } from './security'
+import { generateToken } from './token'
+import { runDir as defaultRunDir, cleanupRunFiles, writeRunFiles } from './runfiles'
+
+const SERVER_NAME = 'gh-projects'
+const SERVER_VERSION = '1.0.0'
+
+export interface StartMcpServerOptions {
+  /** Override the run-files dir (tests). Defaults to `~/.gh-projects/run`. */
+  runDir?: string
+  /** Extra secrets to scrub from tool output beyond the rotating token (e.g. PAT). */
+  extraSecrets?: () => readonly string[]
+  /** Token generator (tests may inject a fixed value). Defaults to `generateToken`. */
+  generateTokenFn?: () => string
+}
+
+export interface McpServerHandle {
+  /** The bound loopback port. */
+  port: number
+  /** Stop the HTTP server and remove the run files. Idempotent. */
+  close: () => Promise<void>
+}
+
+/** Build a fresh MCP `Server` that advertises tool capability + registers tools. */
+function createConfiguredServer(deps: ToolDeps): Server {
+  const server = new Server(
+    { name: SERVER_NAME, version: SERVER_VERSION },
+    { capabilities: { tools: {} } }
+  )
+  registerTools(server, deps)
+  return server
+}
+
+/** Read the request body with a hard size cap, then JSON-parse it. */
+function readBody(
+  req: IncomingMessage,
+  max: number
+): Promise<{ ok: true; body: unknown } | { ok: false; status: number }> {
+  return new Promise((resolve) => {
+    const chunks: Buffer[] = []
+    let size = 0
+    let done = false
+    const finish = (value: { ok: true; body: unknown } | { ok: false; status: number }): void => {
+      if (done) return
+      done = true
+      resolve(value)
+    }
+    req.on('data', (chunk: Buffer) => {
+      if (done) return
+      size += chunk.length
+      if (size > max) {
+        req.destroy()
+        finish({ ok: false, status: 413 })
+        return
+      }
+      chunks.push(chunk)
+    })
+    req.on('end', () => {
+      const raw = Buffer.concat(chunks).toString('utf8')
+      if (raw.trim().length === 0) {
+        finish({ ok: true, body: undefined })
+        return
+      }
+      try {
+        finish({ ok: true, body: JSON.parse(raw) })
+      } catch {
+        finish({ ok: false, status: 400 })
+      }
+    })
+    req.on('error', () => finish({ ok: false, status: 400 }))
+  })
+}
+
+/** Send a minimal JSON error response (never leaks the token). */
+function sendError(res: ServerResponse, status: number, reason: string): void {
+  if (res.headersSent) return
+  res.writeHead(status, { 'content-type': 'application/json', connection: 'close' })
+  res.end(JSON.stringify({ error: reason }))
+}
+
+function requestMeta(req: IncomingMessage): RequestMeta {
+  // Pathname only — strip any query string. req.url is a path for HTTP servers.
+  const rawUrl = req.url ?? ''
+  const path = rawUrl.split('?', 1)[0]
+  return {
+    method: req.method,
+    path,
+    host: req.headers.host,
+    origin: typeof req.headers.origin === 'string' ? req.headers.origin : undefined,
+    authorization: req.headers.authorization,
+    remoteAddress: req.socket.remoteAddress,
+  }
+}
+
+/**
+ * Start the loopback MCP server. Resolves once it is listening AND the run files
+ * have been published (so a reader never sees a port that isn't accepting yet).
+ */
+export function startMcpServer(options: StartMcpServerOptions = {}): Promise<McpServerHandle> {
+  const dir = options.runDir ?? defaultRunDir()
+  const token = (options.generateTokenFn ?? generateToken)()
+  const toolDeps: ToolDeps = {
+    getSecrets: () => [token, ...(options.extraSecrets?.() ?? [])],
+  }
+
+  const httpServer: HttpServer = createServer((req, res) => {
+    void handleRequest(req, res)
+  })
+
+  async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    const port = (httpServer.address() as AddressInfo | null)?.port ?? 0
+    const verdict = authorizeRequest(requestMeta(req), { port, token })
+    if (!verdict.ok) {
+      sendError(res, verdict.status, verdict.reason)
+      return
+    }
+
+    const body = await readBody(req, MAX_BODY_BYTES)
+    if (!body.ok) {
+      sendError(res, body.status, body.status === 413 ? 'payload too large' : 'invalid json')
+      return
+    }
+
+    // Fresh per-request server + stateless transport (see file header).
+    const server = createConfiguredServer(toolDeps)
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: undefined,
+      enableJsonResponse: true,
+    })
+    let closed = false
+    const teardown = (): void => {
+      if (closed) return
+      closed = true
+      transport.close().catch(() => {})
+      server.close().catch(() => {})
+    }
+    // Covers the normal path (response finished/aborted).
+    res.on('close', teardown)
+    try {
+      await server.connect(transport)
+      await transport.handleRequest(req, res, body.body)
+    } catch (err) {
+      // Never surface internals (which could include a secret) to the client.
+      console.error('[mcp-server] request handling failed:', err instanceof Error ? err.name : 'error')
+      sendError(res, 500, 'internal error')
+      teardown()
+    }
+  }
+
+  return new Promise<McpServerHandle>((resolve, reject) => {
+    httpServer.on('error', reject)
+    httpServer.listen(0, '127.0.0.1', () => {
+      const port = (httpServer.address() as AddressInfo).port
+      // Publish run files only after listen() has succeeded.
+      writeRunFiles({ port, token }, dir)
+      let stopped = false
+      resolve({
+        port,
+        close: () =>
+          new Promise<void>((resolveClose) => {
+            if (stopped) {
+              resolveClose()
+              return
+            }
+            stopped = true
+            cleanupRunFiles(dir)
+            httpServer.close(() => resolveClose())
+          }),
+      })
+    })
+  })
+}

--- a/src/main/mcp-server/server.ts
+++ b/src/main/mcp-server/server.ts
@@ -178,8 +178,17 @@ export function startMcpServer(options: StartMcpServerOptions = {}): Promise<Mcp
     httpServer.on('error', reject)
     httpServer.listen(0, '127.0.0.1', () => {
       const port = (httpServer.address() as AddressInfo).port
-      // Publish run files only after listen() has succeeded.
-      writeRunFiles({ port, token }, dir)
+      // Publish run files only after listen() has succeeded. If publication fails
+      // (unwritable dir, disk error, …), tear the server back down and reject the
+      // start — never leave a listening server without discoverable run files.
+      try {
+        writeRunFiles({ port, token }, dir)
+      } catch (err) {
+        cleanupRunFiles(dir)
+        httpServer.close()
+        reject(err instanceof Error ? err : new Error(String(err)))
+        return
+      }
       let stopped = false
       resolve({
         port,

--- a/src/main/mcp-server/settings.ts
+++ b/src/main/mcp-server/settings.ts
@@ -1,0 +1,30 @@
+/**
+ * Persisted setting for the inbound MCP server, stored in the shared
+ * `sync_metadata` key-value table (same pattern as `copilot-app/settings.ts`).
+ * One key: whether the inbound server is enabled. Default ON — this is the
+ * transport foundation the rest of the epic builds on.
+ */
+
+import { getDb } from '../db'
+
+const MCP_SERVER_ENABLED_KEY = 'mcp_server_enabled'
+
+function readMeta(key: string): string | null {
+  const row = getDb().prepare('SELECT value FROM sync_metadata WHERE key = ?').get(key) as
+    | { value: string }
+    | undefined
+  return row === undefined ? null : row.value
+}
+
+function writeMeta(key: string, value: string): void {
+  getDb().prepare('INSERT OR REPLACE INTO sync_metadata (key, value) VALUES (?, ?)').run(key, value)
+}
+
+/** Whether the inbound MCP server is enabled. Default true (unset => enabled). */
+export function getMcpServerEnabled(): boolean {
+  return readMeta(MCP_SERVER_ENABLED_KEY) !== 'false'
+}
+
+export function setMcpServerEnabled(enabled: boolean): void {
+  writeMeta(MCP_SERVER_ENABLED_KEY, enabled ? 'true' : 'false')
+}

--- a/src/main/mcp-server/shim/entry.e2e.test.ts
+++ b/src/main/mcp-server/shim/entry.e2e.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { StdioClientTransport, getDefaultEnvironment } from '@modelcontextprotocol/sdk/client/stdio.js'
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
+import { startMcpServer, type McpServerHandle } from '../server'
+import { PING_TOOL_NAME } from '../tool-manifest'
+
+/**
+ * Electron-as-Node packaging proof. This exercises the EXACT prod spawn strategy
+ * the generated `~/.mcp.json` uses — `process.execPath` (the Electron binary) with
+ * `ELECTRON_RUN_AS_NODE=1` running the bundled, self-contained shim — driven by a
+ * real stdio MCP client, against a real loopback server. It stops short only of
+ * the real Copilot host doing the spawning.
+ *
+ * Skipped when the Electron binary isn't present (keeps CI green). Set
+ * `MCP_SHIM_E2E_REQUIRE=1` to turn "skip" into a hard failure (release gate) so
+ * the most important proof can't silently rot.
+ */
+
+const REPO_ROOT = process.cwd()
+const REQUIRE_E2E = process.env.MCP_SHIM_E2E_REQUIRE === '1'
+
+/** Resolve the installed Electron binary, or null when it isn't downloaded. */
+function electronBinary(): string | null {
+  const pkgDir = join(REPO_ROOT, 'node_modules', 'electron')
+  const pathTxt = join(pkgDir, 'path.txt')
+  if (!existsSync(pathTxt)) return null
+  const bin = join(pkgDir, 'dist', readFileSync(pathTxt, 'utf8').trim())
+  return existsSync(bin) ? bin : null
+}
+
+/** Bun binary to build the shim with (this suite runs under Bun). */
+function bunBinary(): string | null {
+  return process.versions.bun !== undefined ? process.execPath : null
+}
+
+const electron = electronBinary()
+const bun = bunBinary()
+const canRun = electron !== null && bun !== null
+
+if (!canRun && REQUIRE_E2E) {
+  throw new Error(
+    `MCP_SHIM_E2E_REQUIRE=1 but cannot run e2e (electron=${electron !== null}, bun=${bun !== null})`
+  )
+}
+
+const describeMaybe = canRun ? describe : describe.skip
+
+describeMaybe('shim e2e (Electron-as-Node → loopback)', () => {
+  let buildDir: string
+  let shimBundle: string
+
+  beforeAll(() => {
+    buildDir = mkdtempSync(join(tmpdir(), 'gh-mcp-e2e-build-'))
+    shimBundle = join(buildDir, 'mcp-shim.cjs')
+    // Build the self-contained shim exactly like `bun run build:shim`.
+    execFileSync(
+      bun as string,
+      [
+        'build',
+        join(REPO_ROOT, 'src', 'main', 'mcp-server', 'shim', 'entry.ts'),
+        '--target=node',
+        '--format=cjs',
+        `--outfile=${shimBundle}`,
+      ],
+      { cwd: REPO_ROOT, stdio: 'pipe' }
+    )
+    expect(existsSync(shimBundle)).toBe(true)
+  }, 60_000)
+
+  afterAll(() => {
+    rmSync(buildDir, { recursive: true, force: true })
+  })
+
+  /** Spawn the shim via Electron-as-Node against the given run dir. */
+  async function connectShim(runDir: string): Promise<Client> {
+    const transport = new StdioClientTransport({
+      command: electron as string,
+      args: [shimBundle],
+      env: { ...getDefaultEnvironment(), ELECTRON_RUN_AS_NODE: '1', GH_PROJECTS_RUN_DIR: runDir },
+      stderr: 'inherit',
+    })
+    const client = new Client({ name: 'e2e', version: '1.0.0' }, { capabilities: {} })
+    await client.connect(transport)
+    return client
+  }
+
+  it('lists + calls ping through the shim to a live loopback server', async () => {
+    const runDir = mkdtempSync(join(tmpdir(), 'gh-mcp-e2e-run-'))
+    let server: McpServerHandle | null = null
+    let client: Client | null = null
+    try {
+      server = await startMcpServer({ runDir })
+      client = await connectShim(runDir)
+
+      // initialize advertised tool capability
+      expect(client.getServerCapabilities()?.tools).toBeDefined()
+
+      const { tools } = await client.listTools()
+      expect(tools.map((t) => t.name)).toContain(PING_TOOL_NAME)
+
+      const result = (await client.callTool({ name: PING_TOOL_NAME })) as CallToolResult
+      expect(result.content).toEqual([{ type: 'text', text: 'pong' }])
+    } finally {
+      if (client !== null) await client.close()
+      if (server !== null) await server.close()
+      rmSync(runDir, { recursive: true, force: true })
+    }
+  }, 30_000)
+
+  it('with the app DOWN: still lists ping and returns a clean call error', async () => {
+    // Empty run dir → no server running.
+    const runDir = mkdtempSync(join(tmpdir(), 'gh-mcp-e2e-down-'))
+    let client: Client | null = null
+    try {
+      client = await connectShim(runDir)
+
+      const { tools } = await client.listTools()
+      expect(tools.map((t) => t.name)).toContain(PING_TOOL_NAME) // static, never empty
+
+      const result = (await client.callTool({ name: PING_TOOL_NAME })) as CallToolResult
+      expect(result.isError).toBe(true)
+      expect(JSON.stringify(result.content)).toMatch(/isn't running/)
+    } finally {
+      if (client !== null) await client.close()
+      rmSync(runDir, { recursive: true, force: true })
+    }
+  }, 30_000)
+})

--- a/src/main/mcp-server/shim/entry.ts
+++ b/src/main/mcp-server/shim/entry.ts
@@ -1,0 +1,70 @@
+/**
+ * The shipped stdio-shim entrypoint. The Copilot app spawns this (via
+ * `~/.mcp.json`) as a stdio MCP server. It bridges that stdio channel to the
+ * app's loopback MCP server:
+ *
+ *   Copilot app  <--stdio-->  [this shim]  <--Streamable HTTP-->  loopback server
+ *
+ * It reads `~/.gh-projects/run/{port,token}` on each connect attempt (the token
+ * rotates per app launch), dials the loopback server with a bearer header, and
+ * proxies via `runShimProxy`. When the app isn't running, `tools/list` still
+ * returns the static manifest and `tools/call` returns a clean error — it never
+ * hangs.
+ *
+ * This file is bundled self-contained (`bun build --target=node`) into
+ * `build/mcp-shim.cjs` and shipped UNPACKED, then run via Electron-as-Node. It
+ * must import ONLY the SDK + dependency-free helpers (never electron / sqlite),
+ * and must write nothing to stdout except the MCP protocol (diagnostics → stderr).
+ */
+
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
+import { readRunFiles } from '../runfiles'
+import { runShimProxy, type LoopbackClient } from './proxy'
+
+/** Connect a fresh loopback client from the current run files. Throws when down. */
+async function connectLoopback(): Promise<LoopbackClient> {
+  const endpoint = readRunFiles()
+  if (endpoint === null) throw new Error('run files absent')
+
+  const transport = new StreamableHTTPClientTransport(
+    new URL(`http://127.0.0.1:${endpoint.port}/mcp`),
+    { requestInit: { headers: { Authorization: `Bearer ${endpoint.token}` } } }
+  )
+  const client = new Client({ name: 'gh-projects-shim', version: '1.0.0' }, { capabilities: {} })
+  await client.connect(transport)
+
+  return {
+    callTool: async (name, args): Promise<CallToolResult> => {
+      const result = await client.callTool({ name, arguments: args })
+      return result as CallToolResult
+    },
+    close: async (): Promise<void> => {
+      await client.close()
+    },
+  }
+}
+
+async function main(): Promise<void> {
+  const transport = new StdioServerTransport()
+  const proxy = await runShimProxy({ connect: connectLoopback, transport })
+
+  let shuttingDown = false
+  const shutdown = (): void => {
+    if (shuttingDown) return
+    shuttingDown = true
+    proxy.close().finally(() => process.exit(0))
+  }
+  // Exit when the stdio channel closes (Copilot app went away) or on a signal.
+  proxy.server.onclose = shutdown
+  process.on('SIGINT', shutdown)
+  process.on('SIGTERM', shutdown)
+}
+
+main().catch((err: unknown) => {
+  // Never leak details to stdout; a terse stderr line aids debugging.
+  process.stderr.write(`[gh-projects-shim] fatal: ${err instanceof Error ? err.message : 'error'}\n`)
+  process.exit(1)
+})

--- a/src/main/mcp-server/shim/proxy.test.ts
+++ b/src/main/mcp-server/shim/proxy.test.ts
@@ -147,4 +147,32 @@ describe('shim proxy: tools/call (app down / stale)', () => {
       50
     )
   })
+
+  it('handles concurrent tool calls without cross-clobbering clients', async () => {
+    // Each call connects its own client; a slow one must not disrupt a fast one.
+    let created = 0
+    let closed = 0
+    const connect = async (): Promise<LoopbackClient> => {
+      created++
+      const id = created
+      return {
+        callTool: async () => ({ content: [{ type: 'text', text: `client-${id}` }] }),
+        close: async () => {
+          closed++
+        },
+      }
+    }
+    await withShim(connect, async (client) => {
+      const [a, b, c] = await Promise.all([
+        client.callTool({ name: PING_TOOL_NAME }) as Promise<CallToolResult>,
+        client.callTool({ name: PING_TOOL_NAME }) as Promise<CallToolResult>,
+        client.callTool({ name: PING_TOOL_NAME }) as Promise<CallToolResult>,
+      ])
+      // All three succeed with their own distinct client result.
+      for (const r of [a, b, c]) expect(r.isError).toBeFalsy()
+    })
+    // Every connected client was closed (no leaks).
+    expect(closed).toBe(created)
+    expect(created).toBe(3)
+  })
 })

--- a/src/main/mcp-server/shim/proxy.test.ts
+++ b/src/main/mcp-server/shim/proxy.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from 'vitest'
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
+import { runShimProxy, type LoopbackClient, type ShimProxyDeps } from './proxy'
+import { PING_TOOL_NAME } from '../tool-manifest'
+
+/**
+ * Drive the shim's MCP `Server` with a REAL SDK `Client` over an in-memory
+ * transport pair, so we exercise the exact `tools/list` / `tools/call` request
+ * flow without spawning a process or opening a socket. The loopback `connect`
+ * dependency is faked per test.
+ */
+async function withShim(
+  connect: ShimProxyDeps['connect'],
+  fn: (client: Client) => Promise<void>,
+  timeoutMs = 200
+): Promise<void> {
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+  const proxy = await runShimProxy({ connect, transport: serverTransport, timeoutMs })
+  const client = new Client({ name: 'test', version: '1.0.0' }, { capabilities: {} })
+  await client.connect(clientTransport)
+  try {
+    await fn(client)
+  } finally {
+    await client.close()
+    await proxy.close()
+  }
+}
+
+/** A fake loopback client whose `callTool` behavior is scripted per attempt. */
+function fakeClient(callTool: LoopbackClient['callTool']): LoopbackClient {
+  return { callTool, close: async () => {} }
+}
+
+const pong: CallToolResult = { content: [{ type: 'text', text: 'pong' }] }
+
+describe('shim proxy: tools/list', () => {
+  it('returns the static manifest even when the app is down (never empty)', async () => {
+    const connect = async (): Promise<LoopbackClient> => {
+      throw new Error('run files absent')
+    }
+    await withShim(connect, async (client) => {
+      const { tools } = await client.listTools()
+      expect(tools.map((t) => t.name)).toContain(PING_TOOL_NAME)
+    })
+  })
+
+  it('does not connect to the loopback just to list tools', async () => {
+    let connects = 0
+    const connect = async (): Promise<LoopbackClient> => {
+      connects++
+      throw new Error('should not be called')
+    }
+    await withShim(connect, async (client) => {
+      await client.listTools()
+    })
+    expect(connects).toBe(0)
+  })
+})
+
+describe('shim proxy: tools/call (app running)', () => {
+  it('forwards the call and returns the loopback result', async () => {
+    const connect = async (): Promise<LoopbackClient> =>
+      fakeClient(async (name) => (name === PING_TOOL_NAME ? pong : { content: [], isError: true }))
+    await withShim(connect, async (client) => {
+      const result = (await client.callTool({ name: PING_TOOL_NAME })) as CallToolResult
+      expect(result).toEqual(pong)
+    })
+  })
+
+  it('forwards a tool-level isError result WITHOUT retrying', async () => {
+    let calls = 0
+    const appError: CallToolResult = { content: [{ type: 'text', text: 'boom' }], isError: true }
+    const connect = async (): Promise<LoopbackClient> =>
+      fakeClient(async () => {
+        calls++
+        return appError
+      })
+    await withShim(connect, async (client) => {
+      const result = (await client.callTool({ name: PING_TOOL_NAME })) as CallToolResult
+      expect(result).toEqual(appError)
+    })
+    expect(calls).toBe(1) // no retry on a legitimate tool error
+  })
+})
+
+describe('shim proxy: tools/call (app down / stale)', () => {
+  it('returns a clean isError when the app is not running', async () => {
+    const connect = async (): Promise<LoopbackClient> => {
+      throw new Error('run files absent')
+    }
+    await withShim(connect, async (client) => {
+      const result = (await client.callTool({ name: PING_TOOL_NAME })) as CallToolResult
+      expect(result.isError).toBe(true)
+      expect(JSON.stringify(result.content)).toMatch(/isn't running/)
+    })
+  })
+
+  it.each([
+    ['connection refused', new Error('ECONNREFUSED')],
+    ['timeout', new Error('request timed out')],
+    ['401 rotated token', new Error('HTTP 401')],
+    ['5xx startup race', new Error('HTTP 503')],
+    ['invalid/non-MCP response', new Error('invalid JSON-RPC response')],
+  ])('self-heals after a first-attempt %s by reconnecting once', async (_label, err) => {
+    let connects = 0
+    let attempt = 0
+    const connect = async (): Promise<LoopbackClient> => {
+      connects++
+      return fakeClient(async () => {
+        attempt++
+        if (attempt === 1) throw err // first attempt fails
+        return pong // second (post-reconnect) attempt succeeds
+      })
+    }
+    await withShim(connect, async (client) => {
+      const result = (await client.callTool({ name: PING_TOOL_NAME })) as CallToolResult
+      expect(result).toEqual(pong)
+    })
+    expect(connects).toBe(2) // disposed + reconnected exactly once
+  })
+
+  it('returns one clean error after TWO consecutive failures', async () => {
+    let attempt = 0
+    const connect = async (): Promise<LoopbackClient> =>
+      fakeClient(async () => {
+        attempt++
+        throw new Error('HTTP 500')
+      })
+    await withShim(connect, async (client) => {
+      const result = (await client.callTool({ name: PING_TOOL_NAME })) as CallToolResult
+      expect(result.isError).toBe(true)
+      expect(JSON.stringify(result.content)).toMatch(/isn't running/)
+    })
+    expect(attempt).toBe(2) // one retry, then give up
+  })
+
+  it('never hangs when connect never resolves (per-attempt timeout)', async () => {
+    const connect = (): Promise<LoopbackClient> => new Promise<LoopbackClient>(() => {})
+    await withShim(
+      connect,
+      async (client) => {
+        const result = (await client.callTool({ name: PING_TOOL_NAME })) as CallToolResult
+        expect(result.isError).toBe(true)
+      },
+      50
+    )
+  })
+})

--- a/src/main/mcp-server/shim/proxy.ts
+++ b/src/main/mcp-server/shim/proxy.ts
@@ -75,65 +75,52 @@ function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
 }
 
 /**
- * Holds the (lazily connected) loopback client and implements reread+retry-once.
- * Every failure disposes the client so the next attempt reconnects with fresh
- * run-file values — this is what heals app restarts and token rotation.
+ * Forward one `tools/call` to the loopback with reread+retry-once. A FRESH
+ * loopback client is connected per attempt (and closed after), so there is no
+ * shared mutable client — concurrent calls can't clobber or cross-dispose each
+ * other, and a dead client is never reused. `connect()` re-reads the run files
+ * every time, which is what heals app restarts and token rotation.
+ *
+ * At most two attempts. On ANY thrown failure (connect refused/reset, timeout,
+ * 401/403 rotated token, 5xx startup/shutdown race, invalid/non-MCP response) the
+ * first attempt reconnects; the second gives up with a clean result. A tool that
+ * RESOLVES with `isError: true` is a legitimate response — returned as-is, no retry.
  */
-class LoopbackSession {
-  private client: LoopbackClient | null = null
-
-  constructor(
-    private readonly connect: () => Promise<LoopbackClient>,
-    private readonly timeoutMs: number
-  ) {}
-
-  async call(name: string, args: Record<string, unknown>): Promise<CallToolResult> {
-    // At most two attempts total (one retry). Any connect/transport failure
-    // disposes the client and counts as a failed attempt.
-    for (let attempt = 1; attempt <= 2; attempt++) {
-      let client: LoopbackClient
-      try {
-        client = this.client ?? (await withTimeout(this.connect(), this.timeoutMs))
-        this.client = client
-      } catch {
-        this.client = null
-        if (attempt === 2) return appNotRunningResult()
-        continue
-      }
-      try {
-        return await withTimeout(client.callTool(name, args), this.timeoutMs)
-      } catch {
-        // Transport/auth/protocol failure (incl. non-2xx like 401/5xx): dispose
-        // and, on the first attempt, reconnect with fresh run-file values.
-        await this.dispose()
-        if (attempt === 2) return appNotRunningResult()
-      }
-    }
-    return appNotRunningResult()
-  }
-
-  async dispose(): Promise<void> {
-    const client = this.client
-    this.client = null
-    if (client !== null) {
-      try {
-        await client.close()
-      } catch {
-        /* best-effort */
+async function callViaLoopback(
+  connect: () => Promise<LoopbackClient>,
+  timeoutMs: number,
+  name: string,
+  args: Record<string, unknown>
+): Promise<CallToolResult> {
+  for (let attempt = 1; attempt <= 2; attempt++) {
+    let client: LoopbackClient | null = null
+    try {
+      client = await withTimeout(connect(), timeoutMs)
+      return await withTimeout(client.callTool(name, args), timeoutMs)
+    } catch {
+      if (attempt === 2) return appNotRunningResult()
+      // else: fall through to a second attempt with a fresh connection.
+    } finally {
+      if (client !== null) {
+        try {
+          await client.close()
+        } catch {
+          /* best-effort */
+        }
       }
     }
   }
+  return appNotRunningResult()
 }
 
 /**
  * Build + connect the shim's MCP server over the given stdio transport. Returns
- * the connected `Server` plus a `close()` that tears down both the server and any
- * live loopback client.
+ * the connected `Server` plus a `close()` that tears down the server.
  */
 export async function runShimProxy(
   deps: ShimProxyDeps
 ): Promise<{ server: Server; close: () => Promise<void> }> {
-  const session = new LoopbackSession(deps.connect, deps.timeoutMs ?? DEFAULT_ATTEMPT_TIMEOUT_MS)
+  const timeoutMs = deps.timeoutMs ?? DEFAULT_ATTEMPT_TIMEOUT_MS
   const server = new Server(
     { name: SHIM_NAME, version: SHIM_VERSION },
     { capabilities: { tools: {} } }
@@ -151,7 +138,7 @@ export async function runShimProxy(
   server.setRequestHandler(CallToolRequestSchema, (request): Promise<CallToolResult> => {
     const { name } = request.params
     const args = request.params.arguments ?? {}
-    return session.call(name, args)
+    return callViaLoopback(deps.connect, timeoutMs, name, args)
   })
 
   await server.connect(deps.transport)
@@ -159,7 +146,6 @@ export async function runShimProxy(
   return {
     server,
     close: async (): Promise<void> => {
-      await session.dispose()
       await server.close()
     },
   }

--- a/src/main/mcp-server/shim/proxy.ts
+++ b/src/main/mcp-server/shim/proxy.ts
@@ -1,0 +1,166 @@
+/**
+ * The stdio shim's proxy LOGIC (transport-agnostic + dependency-injected so it's
+ * unit-testable without spawning anything). The Copilot app spawns the shim as a
+ * stdio MCP server; this runs a low-level `Server` over that stdio transport and:
+ *
+ *   - `tools/list` → serves the bundled static manifest ALWAYS. The advertised
+ *     surface is therefore stable and never empty, even when the app is down, so
+ *     the host can't cache "no tools". Shim + server ship together, so no drift.
+ *   - `tools/call` → forwards to the loopback server. It re-reads the run files
+ *     per attempt (never caches a dead client) and, on ANY first-attempt failure
+ *     that could mean stale state (connect refused/reset, timeout, 401/403 rotated
+ *     token, 5xx startup/shutdown race, invalid/non-MCP response), disposes the
+ *     client and retries ONCE with the current token/port. Two failures → one
+ *     clean "app isn't running" result. A per-attempt timeout guarantees no hang.
+ *
+ * A tool that legitimately RETURNS `isError: true` is NOT a transport failure —
+ * it's forwarded as-is with no retry.
+ */
+
+import { Server } from '@modelcontextprotocol/sdk/server/index.js'
+import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js'
+import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js'
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
+import { TOOL_MANIFEST } from '../tool-manifest'
+
+const SHIM_NAME = 'gh-projects'
+const SHIM_VERSION = '1.0.0'
+const DEFAULT_ATTEMPT_TIMEOUT_MS = 10_000
+
+/** The minimal loopback surface the shim needs. Injected so tests can fake it. */
+export interface LoopbackClient {
+  callTool(name: string, args: Record<string, unknown>): Promise<CallToolResult>
+  close(): Promise<void>
+}
+
+export interface ShimProxyDeps {
+  /**
+   * Connect a FRESH loopback client — reads the run files and dials the loopback
+   * server. Throws when the app isn't running (no run files) or connect fails.
+   */
+  connect: () => Promise<LoopbackClient>
+  /** The stdio transport to serve MCP over (a StdioServerTransport in prod). */
+  transport: Transport
+  /** Per-attempt timeout guard (ms). Default 10s. Prevents any hang. */
+  timeoutMs?: number
+}
+
+/** The clean result surfaced when the loopback app can't be reached. */
+export function appNotRunningResult(): CallToolResult {
+  return {
+    content: [
+      {
+        type: 'text',
+        text: "The GH Projects app isn't running, so this tool is unavailable. Start GH Projects and try again.",
+      },
+    ],
+    isError: true,
+  }
+}
+
+function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('loopback attempt timed out')), ms)
+    promise.then(
+      (value) => {
+        clearTimeout(timer)
+        resolve(value)
+      },
+      (err) => {
+        clearTimeout(timer)
+        reject(err instanceof Error ? err : new Error(String(err)))
+      }
+    )
+  })
+}
+
+/**
+ * Holds the (lazily connected) loopback client and implements reread+retry-once.
+ * Every failure disposes the client so the next attempt reconnects with fresh
+ * run-file values — this is what heals app restarts and token rotation.
+ */
+class LoopbackSession {
+  private client: LoopbackClient | null = null
+
+  constructor(
+    private readonly connect: () => Promise<LoopbackClient>,
+    private readonly timeoutMs: number
+  ) {}
+
+  async call(name: string, args: Record<string, unknown>): Promise<CallToolResult> {
+    // At most two attempts total (one retry). Any connect/transport failure
+    // disposes the client and counts as a failed attempt.
+    for (let attempt = 1; attempt <= 2; attempt++) {
+      let client: LoopbackClient
+      try {
+        client = this.client ?? (await withTimeout(this.connect(), this.timeoutMs))
+        this.client = client
+      } catch {
+        this.client = null
+        if (attempt === 2) return appNotRunningResult()
+        continue
+      }
+      try {
+        return await withTimeout(client.callTool(name, args), this.timeoutMs)
+      } catch {
+        // Transport/auth/protocol failure (incl. non-2xx like 401/5xx): dispose
+        // and, on the first attempt, reconnect with fresh run-file values.
+        await this.dispose()
+        if (attempt === 2) return appNotRunningResult()
+      }
+    }
+    return appNotRunningResult()
+  }
+
+  async dispose(): Promise<void> {
+    const client = this.client
+    this.client = null
+    if (client !== null) {
+      try {
+        await client.close()
+      } catch {
+        /* best-effort */
+      }
+    }
+  }
+}
+
+/**
+ * Build + connect the shim's MCP server over the given stdio transport. Returns
+ * the connected `Server` plus a `close()` that tears down both the server and any
+ * live loopback client.
+ */
+export async function runShimProxy(
+  deps: ShimProxyDeps
+): Promise<{ server: Server; close: () => Promise<void> }> {
+  const session = new LoopbackSession(deps.connect, deps.timeoutMs ?? DEFAULT_ATTEMPT_TIMEOUT_MS)
+  const server = new Server(
+    { name: SHIM_NAME, version: SHIM_VERSION },
+    { capabilities: { tools: {} } }
+  )
+
+  server.setRequestHandler(ListToolsRequestSchema, () => ({
+    tools: TOOL_MANIFEST.map((tool) => ({
+      name: tool.name,
+      title: tool.title,
+      description: tool.description,
+      inputSchema: tool.inputSchema,
+    })),
+  }))
+
+  server.setRequestHandler(CallToolRequestSchema, (request): Promise<CallToolResult> => {
+    const { name } = request.params
+    const args = request.params.arguments ?? {}
+    return session.call(name, args)
+  })
+
+  await server.connect(deps.transport)
+
+  return {
+    server,
+    close: async (): Promise<void> => {
+      await session.dispose()
+      await server.close()
+    },
+  }
+}

--- a/src/main/mcp-server/token.test.ts
+++ b/src/main/mcp-server/token.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest'
+import { generateToken, timingSafeEqualToken } from './token'
+
+describe('generateToken', () => {
+  it('produces a 43-char base64url token (32 bytes, no padding)', () => {
+    const token = generateToken()
+    expect(token).toMatch(/^[A-Za-z0-9_-]{43}$/)
+    expect(token).not.toContain('=')
+  })
+
+  it('rotates: two calls produce different tokens', () => {
+    expect(generateToken()).not.toBe(generateToken())
+  })
+})
+
+describe('timingSafeEqualToken', () => {
+  it('returns true for identical tokens', () => {
+    const token = generateToken()
+    expect(timingSafeEqualToken(token, token)).toBe(true)
+  })
+
+  it('returns false for different tokens of equal length', () => {
+    expect(timingSafeEqualToken('a'.repeat(43), 'b'.repeat(43))).toBe(false)
+  })
+
+  it('returns false for different-length tokens without throwing', () => {
+    expect(timingSafeEqualToken('short', 'a-much-longer-token')).toBe(false)
+  })
+
+  it('returns false when one side is empty', () => {
+    expect(timingSafeEqualToken('', 'nonempty')).toBe(false)
+  })
+})

--- a/src/main/mcp-server/token.ts
+++ b/src/main/mcp-server/token.ts
@@ -1,0 +1,30 @@
+/**
+ * The rotating auth token for the inbound loopback MCP server.
+ *
+ * Dependency-free (node builtins only) so both the main process and the bundled
+ * shim can use the constant-time compare. A fresh token is generated on every app
+ * launch (see server.ts) and written to `~/.gh-projects/run/token` (mode 0600).
+ * The token is a secret: never log it.
+ */
+
+import { randomBytes, timingSafeEqual } from 'node:crypto'
+
+/**
+ * Generate a fresh auth token: 32 random bytes, base64url-encoded (43 chars, no
+ * padding, URL/header-safe). Cryptographically strong via `crypto.randomBytes`.
+ */
+export function generateToken(): string {
+  return randomBytes(32).toString('base64url')
+}
+
+/**
+ * Constant-time equality for the bearer token. Length-safe (returns false on a
+ * length mismatch without leaking timing) and never throws on non-ASCII input.
+ * Both arguments are treated as secrets.
+ */
+export function timingSafeEqualToken(a: string, b: string): boolean {
+  const bufA = Buffer.from(a, 'utf8')
+  const bufB = Buffer.from(b, 'utf8')
+  if (bufA.length !== bufB.length) return false
+  return timingSafeEqual(bufA, bufB)
+}

--- a/src/main/mcp-server/token.ts
+++ b/src/main/mcp-server/token.ts
@@ -18,9 +18,12 @@ export function generateToken(): string {
 }
 
 /**
- * Constant-time equality for the bearer token. Length-safe (returns false on a
- * length mismatch without leaking timing) and never throws on non-ASCII input.
- * Both arguments are treated as secrets.
+ * Compare the presented bearer token to the expected one. When the lengths match
+ * the comparison is constant-time (`crypto.timingSafeEqual`). A length mismatch
+ * returns early — that path is NOT constant-time, but the token length is not
+ * secret in a way that helps an attacker (a 32-byte base64url token is
+ * fixed-length), so this is an accepted trade-off. Never throws on non-ASCII
+ * input. Both arguments are treated as secrets.
  */
 export function timingSafeEqualToken(a: string, b: string): boolean {
   const bufA = Buffer.from(a, 'utf8')

--- a/src/main/mcp-server/tool-manifest.ts
+++ b/src/main/mcp-server/tool-manifest.ts
@@ -1,0 +1,49 @@
+/**
+ * The tool surface of the inbound MCP server — the single source of truth for
+ * BOTH the loopback server (which registers handlers) and the stdio shim (which
+ * serves this list statically for `tools/list`, so the advertised surface is
+ * stable and never empty even when the app is down).
+ *
+ * Deliberately dependency-free and JSON-Schema-based (no zod), so it is
+ * JSON-serializable and cheap to bundle into the shim. Because the shim ships
+ * inside the same app bundle as the server, the two can never drift.
+ *
+ * Later epic issues (#102/#100/#106/#105) add real tools by appending to
+ * `TOOL_MANIFEST` here and adding the matching handler in `tools.ts`. For the
+ * foundation there is exactly one no-op tool: `ping`.
+ */
+
+/** A JSON Schema object describing a tool's input. */
+export interface JsonSchemaObject {
+  type: 'object'
+  properties?: Record<string, unknown>
+  required?: string[]
+  additionalProperties?: boolean
+}
+
+/** A single tool's advertised metadata (the `tools/list` shape). */
+export interface ManifestTool {
+  name: string
+  title?: string
+  description: string
+  inputSchema: JsonSchemaObject
+}
+
+/** The `ping` tool: no input, exercises the surface end-to-end. */
+export const PING_TOOL_NAME = 'ping'
+
+/** The full inbound tool surface. Order is the advertised order. */
+export const TOOL_MANIFEST: readonly ManifestTool[] = [
+  {
+    name: PING_TOOL_NAME,
+    title: 'Ping',
+    description:
+      "No-op liveness check for the GH Projects inbound MCP server. Returns 'pong'.",
+    inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+  },
+]
+
+/** Lookup a manifest tool by name; undefined when not present. */
+export function findManifestTool(name: string): ManifestTool | undefined {
+  return TOOL_MANIFEST.find((tool) => tool.name === name)
+}

--- a/src/main/mcp-server/tools.test.ts
+++ b/src/main/mcp-server/tools.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest'
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { Server } from '@modelcontextprotocol/sdk/server/index.js'
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
+import { registerTools } from './tools'
+import { PING_TOOL_NAME } from './tool-manifest'
+
+/** Stand up a low-level Server with the tools registered, over an in-memory pair. */
+async function withServer(
+  getSecrets: () => readonly string[],
+  fn: (client: Client) => Promise<void>
+): Promise<void> {
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+  const server = new Server({ name: 'test', version: '1.0.0' }, { capabilities: { tools: {} } })
+  registerTools(server, { getSecrets })
+  await server.connect(serverTransport)
+  const client = new Client({ name: 'test', version: '1.0.0' }, { capabilities: {} })
+  await client.connect(clientTransport)
+  try {
+    await fn(client)
+  } finally {
+    await client.close()
+    await server.close()
+  }
+}
+
+describe('registerTools', () => {
+  it('advertises the ping tool via tools/list', async () => {
+    await withServer(
+      () => [],
+      async (client) => {
+        const { tools } = await client.listTools()
+        const ping = tools.find((t) => t.name === PING_TOOL_NAME)
+        expect(ping).toBeDefined()
+        expect(ping?.inputSchema.type).toBe('object')
+      }
+    )
+  })
+
+  it('ping returns pong', async () => {
+    await withServer(
+      () => [],
+      async (client) => {
+        const result = (await client.callTool({ name: PING_TOOL_NAME })) as CallToolResult
+        expect(result.content).toEqual([{ type: 'text', text: 'pong' }])
+      }
+    )
+  })
+
+  it('returns an isError result for an unknown tool', async () => {
+    await withServer(
+      () => [],
+      async (client) => {
+        const result = (await client.callTool({ name: 'does-not-exist' })) as CallToolResult
+        expect(result.isError).toBe(true)
+      }
+    )
+  })
+})

--- a/src/main/mcp-server/tools.ts
+++ b/src/main/mcp-server/tools.ts
@@ -1,0 +1,63 @@
+/**
+ * Wires the tool manifest to a low-level MCP `Server`: registers the `tools/list`
+ * and `tools/call` request handlers. This is the ONE place tools are registered;
+ * later epic issues add tools by extending `tool-manifest.ts` + the handler map
+ * here.
+ *
+ * `tools/list` is served straight from `TOOL_MANIFEST` (the same source the shim
+ * uses), so the advertised surface can't drift. `tools/call` output is scrubbed
+ * through `sanitizeMcpJson` as defense-in-depth before it leaves the process.
+ */
+
+import type { Server } from '@modelcontextprotocol/sdk/server/index.js'
+import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js'
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
+import { PING_TOOL_NAME, TOOL_MANIFEST } from './tool-manifest'
+import { sanitizeMcpJson } from './sanitize'
+
+/** Dependencies a tool handler may need. */
+export interface ToolDeps {
+  /**
+   * The current set of secret strings to scrub from tool output (rotating token,
+   * GitHub PAT, …). Read lazily so a rotated token is always current.
+   */
+  getSecrets: () => readonly string[]
+}
+
+/** A tool handler: validated args in, an MCP `CallToolResult` out. */
+export type ToolHandler = (
+  args: Record<string, unknown>
+) => CallToolResult | Promise<CallToolResult>
+
+/** Build the name → handler map. Foundation surface: just `ping`. */
+export function buildToolHandlers(_deps: ToolDeps): Map<string, ToolHandler> {
+  const handlers = new Map<string, ToolHandler>()
+  handlers.set(PING_TOOL_NAME, () => ({ content: [{ type: 'text', text: 'pong' }] }))
+  return handlers
+}
+
+/** Register `tools/list` + `tools/call` on `server`, driven by the manifest. */
+export function registerTools(server: Server, deps: ToolDeps): void {
+  const handlers = buildToolHandlers(deps)
+
+  server.setRequestHandler(ListToolsRequestSchema, () => ({
+    tools: TOOL_MANIFEST.map((tool) => ({
+      name: tool.name,
+      title: tool.title,
+      description: tool.description,
+      inputSchema: tool.inputSchema,
+    })),
+  }))
+
+  server.setRequestHandler(CallToolRequestSchema, async (request): Promise<CallToolResult> => {
+    const { name } = request.params
+    const args = request.params.arguments ?? {}
+    const handler = handlers.get(name)
+    if (handler === undefined) {
+      return { content: [{ type: 'text', text: `Unknown tool: ${name}` }], isError: true }
+    }
+    const result = await handler(args)
+    // Defense-in-depth: scrub any known secret that slipped into the output.
+    return sanitizeMcpJson(result, deps.getSecrets()) as CallToolResult
+  })
+}

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -890,6 +890,19 @@ export type IpcChannels = {
     result: void
   }
 
+  /** Reads whether the inbound MCP server is enabled (default true). */
+  'settings:get-mcp-server-enabled': {
+    args: []
+    result: boolean
+  }
+
+  /** Enables/disables the inbound MCP server (starts/stops loopback + mcp.json). */
+  'settings:set-mcp-server-enabled': {
+    args: [enabled: boolean]
+    result: void
+  }
+
+
   // ── Focus: re-entry digest + drift ───────────────────────────────────────────
 
   /** Computes the blame-free "since you were here" digest for a project. */


### PR DESCRIPTION
Closes #103. Part of the epic in #98 - this is the transport foundation the rest (#102, #100, #106, #105) builds on. Branched off `main` after #99 landed.

## What this does

Stands up **one** inbound MCP server the Copilot app can call. Copilot's `~/.mcp.json` is static but our port + token are dynamic, so I used a **stdio shim -> loopback** design that mirrors the outbound `src/main/agent/copilot-app/` adapter in reverse. The whole seam lives behind one dir, `src/main/mcp-server/`, so the protocol can only break in one place.

- **Loopback server** in the Electron main process, bound to `127.0.0.1:<ephemeral>`, serving MCP over the SDK's Streamable HTTP server transport.
- **Rotating per-launch token + port** written to `~/.gh-projects/run/{token,port}` (0600 files, 0700 dir, atomic temp+rename, published only after `listen()`). Cleaned up on quit.
- **stdio shim** - a self-contained bundle registered once in `~/.mcp.json`. It reads the run files, dials the loopback, and proxies MCP both ways. When the app is down it still lists tools and returns a clean "app isn't running" error - it never hangs.
- **Tool registry** with a no-op `ping` tool so the surface is exercisable now. Later issues add real tools by extending one manifest.
- **App-managed `~/.mcp.json`** - idempotent, marker-gated, atomic.

## Why Streamable HTTP, not WebSocket

The outbound path uses WS because that's what the Copilot app exposes - we don't control it. Here we own both ends. The `@modelcontextprotocol/sdk` ships a first-class **server** transport for Streamable HTTP but **none** for WebSocket (only a `WebSocketClientTransport`), so WS would mean hand-rolling MCP-over-WS server framing. Reusing the SDK's supported transport keeps the protocol in one seam and fits header bearer auth + Origin/Host gating naturally.

## Design decisions worth calling out

- **Stateless per-request.** One local consumer doing tool calls needs no session state. Each `POST /mcp` builds a fresh SDK `Server` + transport (`sessionIdGenerator: undefined`, `enableJsonResponse`), handles the one request, and tears down. No session map / GET-SSE / DELETE lifecycle.
- **Shim serves `tools/list` from a bundled static manifest** (same source the server uses), so the advertised surface is stable and never empty even when the app is down - the host can't cache "no tools". Only `tools/call` forwards to the loopback.
- **Shim self-heals.** `tools/call` re-reads the run files per attempt, connects a fresh client, and on any thrown failure (connect refused/reset, timeout, 401/403 rotated token, 5xx startup race, invalid response) retries once with the current token/port. A resolved `isError: true` is a legit tool response and is forwarded without retry.
- **Shim ships UNPACKED** (`build/mcp-shim.cjs` as an `extraResource`) and runs via `process.execPath` + `ELECTRON_RUN_AS_NODE=1` - no dependency on system node/bun and no asar-script-execution.

## Security model

1. `POST /mcp` only.
2. `Host` must equal `127.0.0.1:<port>` (DNS-rebinding defense).
3. Loopback remote address only.
4. Reject any request carrying an `Origin` header (browsers send one; the shim via Node fetch doesn't) - reuses the outbound-WS non-browser gate.
5. Rotating bearer token, constant-time compare - the real boundary.
6. Body-size cap before parsing.
7. `sanitizeMcpText`/`sanitizeMcpJson` scrub the token + PAT from tool output as defense-in-depth.

Run files are 0600; the token is never logged.

## How I verified

`bun run test` (typecheck + eslint + **489 vitest tests**) is green. Specifically:

- **Unit:** run-file write/read/roundtrip/0600/cleanup/malformed; token format + rotation + constant-time compare; the full security gate (method/path, Host, loopback, Origin, bearer, body cap); sanitize (token/PAT redaction, key + value, depth cap); mcp.json (idempotent enable, marker-gated disable, preserves other servers, refuses to clobber unmanaged/invalid/array shapes); the tool registry; and the shim proxy (app-down still lists `ping` + clean call error, happy-path forward, reread+retry-once self-heal across connect/timeout/401/5xx/invalid-response, two-failures→one clean error, per-attempt timeout so it never hangs, concurrent-call isolation).
- **Lifecycle serialization** (mocked electron): two concurrent enables start the server once; a shutdown queued during an in-flight start still closes it (no orphan); enable→shutdown leaves nothing running.
- **Real integration** (`server.integration.test.ts`): a **real** `@modelcontextprotocol/sdk` client over `StreamableHTTPClientTransport` against the **real** loopback server - `initialize` advertises the tools capability, separate `list` + `call` POSTs succeed (proving stateless per-request), the token rotates per launch, and 401 (bad/missing token) / 403 (Origin present, bad Host) / 404 (wrong path) all reject.
- **Electron-as-Node e2e** (`shim/entry.e2e.test.ts`): the `bun`-built shim spawned by the **real Electron binary** with `ELECTRON_RUN_AS_NODE=1` (the exact strategy the generated `~/.mcp.json` uses), driven by a stdio SDK client - `list` + `call` flow shim -> loopback -> back, and with the server **down** the shim still lists `ping` and returns a clean call error. Skips if the Electron binary is absent (keeps CI green); `MCP_SHIM_E2E_REQUIRE=1` makes it a hard failure for a release gate.
- Full `electron-vite build` succeeds; the main bundle does not import the shim, and the shim bundle does not import electron/sqlite (verified).

### Honest gap

The one thing NOT automated here is the **real Copilot desktop app** spawning the shim from its own `~/.mcp.json` in a packaged/signed bundle - there's no Copilot host or packaging step in this environment. Everything up to and including a real stdio MCP client driving the real shim subprocess (via the real Electron-as-Node spawn strategy) -> real loopback server **is** exercised, so the only unproven link is Copilot itself doing the spawn.

## Review

The plan and the implementation were both reviewed independently by GPT-5.5 across several rounds (transport choice, lifecycle races, run-file publication failure, mcp.json write safety, shim concurrency) until it returned no remaining blockers.