### PR TITLE
add_todo MCP tool + action-proposal todo model (#102)

### DIFF
--- a/db/migrations/020_agent_todos.sql
+++ b/db/migrations/020_agent_todos.sql
@@ -46,10 +46,20 @@ INSERT INTO project_todos_new
 DROP TABLE project_todos;
 ALTER TABLE project_todos_new RENAME TO project_todos;
 
--- Restore the high-water mark (max of the new table's own value and the backed-up one).
-UPDATE sqlite_sequence
-  SET seq = MAX(seq, COALESCE((SELECT seq FROM _todo_seq_backup), 0))
-  WHERE name = 'project_todos';
+-- Restore the AUTOINCREMENT high-water mark robustly. The rebuilt table only gets a
+-- sqlite_sequence row if rows were copied, and SQLite drops the old row on DROP TABLE, so a
+-- plain UPDATE would no-op (silently losing the mark) when the table was empty but had a higher
+-- seq from previously-deleted rows. Re-insert the max of the copied rows and the backed-up seq
+-- so ids are never reused.
+DELETE FROM sqlite_sequence WHERE name = 'project_todos';
+INSERT INTO sqlite_sequence (name, seq)
+  VALUES (
+    'project_todos',
+    MAX(
+      COALESCE((SELECT MAX(id) FROM project_todos), 0),
+      COALESCE((SELECT seq FROM _todo_seq_backup), 0)
+    )
+  );
 
 DROP TABLE _todo_seq_backup;
 

--- a/db/migrations/020_agent_todos.sql
+++ b/db/migrations/020_agent_todos.sql
@@ -1,0 +1,66 @@
+-- Migration: 020_agent_todos.sql
+-- #102: enrich project_todos so Copilot (the inbound MCP server) can create rich,
+-- human-gated "action proposal" todos, and so a todo can sit in the Inbox (no
+-- project) when its repo doesn't resolve to one.
+--
+-- SQLite cannot relax a NOT NULL constraint in place, and we need project_id to be
+-- NULLABLE (NULL = Inbox surface). So we rebuild project_todos, preserving ids so the
+-- dependent FK (todo_copilot_app_sessions.todo_id -> project_todos(id)) stays valid.
+--
+-- foreign_keys MUST be OFF around the DROP: with it ON, dropping the parent performs an
+-- implicit DELETE that cascades and would wipe todo_copilot_app_sessions. PRAGMA
+-- foreign_keys is a no-op inside a transaction, so we toggle it OUTSIDE the tx and do the
+-- swap INSIDE BEGIN..COMMIT for atomicity. New columns are additive with back-compat
+-- defaults: existing rows keep their ids/project_id, get origin='user', and NULL for the
+-- new fields.
+
+PRAGMA foreign_keys=OFF;
+
+BEGIN IMMEDIATE;
+
+-- Preserve the AUTOINCREMENT high-water mark so ids are never reused after the rebuild.
+CREATE TEMP TABLE _todo_seq_backup AS
+  SELECT seq FROM sqlite_sequence WHERE name = 'project_todos';
+
+CREATE TABLE project_todos_new (
+  id               INTEGER PRIMARY KEY AUTOINCREMENT,
+  project_id       INTEGER REFERENCES projects(id) ON DELETE CASCADE,  -- NULLABLE: NULL = Inbox
+  text             TEXT    NOT NULL,
+  done             INTEGER NOT NULL DEFAULT 0,
+  sort_order       INTEGER NOT NULL DEFAULT 0,
+  created_at       TEXT    NOT NULL DEFAULT (datetime('now')),
+  deleted_at       TEXT,
+  title            TEXT,
+  body             TEXT,
+  source_url       TEXT,
+  suggested_action TEXT,   -- JSON-encoded SuggestedAction, or NULL
+  origin           TEXT    NOT NULL DEFAULT 'user' CHECK(origin IN ('user', 'copilot')),
+  idempotency_key  TEXT
+);
+
+INSERT INTO project_todos_new
+  (id, project_id, text, done, sort_order, created_at, deleted_at)
+  SELECT id, project_id, text, done, sort_order, created_at, deleted_at
+  FROM project_todos;
+
+DROP TABLE project_todos;
+ALTER TABLE project_todos_new RENAME TO project_todos;
+
+-- Restore the high-water mark (max of the new table's own value and the backed-up one).
+UPDATE sqlite_sequence
+  SET seq = MAX(seq, COALESCE((SELECT seq FROM _todo_seq_backup), 0))
+  WHERE name = 'project_todos';
+
+DROP TABLE _todo_seq_backup;
+
+-- Enforce one agent todo per idempotency key while allowing unlimited NULL keys
+-- (every user todo has a NULL key).
+CREATE UNIQUE INDEX idx_project_todos_idempotency
+  ON project_todos(idempotency_key) WHERE idempotency_key IS NOT NULL;
+
+-- Speed up per-project loads and the Inbox (project_id IS NULL) query.
+CREATE INDEX idx_project_todos_project ON project_todos(project_id);
+
+COMMIT;
+
+PRAGMA foreign_keys=ON;

--- a/src/main/db/migrate.integration.test.ts
+++ b/src/main/db/migrate.integration.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi } from 'vitest'
 import { Database } from 'bun:sqlite'
+import { readdirSync, readFileSync } from 'fs'
+import { join } from 'path'
 import type BetterSQLite3 from 'better-sqlite3'
 
 // Provide a fake electron app so getMigrationsDir() resolves to the real
@@ -113,5 +115,83 @@ describe('runMigrations', () => {
     db.prepare("UPDATE projects SET last_focused_at = strftime('%Y-%m-%dT%H:%M:%fZ','now') WHERE last_focused_at IS NULL").run()
     const row = db.prepare('SELECT last_focused_at FROM projects LIMIT 1').get() as { last_focused_at: string | null }
     expect(row.last_focused_at).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+  })
+})
+
+// ── 020: project_todos rebuild (#102) ─────────────────────────────────────────
+
+/** Apply every migration whose filename sorts before `before`, mimicking the real runner. */
+function applyMigrationsBefore(db: BetterSQLite3.Database, before: string): void {
+  const dir = join(process.cwd(), 'db', 'migrations')
+  const files = readdirSync(dir)
+    .filter((f) => f.endsWith('.sql') && f < before)
+    .sort()
+  for (const f of files) {
+    const sql = readFileSync(join(dir, f), 'utf8')
+    if (sql.replace(/--[^\n]*/g, '').trim()) db.exec(sql)
+  }
+}
+
+function apply020(db: BetterSQLite3.Database): void {
+  const sql = readFileSync(join(process.cwd(), 'db', 'migrations', '020_agent_todos.sql'), 'utf8')
+  db.exec(sql)
+}
+
+describe('020_agent_todos migration (back-compat)', () => {
+  it('preserves existing todos, their ids, and app-session links; defaults new fields', () => {
+    const db = freshDb()
+    applyMigrationsBefore(db, '020_agent_todos.sql')
+
+    db.prepare("INSERT INTO projects (name) VALUES ('Legacy')").run()
+    db.prepare("INSERT INTO project_todos (id, project_id, text, done, sort_order) VALUES (1, 1, 'active', 0, 0)").run()
+    db.prepare("INSERT INTO project_todos (id, project_id, text, done, sort_order) VALUES (2, 1, 'finished', 1, 1)").run()
+    db.prepare("INSERT INTO project_todos (id, project_id, text, sort_order, deleted_at) VALUES (3, 1, 'dismissed', 2, '2024-01-01T00:00:00Z')").run()
+    // A delegated app session linked to todo #1 — the dependent FK that the rebuild must not wipe.
+    db.prepare("INSERT INTO copilot_app_sessions (id, project_id, cwd, title) VALUES ('sess1', 1, '/tmp', 'work')").run()
+    db.prepare("INSERT INTO todo_copilot_app_sessions (todo_id, session_id) VALUES (1, 'sess1')").run()
+
+    apply020(db)
+
+    // Rows + ids preserved, with sensible new-field defaults.
+    const rows = db
+      .prepare('SELECT id, project_id, text, done, origin, title, idempotency_key, deleted_at FROM project_todos ORDER BY id')
+      .all() as Array<{ id: number; project_id: number | null; text: string; done: number; origin: string; title: string | null; idempotency_key: string | null; deleted_at: string | null }>
+    expect(rows.map((r) => r.id)).toEqual([1, 2, 3])
+    expect(rows.every((r) => r.origin === 'user')).toBe(true)
+    expect(rows.every((r) => r.title === null && r.idempotency_key === null)).toBe(true)
+    expect(rows[1].done).toBe(1) // completion preserved
+    expect(rows[2].deleted_at).toBe('2024-01-01T00:00:00Z') // soft-delete preserved
+
+    // The app-session link still resolves through the rebuilt table.
+    const link = db
+      .prepare(
+        `SELECT pt.text AS text FROM todo_copilot_app_sessions t
+         JOIN project_todos pt ON pt.id = t.todo_id WHERE t.session_id = 'sess1'`
+      )
+      .get() as { text: string } | undefined
+    expect(link?.text).toBe('active')
+
+    // No FK violations were introduced by the rebuild.
+    expect(db.prepare('PRAGMA foreign_key_check').all()).toEqual([])
+
+    // project_id is now nullable (the Inbox surface).
+    expect(() =>
+      db.prepare("INSERT INTO project_todos (project_id, text, origin) VALUES (NULL, 'inbox', 'copilot')").run()
+    ).not.toThrow()
+  })
+
+  it('enforces one non-null idempotency_key while allowing many null keys', () => {
+    const db = freshDb()
+    runMigrations(db)
+    db.prepare("INSERT INTO projects (name) VALUES ('P')").run()
+    db.prepare("INSERT INTO project_todos (project_id, text, origin, idempotency_key) VALUES (1, 'a', 'copilot', 'k1')").run()
+    expect(() =>
+      db.prepare("INSERT INTO project_todos (project_id, text, origin, idempotency_key) VALUES (1, 'b', 'copilot', 'k1')").run()
+    ).toThrow()
+    // Many user todos with a NULL key coexist fine.
+    db.prepare("INSERT INTO project_todos (project_id, text) VALUES (1, 'x')").run()
+    db.prepare("INSERT INTO project_todos (project_id, text) VALUES (1, 'y')").run()
+    const n = (db.prepare('SELECT COUNT(*) AS n FROM project_todos WHERE idempotency_key IS NULL').get() as { n: number }).n
+    expect(n).toBe(2)
   })
 })

--- a/src/main/db/migrate.integration.test.ts
+++ b/src/main/db/migrate.integration.test.ts
@@ -194,4 +194,23 @@ describe('020_agent_todos migration (back-compat)', () => {
     const n = (db.prepare('SELECT COUNT(*) AS n FROM project_todos WHERE idempotency_key IS NULL').get() as { n: number }).n
     expect(n).toBe(2)
   })
+
+  it('does not reuse ids when the table was empty-but-previously-used at migration time', () => {
+    const db = freshDb()
+    applyMigrationsBefore(db, '020_agent_todos.sql')
+    db.prepare("INSERT INTO projects (name) VALUES ('P')").run()
+    // Bump the AUTOINCREMENT high-water to 5, then hard-delete so the table is empty but
+    // sqlite_sequence still holds 5 (simulates a prior cascade/hard delete).
+    db.prepare("INSERT INTO project_todos (id, project_id, text) VALUES (5, 1, 'gone')").run()
+    db.prepare('DELETE FROM project_todos').run()
+    expect((db.prepare("SELECT seq FROM sqlite_sequence WHERE name='project_todos'").get() as { seq: number }).seq).toBe(5)
+
+    apply020(db)
+
+    // The high-water must survive the rebuild, so the next id is 6 (not a reused 1..5).
+    const row = db
+      .prepare("INSERT INTO project_todos (project_id, text) VALUES (1, 'fresh') RETURNING id")
+      .get() as { id: number }
+    expect(row.id).toBe(6)
+  })
 })

--- a/src/main/db/migrate.ts
+++ b/src/main/db/migrate.ts
@@ -36,7 +36,26 @@ export function runMigrations(db: Database.Database): void {
       // Strip SQL comments and skip files that contain no actual statements
       const strippedSql = sql.replace(/--[^\n]*/g, '').trim()
       if (strippedSql) {
-        db.exec(sql)
+        try {
+          db.exec(sql)
+        } catch (err) {
+          // A migration may open an explicit transaction (e.g. a table rebuild that
+          // toggles PRAGMA foreign_keys). If it throws mid-way, better-sqlite3 leaves
+          // that transaction open and can leave foreign_keys OFF. Roll back and restore
+          // FK enforcement before rethrowing so startup aborts from a clean connection
+          // state — nothing is recorded in _migrations, so the next launch retries.
+          try {
+            db.exec('ROLLBACK')
+          } catch {
+            // No transaction was open — nothing to roll back.
+          }
+          try {
+            db.exec('PRAGMA foreign_keys = ON')
+          } catch {
+            // Best effort; the throw below is what matters.
+          }
+          throw err
+        }
       }
       db.prepare('INSERT INTO _migrations (filename) VALUES (?)').run(file)
       console.log(`[db] Applied migration: ${file}`)

--- a/src/main/db/projects.integration.test.ts
+++ b/src/main/db/projects.integration.test.ts
@@ -358,6 +358,18 @@ describe('addAgentTodo', () => {
     restoreTodo(created.todo.id)
     expect(getProject(p.id).todos.map((t) => t.id)).toContain(created.todo.id)
   })
+
+  it('never touches a non-copilot todo that carries a stray idempotency_key', () => {
+    const a = createProject('Guarded')
+    getDb()
+      .prepare("INSERT INTO project_todos (project_id, text, origin, idempotency_key) VALUES (?, 'user note', 'user', 'shared')")
+      .run(a.id)
+    // The lookup is origin-scoped, so this falls through to INSERT and the unique index rejects it.
+    expect(() => addAgentTodo(base({ resolvedProjectId: a.id, idempotencyKey: 'shared', title: 'hijack' }))).toThrow()
+    const row = getDb().prepare("SELECT text, origin FROM project_todos WHERE idempotency_key = 'shared'").get() as { text: string; origin: string }
+    expect(row.text).toBe('user note') // untouched
+    expect(row.origin).toBe('user')
+  })
 })
 
 describe('listInboxTodos', () => {
@@ -370,6 +382,13 @@ describe('listInboxTodos', () => {
     const ids = listInboxTodos().map((t) => t.id)
     expect(ids).toContain(inbox.todo.id)
     expect(ids).not.toContain(dismissed.todo.id)
+  })
+
+  it('excludes non-copilot project-less todos (agent-todo surface only)', () => {
+    getDb().prepare("INSERT INTO project_todos (project_id, text, origin) VALUES (NULL, 'stray user', 'user')").run()
+    const agent = addAgentTodo(base({ title: 'agent inbox' }))
+    expect(listInboxTodos().map((t) => t.id)).toContain(agent.todo.id)
+    expect(listInboxTodos().every((t) => t.origin === 'copilot')).toBe(true)
   })
 })
 

--- a/src/main/db/projects.integration.test.ts
+++ b/src/main/db/projects.integration.test.ts
@@ -20,6 +20,11 @@ import {
   wakeExpiredSnoozes,
   createTodo,
   createLink,
+  addAgentTodo,
+  listInboxTodos,
+  getProjectNameById,
+  deleteTodo,
+  restoreTodo,
 } from './projects'
 
 // ── Setup ─────────────────────────────────────────────────────────────────────
@@ -229,5 +234,136 @@ describe('wakeExpiredSnoozes', () => {
     snoozeProject(p.id, 'notification')
     wakeExpiredSnoozes()
     expect(getProject(p.id).status).toBe('snoozed')
+  })
+})
+
+// ── addAgentTodo / listInboxTodos (#102) ──────────────────────────────────────
+
+function base(overrides: Partial<Parameters<typeof addAgentTodo>[0]> = {}): Parameters<typeof addAgentTodo>[0] {
+  return {
+    resolvedProjectId: null,
+    explicitPlacement: false,
+    title: 'Approve PR',
+    body: null,
+    sourceUrl: null,
+    suggestedAction: null,
+    idempotencyKey: null,
+    ...overrides,
+  }
+}
+
+describe('addAgentTodo', () => {
+  it('creates a copilot-origin todo on the resolved project', () => {
+    const p = createProject('Alpha')
+    const { todo, status } = addAgentTodo(base({ resolvedProjectId: p.id, title: 'Do it', body: 'details' }))
+    expect(status).toBe('created')
+    expect(todo.origin).toBe('copilot')
+    expect(todo.projectId).toBe(p.id)
+    expect(todo.text).toBe('Do it') // text mirrors the title for back-compat renderers
+    expect(todo.title).toBe('Do it')
+    expect(todo.body).toBe('details')
+    expect(getProject(p.id).todos).toHaveLength(1)
+  })
+
+  it('lands in the Inbox (null project) when resolvedProjectId is null', () => {
+    const { todo } = addAgentTodo(base({ title: 'Unrouted' }))
+    expect(todo.projectId).toBeNull()
+    expect(listInboxTodos().map((t) => t.id)).toContain(todo.id)
+  })
+
+  it('is idempotent on the key — a repeat updates instead of duplicating', () => {
+    const p = createProject('Beta')
+    const first = addAgentTodo(base({ resolvedProjectId: p.id, title: 'v1', idempotencyKey: 'k1' }))
+    expect(first.status).toBe('created')
+    const second = addAgentTodo(base({ resolvedProjectId: p.id, title: 'v2 refined', idempotencyKey: 'k1' }))
+    expect(second.status).toBe('updated')
+    expect(second.todo.id).toBe(first.todo.id)
+    expect(second.todo.title).toBe('v2 refined')
+    expect(getProject(p.id).todos).toHaveLength(1)
+  })
+
+  it('a null idempotency key always inserts (no dedup)', () => {
+    const p = createProject('Gamma')
+    addAgentTodo(base({ resolvedProjectId: p.id, title: 'a' }))
+    addAgentTodo(base({ resolvedProjectId: p.id, title: 'b' }))
+    expect(getProject(p.id).todos).toHaveLength(2)
+  })
+
+  it('stores and round-trips the suggested action', () => {
+    const p = createProject('Delta')
+    const action = { kind: 'pr_comment' as const, url: 'https://example.com/pr/1', comment: 'nice' }
+    const { todo } = addAgentTodo(base({ resolvedProjectId: p.id, suggestedAction: action, sourceUrl: 'https://example.com/pr/1', idempotencyKey: 'k' }))
+    expect(getProject(p.id).todos[0].suggestedAction).toEqual(action)
+    expect(todo.sourceUrl).toBe('https://example.com/pr/1')
+  })
+
+  it('explicit placement MOVES an existing todo on the conflict', () => {
+    const a = createProject('Home')
+    const b = createProject('Elsewhere')
+    const first = addAgentTodo(base({ resolvedProjectId: a.id, idempotencyKey: 'k1' }))
+    const second = addAgentTodo(base({ resolvedProjectId: b.id, explicitPlacement: true, idempotencyKey: 'k1' }))
+    expect(second.todo.id).toBe(first.todo.id)
+    expect(second.todo.projectId).toBe(b.id)
+  })
+
+  it('non-explicit re-resolution leaves placement STICKY', () => {
+    const a = createProject('Sticky')
+    const b = createProject('Other')
+    const first = addAgentTodo(base({ resolvedProjectId: a.id, idempotencyKey: 'k1' }))
+    const second = addAgentTodo(base({ resolvedProjectId: b.id, explicitPlacement: false, idempotencyKey: 'k1' }))
+    expect(second.todo.id).toBe(first.todo.id)
+    expect(second.todo.projectId).toBe(a.id) // did not move
+  })
+
+  it('moves a todo off a now-soft-deleted project on a non-explicit update', () => {
+    const dead = createProject('Dead')
+    const first = addAgentTodo(base({ resolvedProjectId: dead.id, idempotencyKey: 'k1' }))
+    deleteProject(dead.id) // soft-delete
+    const second = addAgentTodo(base({ resolvedProjectId: null, explicitPlacement: false, idempotencyKey: 'k1' }))
+    expect(second.todo.id).toBe(first.todo.id)
+    expect(second.todo.projectId).toBeNull() // rehomed to the Inbox
+  })
+
+  it('preserves done + reports updated_completed on a re-propose', () => {
+    const p = createProject('Complete')
+    const created = addAgentTodo(base({ resolvedProjectId: p.id, idempotencyKey: 'c1' }))
+    // Mark it done at the DB level via the same table the app uses.
+    getDb().prepare('UPDATE project_todos SET done = 1 WHERE id = ?').run(created.todo.id)
+    const again = addAgentTodo(base({ resolvedProjectId: p.id, title: 'still relevant', idempotencyKey: 'c1' }))
+    expect(again.status).toBe('updated_completed')
+    expect(again.todo.done).toBe(true) // stayed done
+    expect(again.todo.title).toBe('still relevant') // content still refreshed
+  })
+
+  it('preserves deleted_at + reports updated_dismissed on a re-propose', () => {
+    const p = createProject('Dismissed')
+    const created = addAgentTodo(base({ resolvedProjectId: p.id, idempotencyKey: 'd1' }))
+    deleteTodo(created.todo.id) // soft-delete = dismiss
+    const again = addAgentTodo(base({ resolvedProjectId: p.id, idempotencyKey: 'd1' }))
+    expect(again.status).toBe('updated_dismissed')
+    // A restore brings the refreshed todo back.
+    restoreTodo(created.todo.id)
+    expect(getProject(p.id).todos.map((t) => t.id)).toContain(created.todo.id)
+  })
+})
+
+describe('listInboxTodos', () => {
+  it('returns only project-less, non-deleted todos', () => {
+    const p = createProject('WithTodos')
+    createTodo(p.id, 'project todo')
+    const inbox = addAgentTodo(base({ title: 'inbox todo' }))
+    const dismissed = addAgentTodo(base({ title: 'dismissed', idempotencyKey: 'x' }))
+    deleteTodo(dismissed.todo.id)
+    const ids = listInboxTodos().map((t) => t.id)
+    expect(ids).toContain(inbox.todo.id)
+    expect(ids).not.toContain(dismissed.todo.id)
+  })
+})
+
+describe('getProjectNameById', () => {
+  it('returns the name for a live project and null when missing', () => {
+    const p = createProject('Named')
+    expect(getProjectNameById(p.id)).toBe('Named')
+    expect(getProjectNameById(999999)).toBeNull()
   })
 })

--- a/src/main/db/projects.integration.test.ts
+++ b/src/main/db/projects.integration.test.ts
@@ -315,6 +315,19 @@ describe('addAgentTodo', () => {
     expect(second.todo.projectId).toBe(a.id) // did not move
   })
 
+  it('appends (recomputes sort_order) when a todo moves buckets', () => {
+    const a = createProject('From')
+    const b = createProject('To')
+    // Fill B with two todos so its max sort_order is 1.
+    createTodo(b.id, 'b0')
+    createTodo(b.id, 'b1')
+    const moved = addAgentTodo(base({ resolvedProjectId: a.id, idempotencyKey: 'k1' }))
+    expect(moved.todo.sortOrder).toBe(0) // first in A
+    const after = addAgentTodo(base({ resolvedProjectId: b.id, explicitPlacement: true, idempotencyKey: 'k1' }))
+    expect(after.todo.projectId).toBe(b.id)
+    expect(after.todo.sortOrder).toBe(2) // appended after B's 0 and 1, not left at 0
+  })
+
   it('moves a todo off a now-soft-deleted project on a non-explicit update', () => {
     const dead = createProject('Dead')
     const first = addAgentTodo(base({ resolvedProjectId: dead.id, idempotencyKey: 'k1' }))

--- a/src/main/db/projects.test.ts
+++ b/src/main/db/projects.test.ts
@@ -93,10 +93,20 @@ describe('toProject', () => {
 // ── toTodo ────────────────────────────────────────────────────────────────────
 
 describe('toTodo', () => {
+  const baseRow = {
+    deleted_at: null as string | null,
+    title: null as string | null,
+    body: null as string | null,
+    source_url: null as string | null,
+    suggested_action: null as string | null,
+    origin: 'user',
+    idempotency_key: null as string | null,
+  }
+
   it('maps all fields', () => {
     const row = {
-      id: 5, project_id: 1, text: 'Do something', done: 0 as number,
-      sort_order: 2, created_at: '2024-01-01T00:00:00Z',
+      id: 5, project_id: 1 as number | null, text: 'Do something', done: 0 as number,
+      sort_order: 2, created_at: '2024-01-01T00:00:00Z', ...baseRow,
     }
     expect(toTodo(row)).toEqual({
       id: 5,
@@ -105,16 +115,46 @@ describe('toTodo', () => {
       done: false,
       sortOrder: 2,
       createdAt: '2024-01-01T00:00:00Z',
+      title: null,
+      body: null,
+      sourceUrl: null,
+      suggestedAction: null,
+      origin: 'user',
+      idempotencyKey: null,
     })
   })
 
+  it('maps agent-todo fields and parses suggested_action JSON', () => {
+    const row = {
+      id: 9, project_id: null as number | null, text: 'Approve PR', done: 0 as number,
+      sort_order: 0, created_at: '', ...baseRow,
+      title: 'Approve PR', body: 'Looks good', source_url: 'https://example.com/pr/1',
+      suggested_action: JSON.stringify({ kind: 'open_url', url: 'https://example.com/pr/1' }),
+      origin: 'copilot', idempotency_key: 'abc',
+    }
+    const todo = toTodo(row)
+    expect(todo.projectId).toBeNull()
+    expect(todo.origin).toBe('copilot')
+    expect(todo.title).toBe('Approve PR')
+    expect(todo.suggestedAction).toEqual({ kind: 'open_url', url: 'https://example.com/pr/1' })
+    expect(todo.idempotencyKey).toBe('abc')
+  })
+
+  it('degrades a corrupt suggested_action blob to null', () => {
+    const row = {
+      id: 1, project_id: 1 as number | null, text: 'T', done: 0 as number, sort_order: 0,
+      created_at: '', ...baseRow, suggested_action: '{not json',
+    }
+    expect(toTodo(row).suggestedAction).toBeNull()
+  })
+
   it('converts done integer 1 to boolean true', () => {
-    const row = { id: 1, project_id: 1, text: 'T', done: 1 as number, sort_order: 0, created_at: '' }
+    const row = { id: 1, project_id: 1 as number | null, text: 'T', done: 1 as number, sort_order: 0, created_at: '', ...baseRow }
     expect(toTodo(row).done).toBe(true)
   })
 
   it('converts done integer 0 to boolean false', () => {
-    const row = { id: 1, project_id: 1, text: 'T', done: 0 as number, sort_order: 0, created_at: '' }
+    const row = { id: 1, project_id: 1 as number | null, text: 'T', done: 0 as number, sort_order: 0, created_at: '', ...baseRow }
     expect(toTodo(row).done).toBe(false)
   })
 })

--- a/src/main/db/projects.test.ts
+++ b/src/main/db/projects.test.ts
@@ -140,12 +140,18 @@ describe('toTodo', () => {
     expect(todo.idempotencyKey).toBe('abc')
   })
 
-  it('degrades a corrupt suggested_action blob to null', () => {
-    const row = {
-      id: 1, project_id: 1 as number | null, text: 'T', done: 0 as number, sort_order: 0,
-      created_at: '', ...baseRow, suggested_action: '{not json',
-    }
-    expect(toTodo(row).suggestedAction).toBeNull()
+  it('degrades a corrupt or partial suggested_action blob to null', () => {
+    const mk = (blob: string): ReturnType<typeof toTodo>['suggestedAction'] =>
+      toTodo({
+        id: 1, project_id: 1 as number | null, text: 'T', done: 0 as number, sort_order: 0,
+        created_at: '', ...baseRow, suggested_action: blob,
+      }).suggestedAction
+    expect(mk('{not json')).toBeNull() // unparseable
+    expect(mk('{"kind":"delegate"}')).toBeNull() // missing prompt
+    expect(mk('{"kind":"pr_comment","url":"https://e.com/1"}')).toBeNull() // missing comment
+    expect(mk('{"kind":"open_url","url":123}')).toBeNull() // url not a string
+    expect(mk('{"kind":"mystery","url":"https://e.com"}')).toBeNull() // unknown kind
+    expect(mk('{"kind":"open_url","url":"https://e.com/1"}')).toEqual({ kind: 'open_url', url: 'https://e.com/1' })
   })
 
   it('converts done integer 1 to boolean true', () => {

--- a/src/main/db/projects.ts
+++ b/src/main/db/projects.ts
@@ -589,14 +589,26 @@ export function addAgentTodo(input: AddAgentTodoInput): AddAgentTodoResult {
       projectId = input.resolvedProjectId
     }
 
+    // If the todo moves to a different bucket, append it (max sort_order + 1 in the
+    // destination) rather than carrying its old sort_order, which would interleave it oddly
+    // in the destination's (sort_order, id) ordering. Otherwise keep its place.
+    const moved = projectId !== existing.project_id
+    let sortOrder = existing.sort_order
+    if (moved) {
+      const { m } = db
+        .prepare('SELECT COALESCE(MAX(sort_order), -1) AS m FROM project_todos WHERE project_id IS ?')
+        .get(projectId) as { m: number }
+      sortOrder = m + 1
+    }
+
     const row = db
       .prepare(
         `UPDATE project_todos
-           SET title = ?, body = ?, text = ?, source_url = ?, suggested_action = ?, project_id = ?
+           SET title = ?, body = ?, text = ?, source_url = ?, suggested_action = ?, project_id = ?, sort_order = ?
          WHERE id = ?
          RETURNING *`
       )
-      .get(input.title, input.body, input.title, input.sourceUrl, actionJson, projectId, existing.id) as TodoRow
+      .get(input.title, input.body, input.title, input.sourceUrl, actionJson, projectId, sortOrder, existing.id) as TodoRow
 
     const status: AddAgentTodoStatus =
       existing.deleted_at !== null

--- a/src/main/db/projects.ts
+++ b/src/main/db/projects.ts
@@ -538,8 +538,10 @@ function isLiveProject(db: ReturnType<typeof getDb>, projectId: number): boolean
  * `done` and `deleted_at` are always preserved — a re-review never silently un-completes or
  * un-dismisses a human's decision; the returned status reports when a hidden todo was touched.
  *
- * Runs read-then-write in a transaction so the status is accurate and concurrent calls with
- * the same key serialize (the partial unique index is the backstop).
+ * Runs read-then-write in a transaction. better-sqlite3 is synchronous and the app uses a
+ * single DB connection, so this read-then-write block runs to completion before any other JS
+ * (including another add_todo) can begin — there is no interleaving in practice. The partial
+ * unique index on idempotency_key is the backstop if that assumption ever changes.
  */
 export function addAgentTodo(input: AddAgentTodoInput): AddAgentTodoResult {
   const db = getDb()

--- a/src/main/db/projects.ts
+++ b/src/main/db/projects.ts
@@ -552,7 +552,11 @@ export function addAgentTodo(input: AddAgentTodoInput): AddAgentTodoResult {
       input.idempotencyKey === null
         ? undefined
         : (db
-            .prepare('SELECT * FROM project_todos WHERE idempotency_key = ?')
+            // Scope to agent todos: the tool must never update a user todo, even if one
+            // somehow carried a non-null idempotency_key (corrupt DB, manual edit, future
+            // feature). A stray key on a user row then falls through to INSERT, where the
+            // unique index rejects it — surfaced as a clean isError rather than a silent edit.
+            .prepare("SELECT * FROM project_todos WHERE idempotency_key = ? AND origin = 'copilot'")
             .get(input.idempotencyKey) as TodoRow | undefined)
     // bun:sqlite returns null (better-sqlite3 returns undefined) for a missing row — normalize.
     const existing: TodoRow | null = found ?? null
@@ -622,11 +626,11 @@ export function addAgentTodo(input: AddAgentTodoInput): AddAgentTodoResult {
   return run()
 }
 
-/** Lists Inbox todos (no owning project, not soft-deleted) for the agent-todo Inbox surface. */
+/** Lists Inbox todos (agent-origin, no owning project, not soft-deleted) for the Inbox surface. */
 export function listInboxTodos(): ProjectTodo[] {
   const rows = getDb()
     .prepare(
-      'SELECT * FROM project_todos WHERE project_id IS NULL AND deleted_at IS NULL ORDER BY sort_order ASC, id ASC'
+      "SELECT * FROM project_todos WHERE project_id IS NULL AND deleted_at IS NULL AND origin = 'copilot' ORDER BY sort_order ASC, id ASC"
     )
     .all() as TodoRow[]
   return rows.map(toTodo)

--- a/src/main/db/projects.ts
+++ b/src/main/db/projects.ts
@@ -94,20 +94,31 @@ function driftStateForRow(row: ProjectRow, now: Date): DriftState {
 }
 
 /**
- * Parse the stored `suggested_action` JSON back into a typed union. We wrote this value,
- * so we trust its shape but guard against corruption/legacy nulls — a bad blob degrades to
- * `null` (no action affordance) rather than throwing.
+ * Parse the stored `suggested_action` JSON back into a typed union. We wrote this value, so it
+ * is normally well-formed, but this is the boundary where stored data re-enters the domain, so
+ * validate per-kind (required string fields) and degrade a corrupt/partial blob to `null` (no
+ * action affordance) rather than letting `undefined` fields leak into the UI.
  */
 function parseSuggestedAction(raw: string | null): SuggestedAction | null {
   if (raw === null) return null
+  let parsed: unknown
   try {
-    const parsed: unknown = JSON.parse(raw)
-    if (parsed !== null && typeof parsed === 'object' && 'kind' in parsed) {
-      return parsed as SuggestedAction
-    }
-    return null
+    parsed = JSON.parse(raw)
   } catch {
     return null
+  }
+  if (parsed === null || typeof parsed !== 'object') return null
+  const obj = parsed as Record<string, unknown>
+  const str = (v: unknown): v is string => typeof v === 'string' && v.length > 0
+  switch (obj.kind) {
+    case 'pr_comment':
+      return str(obj.url) && str(obj.comment) ? { kind: 'pr_comment', url: obj.url, comment: obj.comment } : null
+    case 'delegate':
+      return str(obj.prompt) ? { kind: 'delegate', prompt: obj.prompt } : null
+    case 'open_url':
+      return str(obj.url) ? { kind: 'open_url', url: obj.url } : null
+    default:
+      return null
   }
 }
 

--- a/src/main/db/projects.ts
+++ b/src/main/db/projects.ts
@@ -10,6 +10,7 @@ import type {
   ProjectTodo,
   ProjectTodoPatch,
   SnoozeMode,
+  SuggestedAction,
 } from '../../shared/ipc-channels'
 import { getDb } from './index'
 import { classifyDrift } from '../digest/classify'
@@ -35,11 +36,18 @@ interface ProjectRow {
 
 interface TodoRow {
   id: number
-  project_id: number
+  project_id: number | null
   text: string
   done: number
   sort_order: number
   created_at: string
+  deleted_at: string | null
+  title: string | null
+  body: string | null
+  source_url: string | null
+  suggested_action: string | null
+  origin: string
+  idempotency_key: string | null
 }
 
 interface LinkRow {
@@ -85,6 +93,24 @@ function driftStateForRow(row: ProjectRow, now: Date): DriftState {
   })
 }
 
+/**
+ * Parse the stored `suggested_action` JSON back into a typed union. We wrote this value,
+ * so we trust its shape but guard against corruption/legacy nulls — a bad blob degrades to
+ * `null` (no action affordance) rather than throwing.
+ */
+function parseSuggestedAction(raw: string | null): SuggestedAction | null {
+  if (raw === null) return null
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    if (parsed !== null && typeof parsed === 'object' && 'kind' in parsed) {
+      return parsed as SuggestedAction
+    }
+    return null
+  } catch {
+    return null
+  }
+}
+
 export function toTodo(row: TodoRow): ProjectTodo {
   return {
     id: row.id,
@@ -93,6 +119,12 @@ export function toTodo(row: TodoRow): ProjectTodo {
     done: row.done === 1,
     sortOrder: row.sort_order,
     createdAt: row.created_at,
+    title: row.title,
+    body: row.body,
+    sourceUrl: row.source_url,
+    suggestedAction: parseSuggestedAction(row.suggested_action),
+    origin: row.origin === 'copilot' ? 'copilot' : 'user',
+    idempotencyKey: row.idempotency_key,
   }
 }
 
@@ -394,6 +426,14 @@ export function wakeExpiredSnoozes(): number[] {
 
 // ── Todos ─────────────────────────────────────────────────────────────────────
 
+/** Look up a project's display name by id (live or soft-deleted), or null if it's gone. */
+export function getProjectNameById(id: number): string | null {
+  const row = getDb().prepare('SELECT name FROM projects WHERE id = ?').get(id) as
+    | { name: string }
+    | undefined
+  return row?.name ?? null
+}
+
 export function createTodo(projectId: number, text: string): ProjectTodo {
   const db = getDb()
   const { m } = db
@@ -439,6 +479,132 @@ export function deleteTodo(id: number): void {
 /** Restore a soft-deleted todo. */
 export function restoreTodo(id: number): void {
   getDb().prepare('UPDATE project_todos SET deleted_at = NULL WHERE id = ?').run(id)
+}
+
+// ── Agent todos (the `add_todo` MCP tool) ─────────────────────────────────────
+
+/** Input for {@link addAgentTodo}. Placement is pre-resolved by the tool layer. */
+export interface AddAgentTodoInput {
+  /** The project this todo resolves to, or `null` for the Inbox. */
+  resolvedProjectId: number | null
+  /**
+   * True only when the caller passed an explicit `project`. On an idempotent update this
+   * lets the explicit target MOVE the todo; a repo/inbox resolution leaves placement sticky.
+   */
+  explicitPlacement: boolean
+  title: string
+  body: string | null
+  sourceUrl: string | null
+  suggestedAction: SuggestedAction | null
+  /** Deterministic dedup key, or `null` to always insert (no dedup). */
+  idempotencyKey: string | null
+}
+
+export type AddAgentTodoStatus = 'created' | 'updated' | 'updated_dismissed' | 'updated_completed'
+
+export interface AddAgentTodoResult {
+  todo: ProjectTodo
+  status: AddAgentTodoStatus
+}
+
+function isLiveProject(db: ReturnType<typeof getDb>, projectId: number): boolean {
+  const row = db
+    .prepare('SELECT 1 AS x FROM projects WHERE id = ? AND deleted_at IS NULL')
+    .get(projectId)
+  return row != null
+}
+
+/**
+ * Insert (or idempotently update) an agent-originated todo. NEVER touches GitHub — it only
+ * writes a row. Dedup is by `idempotencyKey`: a repeated call with the same key updates the
+ * existing todo's content instead of duplicating.
+ *
+ * Placement on an update:
+ * - explicit `project` (explicitPlacement) MOVES the todo to the resolved project;
+ * - else if the existing todo sits on a now-soft-deleted project, it MOVES to the freshly
+ *   resolved target (project or Inbox) so it never gets stranded on a dead project;
+ * - else placement is STICKY (respects wherever it currently lives).
+ * `done` and `deleted_at` are always preserved — a re-review never silently un-completes or
+ * un-dismisses a human's decision; the returned status reports when a hidden todo was touched.
+ *
+ * Runs read-then-write in a transaction so the status is accurate and concurrent calls with
+ * the same key serialize (the partial unique index is the backstop).
+ */
+export function addAgentTodo(input: AddAgentTodoInput): AddAgentTodoResult {
+  const db = getDb()
+  const actionJson = input.suggestedAction === null ? null : JSON.stringify(input.suggestedAction)
+
+  const run = db.transaction((): AddAgentTodoResult => {
+    const found =
+      input.idempotencyKey === null
+        ? undefined
+        : (db
+            .prepare('SELECT * FROM project_todos WHERE idempotency_key = ?')
+            .get(input.idempotencyKey) as TodoRow | undefined)
+    // bun:sqlite returns null (better-sqlite3 returns undefined) for a missing row — normalize.
+    const existing: TodoRow | null = found ?? null
+
+    if (existing === null) {
+      // `project_id IS ?` matches both a numeric bucket and the NULL (Inbox) bucket.
+      const { m } = db
+        .prepare('SELECT COALESCE(MAX(sort_order), -1) AS m FROM project_todos WHERE project_id IS ?')
+        .get(input.resolvedProjectId) as { m: number }
+      const row = db
+        .prepare(
+          `INSERT INTO project_todos
+             (project_id, text, sort_order, title, body, source_url, suggested_action, origin, idempotency_key)
+           VALUES (?, ?, ?, ?, ?, ?, ?, 'copilot', ?)
+           RETURNING *`
+        )
+        .get(
+          input.resolvedProjectId,
+          input.title,
+          m + 1,
+          input.title,
+          input.body,
+          input.sourceUrl,
+          actionJson,
+          input.idempotencyKey
+        ) as TodoRow
+      return { todo: toTodo(row), status: 'created' }
+    }
+
+    let projectId = existing.project_id
+    if (input.explicitPlacement) {
+      projectId = input.resolvedProjectId
+    } else if (existing.project_id !== null && !isLiveProject(db, existing.project_id)) {
+      projectId = input.resolvedProjectId
+    }
+
+    const row = db
+      .prepare(
+        `UPDATE project_todos
+           SET title = ?, body = ?, text = ?, source_url = ?, suggested_action = ?, project_id = ?
+         WHERE id = ?
+         RETURNING *`
+      )
+      .get(input.title, input.body, input.title, input.sourceUrl, actionJson, projectId, existing.id) as TodoRow
+
+    const status: AddAgentTodoStatus =
+      existing.deleted_at !== null
+        ? 'updated_dismissed'
+        : existing.done === 1
+          ? 'updated_completed'
+          : 'updated'
+    return { todo: toTodo(row), status }
+  })
+
+  return run()
+}
+
+/** Lists Inbox todos (no owning project, not soft-deleted) for the agent-todo Inbox surface. */
+export function listInboxTodos(): ProjectTodo[] {
+  const rows = getDb()
+    .prepare(
+      'SELECT * FROM project_todos WHERE project_id IS NULL AND deleted_at IS NULL ORDER BY sort_order ASC, id ASC'
+    )
+    .all() as TodoRow[]
+  return rows.map(toTodo)
 }
 
 // ── Links ─────────────────────────────────────────────────────────────────────

--- a/src/main/db/routing-rules.integration.test.ts
+++ b/src/main/db/routing-rules.integration.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Database as BunDb } from 'bun:sqlite'
+import type BetterSQLite3 from 'better-sqlite3'
+
+vi.mock('electron', () => ({
+  app: { isPackaged: false, getAppPath: () => process.cwd() },
+}))
+
+vi.mock('./index', () => ({ getDb: vi.fn() }))
+
+import { getDb } from './index'
+import { runMigrations } from './migrate'
+import { createProject, deleteProject } from './projects'
+import { createRepoRule } from './notifications'
+import { createRoutingRule, resolveProjectIdForRepo, resolveProjectIdByName } from './routing-rules'
+
+let db: BunDb
+
+beforeEach(() => {
+  db = new BunDb(':memory:')
+  db.exec('PRAGMA foreign_keys = ON')
+  const betterDb = db as unknown as BetterSQLite3.Database
+  runMigrations(betterDb)
+  vi.mocked(getDb).mockReturnValue(betterDb)
+})
+
+describe('resolveProjectIdForRepo', () => {
+  it('resolves via an exact repo rule (repo rule wins)', () => {
+    const p = createProject('Repo')
+    createRepoRule('acme', 'widgets', p.id)
+    expect(resolveProjectIdForRepo('acme', 'widgets')).toBe(p.id)
+  })
+
+  it('a repo rule pointing at a soft-deleted project resolves to the Inbox (does not fall through)', () => {
+    const p = createProject('Dead')
+    const other = createProject('Live')
+    createRepoRule('acme', 'widgets', p.id)
+    // A routing rule that WOULD match — must be ignored because the repo rule claims the repo.
+    createRoutingRule({ action: 'route', projectId: other.id, matchRepoOwner: 'acme', matchRepoName: 'widgets' })
+    deleteProject(p.id)
+    expect(resolveProjectIdForRepo('acme', 'widgets')).toBeNull()
+  })
+
+  it('falls through to a routing rule when there is no repo rule', () => {
+    const p = createProject('Routed')
+    createRoutingRule({ action: 'route', projectId: p.id, matchRepoOwner: 'acme', matchRepoName: 'widgets' })
+    expect(resolveProjectIdForRepo('acme', 'widgets')).toBe(p.id)
+  })
+
+  it('matches an org-scoped routing rule', () => {
+    const p = createProject('Org')
+    createRoutingRule({ action: 'route', projectId: p.id, matchOrg: 'acme' })
+    expect(resolveProjectIdForRepo('acme', 'anything')).toBe(p.id)
+  })
+
+  it('does NOT match a routing rule that also requires a type/reason (a bare repo has neither)', () => {
+    const p = createProject('Typed')
+    createRoutingRule({ action: 'route', projectId: p.id, matchRepoOwner: 'acme', matchRepoName: 'widgets', matchReason: 'review_requested' })
+    expect(resolveProjectIdForRepo('acme', 'widgets')).toBeNull()
+  })
+
+  it('returns null (Inbox) when nothing matches', () => {
+    createProject('Unrelated')
+    expect(resolveProjectIdForRepo('nobody', 'nothing')).toBeNull()
+  })
+
+  it('ignores a routing rule to a soft-deleted project', () => {
+    const p = createProject('Gone')
+    createRoutingRule({ action: 'route', projectId: p.id, matchRepoOwner: 'acme', matchRepoName: 'widgets' })
+    deleteProject(p.id)
+    expect(resolveProjectIdForRepo('acme', 'widgets')).toBeNull()
+  })
+})
+
+describe('resolveProjectIdByName', () => {
+  it('matches case-insensitively', () => {
+    const p = createProject('My Project')
+    expect(resolveProjectIdByName('my project')).toBe(p.id)
+  })
+
+  it('returns null for an unknown name', () => {
+    createProject('Something')
+    expect(resolveProjectIdByName('nope')).toBeNull()
+  })
+
+  it('excludes soft-deleted projects', () => {
+    const p = createProject('Doomed')
+    deleteProject(p.id)
+    expect(resolveProjectIdByName('Doomed')).toBeNull()
+  })
+
+  it('picks the lowest id on a duplicate-name tie', () => {
+    const first = createProject('Dup')
+    createProject('Dup')
+    expect(resolveProjectIdByName('Dup')).toBe(first.id)
+  })
+})

--- a/src/main/db/routing-rules.integration.test.ts
+++ b/src/main/db/routing-rules.integration.test.ts
@@ -53,6 +53,13 @@ describe('resolveProjectIdForRepo', () => {
     expect(resolveProjectIdForRepo('acme', 'anything')).toBe(p.id)
   })
 
+  it('matches a repo rule case-insensitively (GitHub owner/name are case-insensitive)', () => {
+    const p = createProject('CaseRepo')
+    createRepoRule('Acme', 'Widgets', p.id)
+    expect(resolveProjectIdForRepo('acme', 'widgets')).toBe(p.id)
+    expect(resolveProjectIdForRepo('ACME', 'WIDGETS')).toBe(p.id)
+  })
+
   it('does NOT match a routing rule that also requires a type/reason (a bare repo has neither)', () => {
     const p = createProject('Typed')
     createRoutingRule({ action: 'route', projectId: p.id, matchRepoOwner: 'acme', matchRepoName: 'widgets', matchReason: 'review_requested' })

--- a/src/main/db/routing-rules.ts
+++ b/src/main/db/routing-rules.ts
@@ -134,7 +134,11 @@ export function resolveProjectIdForRepo(repoOwner: string, repoName: string): nu
   )
 
   const repoRule = db
-    .prepare('SELECT project_id FROM repo_rules WHERE repo_owner = ? AND repo_name = ?')
+    .prepare(
+      // GitHub owner/name are case-insensitive, and Copilot may send `repo` with different
+      // casing than the stored canonical form, so match case-insensitively.
+      'SELECT project_id FROM repo_rules WHERE lower(repo_owner) = lower(?) AND lower(repo_name) = lower(?) LIMIT 1'
+    )
     .get(repoOwner, repoName) as { project_id: number } | undefined
   if (repoRule != null) {
     // A repo rule claims the repo even when its target is dead — matching upsertThreads,

--- a/src/main/db/routing-rules.ts
+++ b/src/main/db/routing-rules.ts
@@ -115,6 +115,79 @@ export function deleteRoutingRule(id: number): void {
   getDb().prepare('DELETE FROM routing_rules WHERE id = ?').run(id)
 }
 
+// ── Repo -> project resolution (shared with the `add_todo` MCP tool) ───────────
+
+/**
+ * Resolve a bare `owner/name` repo to the project it should land in, mirroring the exact
+ * precedence `upsertThreads` applies to notifications: (1) an exact `repo_rules` entry claims
+ * the repo (and resolves to the Inbox if its target project is soft-deleted — it does NOT fall
+ * through); (2) otherwise the `route` routing rules, first match wins, evaluated through the
+ * SAME `routingRuleMatches` matcher via a repo-only pseudo-thread (empty type/reason, so a
+ * type/reason-conditioned rule simply won't match — correct, since a bare repo carries neither);
+ * (3) otherwise the Inbox (`null`). We reuse the matcher rather than reinventing it, but do NOT
+ * route notifications through here — those legitimately need type/reason matching.
+ */
+export function resolveProjectIdForRepo(repoOwner: string, repoName: string): number | null {
+  const db = getDb()
+  const liveProjectIds = new Set(
+    (db.prepare('SELECT id FROM projects WHERE deleted_at IS NULL').all() as { id: number }[]).map((r) => r.id)
+  )
+
+  const repoRule = db
+    .prepare('SELECT project_id FROM repo_rules WHERE repo_owner = ? AND repo_name = ?')
+    .get(repoOwner, repoName) as { project_id: number } | undefined
+  if (repoRule != null) {
+    // A repo rule claims the repo even when its target is dead — matching upsertThreads,
+    // which then gates a dead target down to the Inbox rather than trying routing rules.
+    return liveProjectIds.has(repoRule.project_id) ? repoRule.project_id : null
+  }
+
+  const routeRules = listRoutingRules().filter(
+    (r) => r.action === 'route' && r.projectId !== null && liveProjectIds.has(r.projectId)
+  )
+  const pseudoThread: NotificationThread = {
+    id: '',
+    projectId: null,
+    repoOwner,
+    repoName,
+    title: '',
+    type: '' as NotificationThread['type'],
+    reason: '',
+    unread: false,
+    updatedAt: '',
+    lastReadAt: null,
+    apiUrl: '',
+    subjectUrl: null,
+    subjectState: null,
+    htmlUrl: null,
+  }
+  for (const rule of routeRules) {
+    if (routingRuleMatches(rule, pseudoThread)) {
+      return rule.projectId
+    }
+  }
+
+  return null
+}
+
+/**
+ * Resolve an explicit project name to a live project id. Case-insensitive exact match;
+ * lowest id wins on the (rare) duplicate-name tie. Returns `null` when no live project matches.
+ */
+export function resolveProjectIdByName(name: string): number | null {
+  const trimmed = name.trim()
+  if (trimmed.length === 0) return null
+  const row = getDb()
+    .prepare(
+      `SELECT id FROM projects
+       WHERE deleted_at IS NULL AND lower(name) = lower(?)
+       ORDER BY id ASC
+       LIMIT 1`
+    )
+    .get(trimmed) as { id: number } | undefined
+  return row?.id ?? null
+}
+
 // ── Rule evaluation ───────────────────────────────────────────────────────────
 
 /**

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -5,7 +5,7 @@ import { initDb } from './db'
 import { initAuth, getAuthStatus, savePat, logout, getOctokit } from './auth'
 import {
   listProjects, getProject, createProject, updateProject, deleteProject, restoreProject,
-  createTodo, updateTodo, deleteTodo, restoreTodo,
+  createTodo, updateTodo, deleteTodo, restoreTodo, listInboxTodos,
   createLink, updateLink, deleteLink,
   snoozeProject,
 } from './db/projects'
@@ -177,6 +177,7 @@ app.whenReady().then(async () => {
   ipcMain.handle('todos:create', (_event, projectId: number, text: string) => createTodo(projectId, text))
   ipcMain.handle('todos:update', (_event, id: number, patch: ProjectTodoPatch) => updateTodo(id, patch))
   ipcMain.handle('todos:delete', (_event, id: number) => deleteTodo(id))
+  ipcMain.handle('todos:inbox', () => listInboxTodos())
 
   // Link handlers
   ipcMain.handle('links:create', (_event, projectId: number, label: string, url: string) => createLink(projectId, label, url))

--- a/src/main/mcp-server/add-todo.test.ts
+++ b/src/main/mcp-server/add-todo.test.ts
@@ -98,6 +98,16 @@ describe('runAddTodo — resolution', () => {
     expect(r.isError).toBeUndefined()
     expect(listInboxTodos().map((t) => t.title)).toContain('Weird')
   })
+
+  it('tolerates a github.com-prefixed repo (with or without scheme)', () => {
+    const p = createProject('Prefixed')
+    createRepoRule('acme', 'widgets', p.id)
+    runAddTodo({ repo: 'github.com/acme/widgets', title: 'bare host' })
+    runAddTodo({ repo: 'https://github.com/acme/widgets', title: 'full url' })
+    expect(getProject(p.id).todos.map((t) => t.title)).toEqual(
+      expect.arrayContaining(['bare host', 'full url'])
+    )
+  })
 })
 
 describe('runAddTodo — idempotency', () => {

--- a/src/main/mcp-server/add-todo.test.ts
+++ b/src/main/mcp-server/add-todo.test.ts
@@ -14,6 +14,7 @@ import { runMigrations } from '../db/migrate'
 import { createProject, getProject, listInboxTodos } from '../db/projects'
 import { createRepoRule } from '../db/notifications'
 import { runAddTodo } from './add-todo'
+import { ADD_TODO_TOOL_NAME, findManifestTool } from './tool-manifest'
 
 let db: BunDb
 
@@ -55,6 +56,24 @@ describe('runAddTodo — validation', () => {
   it('rejects a pr_comment without a comment', () => {
     const r = runAddTodo({ title: 'x', suggestedAction: { kind: 'pr_comment', url: 'https://e.com/1' } })
     expect(r.isError).toBe(true)
+  })
+})
+
+describe('add_todo advertised schema matches the runtime contract', () => {
+  it('models suggestedAction as a per-kind oneOf with the same required fields the handler enforces', () => {
+    const tool = findManifestTool(ADD_TODO_TOOL_NAME)
+    expect(tool).toBeDefined()
+    const action = (tool?.inputSchema.properties?.suggestedAction ?? {}) as {
+      oneOf?: Array<{ properties?: Record<string, { const?: string }>; required?: string[] }>
+    }
+    expect(Array.isArray(action.oneOf)).toBe(true)
+    const byKind = new Map(
+      (action.oneOf ?? []).map((v) => [v.properties?.kind?.const, new Set(v.required ?? [])])
+    )
+    // Same required fields the handler rejects on when missing.
+    expect(byKind.get('pr_comment')).toEqual(new Set(['kind', 'url', 'comment']))
+    expect(byKind.get('delegate')).toEqual(new Set(['kind', 'prompt']))
+    expect(byKind.get('open_url')).toEqual(new Set(['kind', 'url']))
   })
 })
 

--- a/src/main/mcp-server/add-todo.test.ts
+++ b/src/main/mcp-server/add-todo.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Database as BunDb } from 'bun:sqlite'
+import type BetterSQLite3 from 'better-sqlite3'
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
+
+vi.mock('electron', () => ({
+  app: { isPackaged: false, getAppPath: () => process.cwd() },
+}))
+
+vi.mock('../db/index', () => ({ getDb: vi.fn() }))
+
+import { getDb } from '../db/index'
+import { runMigrations } from '../db/migrate'
+import { createProject, getProject, listInboxTodos } from '../db/projects'
+import { createRepoRule } from '../db/notifications'
+import { runAddTodo } from './add-todo'
+
+let db: BunDb
+
+beforeEach(() => {
+  db = new BunDb(':memory:')
+  db.exec('PRAGMA foreign_keys = ON')
+  const betterDb = db as unknown as BetterSQLite3.Database
+  runMigrations(betterDb)
+  vi.mocked(getDb).mockReturnValue(betterDb)
+})
+
+function textOf(result: CallToolResult): string {
+  const first = result.content[0]
+  return first.type === 'text' ? first.text : ''
+}
+
+describe('runAddTodo — validation', () => {
+  it('requires a non-empty title', () => {
+    expect(runAddTodo({}).isError).toBe(true)
+    expect(runAddTodo({ title: '   ' }).isError).toBe(true)
+  })
+
+  it('rejects a non-http(s) sourceUrl', () => {
+    const r = runAddTodo({ title: 'x', sourceUrl: 'javascript:alert(1)' })
+    expect(r.isError).toBe(true)
+    expect(textOf(r)).toMatch(/sourceUrl/)
+  })
+
+  it('rejects a suggestedAction with a bad url scheme', () => {
+    const r = runAddTodo({ title: 'x', suggestedAction: { kind: 'open_url', url: 'file:///etc/passwd' } })
+    expect(r.isError).toBe(true)
+  })
+
+  it('rejects an unknown suggestedAction kind', () => {
+    const r = runAddTodo({ title: 'x', suggestedAction: { kind: 'launch_missiles' } })
+    expect(r.isError).toBe(true)
+  })
+
+  it('rejects a pr_comment without a comment', () => {
+    const r = runAddTodo({ title: 'x', suggestedAction: { kind: 'pr_comment', url: 'https://e.com/1' } })
+    expect(r.isError).toBe(true)
+  })
+})
+
+describe('runAddTodo — resolution', () => {
+  it('lands in the Inbox with no project/repo', () => {
+    const r = runAddTodo({ title: 'Unrouted' })
+    expect(r.isError).toBeUndefined()
+    expect(textOf(r)).toMatch(/Inbox/)
+    expect(listInboxTodos().map((t) => t.title)).toContain('Unrouted')
+  })
+
+  it('files under an explicit project by name', () => {
+    const p = createProject('Alpha')
+    const r = runAddTodo({ project: 'alpha', title: 'Task' }) // case-insensitive
+    expect(r.isError).toBeUndefined()
+    expect(getProject(p.id).todos.map((t) => t.title)).toContain('Task')
+  })
+
+  it('errors when the explicit project does not exist', () => {
+    const r = runAddTodo({ project: 'Ghost', title: 'Task' })
+    expect(r.isError).toBe(true)
+    expect(textOf(r)).toMatch(/Ghost/)
+  })
+
+  it('routes a repo through the routing rules', () => {
+    const p = createProject('Routed')
+    createRepoRule('acme', 'widgets', p.id)
+    const r = runAddTodo({ repo: 'acme/widgets', title: 'From repo' })
+    expect(r.isError).toBeUndefined()
+    expect(getProject(p.id).todos.map((t) => t.title)).toContain('From repo')
+  })
+
+  it('drops an unresolved repo into the Inbox', () => {
+    const r = runAddTodo({ repo: 'nobody/nothing', title: 'Stray' })
+    expect(textOf(r)).toMatch(/Inbox/)
+    expect(listInboxTodos().map((t) => t.title)).toContain('Stray')
+  })
+
+  it('a malformed repo string lands in the Inbox rather than erroring', () => {
+    const r = runAddTodo({ repo: 'not-a-repo', title: 'Weird' })
+    expect(r.isError).toBeUndefined()
+    expect(listInboxTodos().map((t) => t.title)).toContain('Weird')
+  })
+})
+
+describe('runAddTodo — idempotency', () => {
+  it('re-review of the same PR with the same action updates in place (no duplicate)', () => {
+    const p = createProject('Repo')
+    createRepoRule('acme', 'widgets', p.id)
+    const args = {
+      repo: 'acme/widgets',
+      title: 'Approve PR',
+      sourceUrl: 'https://github.com/acme/widgets/pull/7',
+      suggestedAction: { kind: 'pr_comment', url: 'https://github.com/acme/widgets/pull/7', comment: 'nice' },
+    }
+    const first = runAddTodo(args)
+    expect(textOf(first)).toMatch(/Created/)
+    const second = runAddTodo({ ...args, title: 'Approve PR (updated)' })
+    expect(textOf(second)).toMatch(/Updated/)
+    const todos = getProject(p.id).todos
+    expect(todos).toHaveLength(1)
+    expect(todos[0].title).toBe('Approve PR (updated)')
+  })
+
+  it('distinct actions on the same PR produce distinct todos', () => {
+    const p = createProject('Repo')
+    createRepoRule('acme', 'widgets', p.id)
+    const url = 'https://github.com/acme/widgets/pull/7'
+    runAddTodo({ repo: 'acme/widgets', title: 'Comment A', sourceUrl: url, suggestedAction: { kind: 'pr_comment', url, comment: 'A' } })
+    runAddTodo({ repo: 'acme/widgets', title: 'Comment B', sourceUrl: url, suggestedAction: { kind: 'pr_comment', url, comment: 'B' } })
+    expect(getProject(p.id).todos).toHaveLength(2)
+  })
+
+  it('a sourceUrl differing only by trailing case in the host still dedups', () => {
+    const p = createProject('Repo')
+    createRepoRule('acme', 'widgets', p.id)
+    runAddTodo({ repo: 'acme/widgets', title: 'a', sourceUrl: 'https://GitHub.com/acme/widgets/pull/7' })
+    runAddTodo({ repo: 'acme/widgets', title: 'b', sourceUrl: 'https://github.com/acme/widgets/pull/7' })
+    expect(getProject(p.id).todos).toHaveLength(1)
+  })
+
+  it('no sourceUrl means no dedup — each call inserts', () => {
+    const p = createProject('Repo')
+    createRepoRule('acme', 'widgets', p.id)
+    runAddTodo({ repo: 'acme/widgets', title: 'a' })
+    runAddTodo({ repo: 'acme/widgets', title: 'a' })
+    expect(getProject(p.id).todos).toHaveLength(2)
+  })
+})

--- a/src/main/mcp-server/add-todo.ts
+++ b/src/main/mcp-server/add-todo.ts
@@ -1,0 +1,176 @@
+/**
+ * The `add_todo` MCP tool handler. Copilot calls this to file a rich, human-gated todo in a
+ * GH Projects project — the first real tool on the inbound MCP server (#102).
+ *
+ * Hard invariant: this NEVER writes to GitHub. It validates its input, resolves a project,
+ * and inserts (or idempotently updates) a todo row. Any "action" it carries is a PROPOSAL the
+ * human approves in the app.
+ *
+ * Placement precedence mirrors how notifications resolve a repo: explicit `project` name wins;
+ * else `repo` (owner/name) via the shared routing rules; else the Inbox. Dedup is by a
+ * deterministic key derived from the (normalized) `sourceUrl` plus the full suggested-action
+ * identity, so a re-review of the same PR proposing the same action updates in place, while a
+ * genuinely different action produces a distinct todo.
+ */
+
+import { createHash } from 'node:crypto'
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
+import type { SuggestedAction } from '../../shared/ipc-channels'
+import { parseSafeExternalUrl } from '../../shared/safe-url'
+import { resolveProjectIdByName, resolveProjectIdForRepo } from '../db/routing-rules'
+import { addAgentTodo, getProjectNameById } from '../db/projects'
+
+function textResult(text: string): CallToolResult {
+  return { content: [{ type: 'text', text }] }
+}
+
+function errorResult(text: string): CallToolResult {
+  return { content: [{ type: 'text', text }], isError: true }
+}
+
+/** Coerce an optional arg to a trimmed non-empty string, or null. */
+function optionalString(value: unknown): string | null {
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+/** Parse `owner/name` (tolerating a leading `github.com/`). Returns null when unparseable. */
+function parseRepo(repo: string): { owner: string; name: string } | null {
+  const cleaned = repo.trim().replace(/^https?:\/\/github\.com\//i, '').replace(/\/+$/, '')
+  const parts = cleaned.split('/').filter((p) => p.length > 0)
+  if (parts.length !== 2) return null
+  return { owner: parts[0], name: parts[1] }
+}
+
+type ActionParse =
+  | { ok: true; value: SuggestedAction | null }
+  | { ok: false; error: string }
+
+/** Validate + normalize the optional `suggestedAction`. URLs are gated to http/https. */
+function parseSuggestedAction(raw: unknown): ActionParse {
+  if (raw === undefined || raw === null) return { ok: true, value: null }
+  if (typeof raw !== 'object') {
+    return { ok: false, error: 'suggestedAction must be an object.' }
+  }
+  const obj = raw as Record<string, unknown>
+  switch (obj.kind) {
+    case 'pr_comment': {
+      const url = parseSafeExternalUrl(obj.url)
+      if (url === null) return { ok: false, error: 'suggestedAction.url must be an http(s) URL.' }
+      if (typeof obj.comment !== 'string' || obj.comment.trim().length === 0) {
+        return { ok: false, error: 'suggestedAction.comment is required for kind "pr_comment".' }
+      }
+      return { ok: true, value: { kind: 'pr_comment', url, comment: obj.comment } }
+    }
+    case 'delegate': {
+      if (typeof obj.prompt !== 'string' || obj.prompt.trim().length === 0) {
+        return { ok: false, error: 'suggestedAction.prompt is required for kind "delegate".' }
+      }
+      return { ok: true, value: { kind: 'delegate', prompt: obj.prompt } }
+    }
+    case 'open_url': {
+      const url = parseSafeExternalUrl(obj.url)
+      if (url === null) return { ok: false, error: 'suggestedAction.url must be an http(s) URL.' }
+      return { ok: true, value: { kind: 'open_url', url } }
+    }
+    default:
+      return {
+        ok: false,
+        error: 'suggestedAction.kind must be one of: pr_comment, delegate, open_url.',
+      }
+  }
+}
+
+/** Stable, collision-resistant serialization of a suggested action's identity. */
+function canonicalAction(action: SuggestedAction | null): string {
+  if (action === null) return 'none'
+  switch (action.kind) {
+    case 'pr_comment':
+      return `pr_comment\n${action.url}\n${action.comment}`
+    case 'delegate':
+      return `delegate\n${action.prompt}`
+    case 'open_url':
+      return `open_url\n${action.url}`
+  }
+}
+
+/**
+ * Deterministic dedup key = sha256(normalized sourceUrl + full action identity). Null when
+ * there is no sourceUrl (nothing stable to dedup on → always insert). We hash the FULL action
+ * (not just its kind) so two distinct actions on the same PR don't collide.
+ */
+function computeIdempotencyKey(sourceHref: string | null, action: SuggestedAction | null): string | null {
+  if (sourceHref === null) return null
+  return createHash('sha256').update(`${sourceHref}\n${canonicalAction(action)}`).digest('hex')
+}
+
+/** Run the `add_todo` tool. Pure w.r.t. the network; only reads/writes the local DB. */
+export function runAddTodo(args: Record<string, unknown>): CallToolResult {
+  const title = optionalString(args.title)
+  if (title === null) {
+    return errorResult('`title` is required and must be a non-empty string.')
+  }
+
+  const body = optionalString(args.body)
+
+  // Validate sourceUrl (if present) and normalize it to a safe href for storage + dedup.
+  let sourceHref: string | null = null
+  if (args.sourceUrl !== undefined && args.sourceUrl !== null) {
+    sourceHref = parseSafeExternalUrl(args.sourceUrl)
+    if (sourceHref === null) {
+      return errorResult('`sourceUrl` must be an http(s) URL.')
+    }
+  }
+
+  const action = parseSuggestedAction(args.suggestedAction)
+  if (!action.ok) {
+    return errorResult(action.error)
+  }
+
+  // Resolve placement: explicit project wins; else repo; else Inbox.
+  const project = optionalString(args.project)
+  const repo = optionalString(args.repo)
+  let resolvedProjectId: number | null = null
+  let explicitPlacement = false
+
+  if (project !== null) {
+    const id = resolveProjectIdByName(project)
+    if (id === null) {
+      return errorResult(
+        `No active project named "${project}". Create it first, or drop \`project\` to route by \`repo\` / land in the Inbox.`
+      )
+    }
+    resolvedProjectId = id
+    explicitPlacement = true
+  } else if (repo !== null) {
+    const parsed = parseRepo(repo)
+    resolvedProjectId = parsed === null ? null : resolveProjectIdForRepo(parsed.owner, parsed.name)
+  }
+
+  const idempotencyKey = computeIdempotencyKey(sourceHref, action.value)
+
+  const { todo, status } = addAgentTodo({
+    resolvedProjectId,
+    explicitPlacement,
+    title,
+    body,
+    sourceUrl: sourceHref,
+    suggestedAction: action.value,
+    idempotencyKey,
+  })
+
+  const location =
+    todo.projectId === null
+      ? 'the Inbox'
+      : `project "${getProjectNameById(todo.projectId) ?? `#${todo.projectId}`}"`
+  const verb = status === 'created' ? 'Created' : 'Updated'
+  const note =
+    status === 'updated_dismissed'
+      ? ' Note: this todo had been dismissed and remains dismissed.'
+      : status === 'updated_completed'
+        ? ' Note: this todo was already marked done and remains done.'
+        : ''
+
+  return textResult(`${verb} todo #${todo.id} "${todo.title ?? todo.text}" in ${location}.${note}`)
+}

--- a/src/main/mcp-server/add-todo.ts
+++ b/src/main/mcp-server/add-todo.ts
@@ -35,9 +35,9 @@ function optionalString(value: unknown): string | null {
   return trimmed.length > 0 ? trimmed : null
 }
 
-/** Parse `owner/name` (tolerating a leading `github.com/`). Returns null when unparseable. */
+/** Parse `owner/name` (tolerating a leading `github.com/` or full URL). Returns null when unparseable. */
 function parseRepo(repo: string): { owner: string; name: string } | null {
-  const cleaned = repo.trim().replace(/^https?:\/\/github\.com\//i, '').replace(/\/+$/, '')
+  const cleaned = repo.trim().replace(/^(?:https?:\/\/)?github\.com\//i, '').replace(/\/+$/, '')
   const parts = cleaned.split('/').filter((p) => p.length > 0)
   if (parts.length !== 2) return null
   return { owner: parts[0], name: parts[1] }

--- a/src/main/mcp-server/lifecycle.ts
+++ b/src/main/mcp-server/lifecycle.ts
@@ -13,7 +13,7 @@
  * — no dependency on a system node/bun and no asar-script-execution.
  */
 
-import { app } from 'electron'
+import { app, BrowserWindow } from 'electron'
 import { existsSync } from 'node:fs'
 import { join } from 'node:path'
 import { loadToken } from '../auth/storage'
@@ -74,11 +74,23 @@ function extraSecrets(): readonly string[] {
   return pat !== null && pat.length > 0 ? [pat] : []
 }
 
+/**
+ * Push a `todos:updated` (+ `projects:updated` for rail counts) event to every renderer when
+ * the `add_todo` tool changes a todo, so open todo surfaces reload live. Kept here (not in the
+ * tool) so the tool stays free of Electron/UI concerns.
+ */
+function broadcastTodoChanged(): void {
+  for (const win of BrowserWindow.getAllWindows()) {
+    win.webContents.send('todos:updated')
+    win.webContents.send('projects:updated')
+  }
+}
+
 /** Start the loopback server (if not already running) and register the shim. */
 export function enableMcpServer(): Promise<void> {
   return serialize(async () => {
     if (handle === null) {
-      handle = await startMcpServer({ extraSecrets })
+      handle = await startMcpServer({ extraSecrets, onTodoChanged: broadcastTodoChanged })
     }
     // Only register in ~/.mcp.json when the shim bundle actually exists, so we
     // never point Copilot at a missing command (e.g. in dev before build:shim).

--- a/src/main/mcp-server/server.integration.test.ts
+++ b/src/main/mcp-server/server.integration.test.ts
@@ -1,14 +1,29 @@
-import { describe, it, expect, afterEach } from 'vitest'
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest'
 import { request as httpRequest } from 'node:http'
 import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { Database as BunDb } from 'bun:sqlite'
+import type BetterSQLite3 from 'better-sqlite3'
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
 import { startMcpServer, type McpServerHandle } from './server'
 import { readRunFiles } from './runfiles'
-import { PING_TOOL_NAME } from './tool-manifest'
+import { PING_TOOL_NAME, ADD_TODO_TOOL_NAME } from './tool-manifest'
+
+// The `add_todo` tool's import graph reaches the DB layer (and, through it, electron).
+// Mock electron so `runMigrations` resolves the migrations dir, and mock the DB singleton
+// so the in-process server's tool handler writes to a real in-memory SQLite we control.
+vi.mock('electron', () => ({
+  app: { isPackaged: false, getAppPath: () => process.cwd() },
+}))
+vi.mock('../db/index', () => ({ getDb: vi.fn() }))
+
+import { getDb } from '../db/index'
+import { runMigrations } from '../db/migrate'
+import { createProject, getProject, listInboxTodos, deleteTodo, restoreTodo } from '../db/projects'
+import { createRepoRule } from '../db/notifications'
 
 /**
  * Stand up the REAL loopback server and drive it with a REAL SDK client over
@@ -20,6 +35,15 @@ const cleanups: Array<() => Promise<void> | void> = []
 
 afterEach(async () => {
   for (const fn of cleanups.splice(0)) await fn()
+})
+
+// A fresh in-memory DB per test, wired into the mocked getDb so the tool handler writes to it.
+beforeEach(() => {
+  const db = new BunDb(':memory:')
+  db.exec('PRAGMA foreign_keys = ON')
+  const betterDb = db as unknown as BetterSQLite3.Database
+  runMigrations(betterDb)
+  vi.mocked(getDb).mockReturnValue(betterDb)
 })
 
 async function startServer(): Promise<{ handle: McpServerHandle; dir: string; token: string }> {
@@ -98,6 +122,79 @@ describe('loopback MCP server (real SDK client)', () => {
     const first = await startServer()
     const second = await startServer()
     expect(first.token).not.toBe(second.token)
+  })
+})
+
+describe('add_todo tool over the real loopback server', () => {
+  function callAddTodo(client: Client, args: Record<string, unknown>): Promise<CallToolResult> {
+    return client.callTool({ name: ADD_TODO_TOOL_NAME, arguments: args }) as Promise<CallToolResult>
+  }
+  function textOf(result: CallToolResult): string {
+    const first = result.content[0]
+    return first.type === 'text' ? first.text : ''
+  }
+
+  it('advertises add_todo in tools/list', async () => {
+    const { handle, token } = await startServer()
+    const client = await connectClient(handle.port, token)
+    const { tools } = await client.listTools()
+    expect(tools.map((t) => t.name)).toContain(ADD_TODO_TOOL_NAME)
+  })
+
+  it('lands a todo on the routed project, is undoable, and dedups a repeat', async () => {
+    const { handle, token } = await startServer()
+    const client = await connectClient(handle.port, token)
+
+    const project = createProject('Widgets')
+    createRepoRule('acme', 'widgets', project.id)
+
+    // 1. Create — lands on the routed project.
+    const created = await callAddTodo(client, {
+      repo: 'acme/widgets',
+      title: 'Approve PR',
+      sourceUrl: 'https://github.com/acme/widgets/pull/9',
+      suggestedAction: { kind: 'pr_comment', url: 'https://github.com/acme/widgets/pull/9', comment: 'well thought out!' },
+    })
+    expect(created.isError).toBeFalsy()
+    expect(textOf(created)).toMatch(/Created/)
+    let todos = getProject(project.id).todos
+    expect(todos).toHaveLength(1)
+    expect(todos[0].origin).toBe('copilot')
+    const todoId = todos[0].id
+
+    // 2. Undo — soft-delete then restore round-trips (the app's undo affordance).
+    deleteTodo(todoId)
+    expect(getProject(project.id).todos).toHaveLength(0)
+    restoreTodo(todoId)
+    expect(getProject(project.id).todos).toHaveLength(1)
+
+    // 3. Re-review the same PR + same action — updates in place, never duplicates.
+    const repeat = await callAddTodo(client, {
+      repo: 'acme/widgets',
+      title: 'Approve PR (rechecked)',
+      sourceUrl: 'https://github.com/acme/widgets/pull/9',
+      suggestedAction: { kind: 'pr_comment', url: 'https://github.com/acme/widgets/pull/9', comment: 'well thought out!' },
+    })
+    expect(textOf(repeat)).toMatch(/Updated/)
+    todos = getProject(project.id).todos
+    expect(todos).toHaveLength(1)
+    expect(todos[0].id).toBe(todoId)
+    expect(todos[0].title).toBe('Approve PR (rechecked)')
+  })
+
+  it('drops an unresolved repo into the Inbox surface', async () => {
+    const { handle, token } = await startServer()
+    const client = await connectClient(handle.port, token)
+    const result = await callAddTodo(client, { repo: 'unknown/repo', title: 'Stray' })
+    expect(textOf(result)).toMatch(/Inbox/)
+    expect(listInboxTodos().map((t) => t.title)).toContain('Stray')
+  })
+
+  it('returns an error result for a missing title', async () => {
+    const { handle, token } = await startServer()
+    const client = await connectClient(handle.port, token)
+    const result = await callAddTodo(client, { repo: 'acme/widgets' })
+    expect(result.isError).toBe(true)
   })
 })
 

--- a/src/main/mcp-server/server.ts
+++ b/src/main/mcp-server/server.ts
@@ -39,6 +39,8 @@ export interface StartMcpServerOptions {
   extraSecrets?: () => readonly string[]
   /** Token generator (tests may inject a fixed value). Defaults to `generateToken`. */
   generateTokenFn?: () => string
+  /** Called after a tool successfully mutates todo state, so the app can push `todos:updated`. */
+  onTodoChanged?: () => void
 }
 
 export interface McpServerHandle {
@@ -134,6 +136,7 @@ export function startMcpServer(options: StartMcpServerOptions = {}): Promise<Mcp
   const token = (options.generateTokenFn ?? generateToken)()
   const toolDeps: ToolDeps = {
     getSecrets: () => [token, ...(options.extraSecrets?.() ?? [])],
+    onTodoChanged: options.onTodoChanged,
   }
 
   const httpServer: HttpServer = createServer((req, res) => {

--- a/src/main/mcp-server/tool-manifest.ts
+++ b/src/main/mcp-server/tool-manifest.ts
@@ -32,6 +32,9 @@ export interface ManifestTool {
 /** The `ping` tool: no input, exercises the surface end-to-end. */
 export const PING_TOOL_NAME = 'ping'
 
+/** The `add_todo` tool: Copilot creates a human-gated action-proposal todo in a project. */
+export const ADD_TODO_TOOL_NAME = 'add_todo'
+
 /** The full inbound tool surface. Order is the advertised order. */
 export const TOOL_MANIFEST: readonly ManifestTool[] = [
   {
@@ -40,6 +43,58 @@ export const TOOL_MANIFEST: readonly ManifestTool[] = [
     description:
       "No-op liveness check for the GH Projects inbound MCP server. Returns 'pong'.",
     inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+  },
+  {
+    name: ADD_TODO_TOOL_NAME,
+    title: 'Add todo',
+    description:
+      'Create a human-gated todo in a GH Projects project. Use this to PROPOSE an action ' +
+      '(e.g. after reviewing a PR) instead of performing it — this tool NEVER writes to ' +
+      'GitHub, it only files a todo the human can approve. Placement: an explicit `project` ' +
+      '(exact name) wins; otherwise `repo` (owner/name) is routed to a project via the same ' +
+      'rules notifications use; otherwise it lands in the Inbox. Repeated calls that carry the ' +
+      'same `sourceUrl` and `suggestedAction` update the existing todo instead of duplicating.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        project: {
+          type: 'string',
+          description: 'Exact name of the project to file the todo under. Takes precedence over `repo`.',
+        },
+        repo: {
+          type: 'string',
+          description: "Repository as 'owner/name'. Routed to a project via routing rules; falls back to the Inbox.",
+        },
+        title: {
+          type: 'string',
+          description: 'Short, imperative todo title. Required.',
+        },
+        body: {
+          type: 'string',
+          description: 'Optional markdown detail / instructions. Rendered as plain linkified text.',
+        },
+        sourceUrl: {
+          type: 'string',
+          description: 'Optional PR/issue URL (http/https). Shown as a clickable link and used for dedup.',
+        },
+        suggestedAction: {
+          type: 'object',
+          description:
+            'Optional one-tap action hint. Advisory only — the app renders an affordance but never ' +
+            'performs a GitHub write automatically.',
+          properties: {
+            kind: { type: 'string', enum: ['pr_comment', 'delegate', 'open_url'] },
+            url: { type: 'string', description: 'Target URL for pr_comment / open_url (http/https).' },
+            comment: { type: 'string', description: 'Comment body for pr_comment.' },
+            prompt: { type: 'string', description: 'Prompt to hand Copilot for delegate.' },
+          },
+          required: ['kind'],
+          additionalProperties: false,
+        },
+      },
+      required: ['title'],
+      additionalProperties: false,
+    },
   },
 ]
 

--- a/src/main/mcp-server/tool-manifest.ts
+++ b/src/main/mcp-server/tool-manifest.ts
@@ -78,18 +78,39 @@ export const TOOL_MANIFEST: readonly ManifestTool[] = [
           description: 'Optional PR/issue URL (http/https). Shown as a clickable link and used for dedup.',
         },
         suggestedAction: {
-          type: 'object',
           description:
-            'Optional one-tap action hint. Advisory only — the app renders an affordance but never ' +
-            'performs a GitHub write automatically.',
-          properties: {
-            kind: { type: 'string', enum: ['pr_comment', 'delegate', 'open_url'] },
-            url: { type: 'string', description: 'Target URL for pr_comment / open_url (http/https).' },
-            comment: { type: 'string', description: 'Comment body for pr_comment.' },
-            prompt: { type: 'string', description: 'Prompt to hand Copilot for delegate.' },
-          },
-          required: ['kind'],
-          additionalProperties: false,
+            'Optional one-tap action hint. Advisory only - the app renders an affordance but never ' +
+            'performs a GitHub write automatically. Shape depends on `kind`.',
+          oneOf: [
+            {
+              type: 'object',
+              properties: {
+                kind: { const: 'pr_comment' },
+                url: { type: 'string', description: 'PR/issue URL (http/https).' },
+                comment: { type: 'string', description: 'Comment body to propose.' },
+              },
+              required: ['kind', 'url', 'comment'],
+              additionalProperties: false,
+            },
+            {
+              type: 'object',
+              properties: {
+                kind: { const: 'delegate' },
+                prompt: { type: 'string', description: 'Prompt to hand Copilot.' },
+              },
+              required: ['kind', 'prompt'],
+              additionalProperties: false,
+            },
+            {
+              type: 'object',
+              properties: {
+                kind: { const: 'open_url' },
+                url: { type: 'string', description: 'URL to open (http/https).' },
+              },
+              required: ['kind', 'url'],
+              additionalProperties: false,
+            },
+          ],
         },
       },
       required: ['title'],

--- a/src/main/mcp-server/tools.test.ts
+++ b/src/main/mcp-server/tools.test.ts
@@ -1,19 +1,37 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { Server } from '@modelcontextprotocol/sdk/server/index.js'
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
+import { Database as BunDb } from 'bun:sqlite'
+import type BetterSQLite3 from 'better-sqlite3'
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
-import { registerTools } from './tools'
-import { PING_TOOL_NAME } from './tool-manifest'
+import { registerTools, type ToolDeps } from './tools'
+import { PING_TOOL_NAME, ADD_TODO_TOOL_NAME } from './tool-manifest'
+
+vi.mock('electron', () => ({
+  app: { isPackaged: false, getAppPath: () => process.cwd() },
+}))
+vi.mock('../db/index', () => ({ getDb: vi.fn() }))
+
+import { getDb } from '../db/index'
+import { runMigrations } from '../db/migrate'
+
+beforeEach(() => {
+  const db = new BunDb(':memory:')
+  db.exec('PRAGMA foreign_keys = ON')
+  const betterDb = db as unknown as BetterSQLite3.Database
+  runMigrations(betterDb)
+  vi.mocked(getDb).mockReturnValue(betterDb)
+})
 
 /** Stand up a low-level Server with the tools registered, over an in-memory pair. */
 async function withServer(
-  getSecrets: () => readonly string[],
+  deps: ToolDeps,
   fn: (client: Client) => Promise<void>
 ): Promise<void> {
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
   const server = new Server({ name: 'test', version: '1.0.0' }, { capabilities: { tools: {} } })
-  registerTools(server, { getSecrets })
+  registerTools(server, deps)
   await server.connect(serverTransport)
   const client = new Client({ name: 'test', version: '1.0.0' }, { capabilities: {} })
   await client.connect(clientTransport)
@@ -28,7 +46,7 @@ async function withServer(
 describe('registerTools', () => {
   it('advertises the ping tool via tools/list', async () => {
     await withServer(
-      () => [],
+      { getSecrets: () => [] },
       async (client) => {
         const { tools } = await client.listTools()
         const ping = tools.find((t) => t.name === PING_TOOL_NAME)
@@ -40,7 +58,7 @@ describe('registerTools', () => {
 
   it('ping returns pong', async () => {
     await withServer(
-      () => [],
+      { getSecrets: () => [] },
       async (client) => {
         const result = (await client.callTool({ name: PING_TOOL_NAME })) as CallToolResult
         expect(result.content).toEqual([{ type: 'text', text: 'pong' }])
@@ -50,11 +68,53 @@ describe('registerTools', () => {
 
   it('returns an isError result for an unknown tool', async () => {
     await withServer(
-      () => [],
+      { getSecrets: () => [] },
       async (client) => {
         const result = (await client.callTool({ name: 'does-not-exist' })) as CallToolResult
         expect(result.isError).toBe(true)
       }
     )
+  })
+})
+
+describe('add_todo registration', () => {
+  it('advertises add_todo via tools/list', async () => {
+    await withServer(
+      { getSecrets: () => [] },
+      async (client) => {
+        const { tools } = await client.listTools()
+        expect(tools.map((t) => t.name)).toContain(ADD_TODO_TOOL_NAME)
+      }
+    )
+  })
+
+  it('fires onTodoChanged after a successful add_todo', async () => {
+    const onTodoChanged = vi.fn()
+    await withServer(
+      { getSecrets: () => [], onTodoChanged },
+      async (client) => {
+        const result = (await client.callTool({
+          name: ADD_TODO_TOOL_NAME,
+          arguments: { title: 'A todo' },
+        })) as CallToolResult
+        expect(result.isError).toBeFalsy()
+      }
+    )
+    expect(onTodoChanged).toHaveBeenCalledTimes(1)
+  })
+
+  it('does NOT fire onTodoChanged when the call errors', async () => {
+    const onTodoChanged = vi.fn()
+    await withServer(
+      { getSecrets: () => [], onTodoChanged },
+      async (client) => {
+        const result = (await client.callTool({
+          name: ADD_TODO_TOOL_NAME,
+          arguments: {}, // missing title -> isError
+        })) as CallToolResult
+        expect(result.isError).toBe(true)
+      }
+    )
+    expect(onTodoChanged).not.toHaveBeenCalled()
   })
 })

--- a/src/main/mcp-server/tools.test.ts
+++ b/src/main/mcp-server/tools.test.ts
@@ -117,4 +117,25 @@ describe('add_todo registration', () => {
     )
     expect(onTodoChanged).not.toHaveBeenCalled()
   })
+
+  it('converts a handler exception into an isError result (no transport failure, no onTodoChanged)', async () => {
+    const onTodoChanged = vi.fn()
+    vi.mocked(getDb).mockImplementationOnce(() => {
+      throw new Error('db exploded')
+    })
+    await withServer(
+      { getSecrets: () => [], onTodoChanged },
+      async (client) => {
+        const result = (await client.callTool({
+          name: ADD_TODO_TOOL_NAME,
+          arguments: { title: 'x' }, // valid input, but the DB access throws
+        })) as CallToolResult
+        expect(result.isError).toBe(true)
+        // The generic failure text must not leak the thrown error's message.
+        const text = result.content[0]
+        expect(text.type === 'text' && text.text.includes('exploded')).toBe(false)
+      }
+    )
+    expect(onTodoChanged).not.toHaveBeenCalled()
+  })
 })

--- a/src/main/mcp-server/tools.ts
+++ b/src/main/mcp-server/tools.ts
@@ -68,7 +68,17 @@ export function registerTools(server: Server, deps: ToolDeps): void {
     if (handler === undefined) {
       return { content: [{ type: 'text', text: `Unknown tool: ${name}` }], isError: true }
     }
-    const result = await handler(args)
+    let result: CallToolResult
+    try {
+      result = await handler(args)
+    } catch (err) {
+      // A tool handler that throws (e.g. a DB error) must surface as a clean isError result,
+      // not a transport-level failure. Never echo the error detail — it could carry a secret
+      // or an internal path. (onTodoChanged lives inside the handler and only fires on a
+      // successful result, so a throw here never triggers it.)
+      console.error(`[mcp-server] tool "${name}" threw:`, err instanceof Error ? err.name : 'error')
+      result = { content: [{ type: 'text', text: `Tool "${name}" failed.` }], isError: true }
+    }
     // Defense-in-depth: scrub any known secret that slipped into the output.
     return sanitizeMcpJson(result, deps.getSecrets()) as CallToolResult
   })

--- a/src/main/mcp-server/tools.ts
+++ b/src/main/mcp-server/tools.ts
@@ -12,8 +12,9 @@
 import type { Server } from '@modelcontextprotocol/sdk/server/index.js'
 import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js'
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
-import { PING_TOOL_NAME, TOOL_MANIFEST } from './tool-manifest'
+import { ADD_TODO_TOOL_NAME, PING_TOOL_NAME, TOOL_MANIFEST } from './tool-manifest'
 import { sanitizeMcpJson } from './sanitize'
+import { runAddTodo } from './add-todo'
 
 /** Dependencies a tool handler may need. */
 export interface ToolDeps {
@@ -22,6 +23,12 @@ export interface ToolDeps {
    * GitHub PAT, …). Read lazily so a rotated token is always current.
    */
   getSecrets: () => readonly string[]
+  /**
+   * Fired after a tool successfully mutates todo state (the `add_todo` tool). The app uses
+   * this to push a `todos:updated` event so open todo surfaces reload live. Optional so tests
+   * and the shim can omit it.
+   */
+  onTodoChanged?: () => void
 }
 
 /** A tool handler: validated args in, an MCP `CallToolResult` out. */
@@ -29,10 +36,15 @@ export type ToolHandler = (
   args: Record<string, unknown>
 ) => CallToolResult | Promise<CallToolResult>
 
-/** Build the name → handler map. Foundation surface: just `ping`. */
-export function buildToolHandlers(_deps: ToolDeps): Map<string, ToolHandler> {
+/** Build the name → handler map. */
+export function buildToolHandlers(deps: ToolDeps): Map<string, ToolHandler> {
   const handlers = new Map<string, ToolHandler>()
   handlers.set(PING_TOOL_NAME, () => ({ content: [{ type: 'text', text: 'pong' }] }))
+  handlers.set(ADD_TODO_TOOL_NAME, (args) => {
+    const result = runAddTodo(args)
+    if (result.isError !== true) deps.onTodoChanged?.()
+    return result
+  })
   return handlers
 }
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -35,6 +35,11 @@ const api: ElectronApi = {
     const handler = () => callback()
     ipcRenderer.on('resources:updated', handler)
     return () => { ipcRenderer.removeListener('resources:updated', handler) }
+  },
+  onTodosUpdated: (callback: () => void) => {
+    const handler = () => callback()
+    ipcRenderer.on('todos:updated', handler)
+    return () => { ipcRenderer.removeListener('todos:updated', handler) }
   }
 }
 

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { Project, SnoozeMode } from '@shared/ipc-channels'
 import styles from './App.module.css'
 import { Titlebar } from './components/Titlebar'
@@ -31,6 +31,7 @@ export function App(): JSX.Element {
   const [railCollapsed, setRailCollapsed] = useState(false)
   const [inboxCount, setInboxCount] = useState(0)
   const [agentTaskCount, setAgentTaskCount] = useState(0)
+  const inboxCountReqRef = useRef(0)
 
   // Keep focus on a valid project; fall back to the first active one.
   useEffect(() => {
@@ -43,12 +44,17 @@ export function App(): JSX.Element {
   }, [isLoading, projects, focusedId, setFocusedId])
 
   const loadInboxCount = useCallback(async () => {
+    const reqId = ++inboxCountReqRef.current
     try {
       const [threads, inboxTodos] = await Promise.all([
         window.electron.ipc.invoke('notifications:inbox'),
         window.electron.ipc.invoke('todos:inbox'),
       ])
-      setInboxCount(threads.filter((t) => t.unread).length + inboxTodos.filter((t) => !t.done).length)
+      // Only the latest in-flight request may set the count, so a slower stale load
+      // can't overwrite a fresher one.
+      if (reqId === inboxCountReqRef.current) {
+        setInboxCount(threads.filter((t) => t.unread).length + inboxTodos.filter((t) => !t.done).length)
+      }
     } catch (err) {
       console.error('[App] Failed to load inbox count:', err)
     }

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -44,8 +44,11 @@ export function App(): JSX.Element {
 
   const loadInboxCount = useCallback(async () => {
     try {
-      const threads = await window.electron.ipc.invoke('notifications:inbox')
-      setInboxCount(threads.filter((t) => t.unread).length)
+      const [threads, inboxTodos] = await Promise.all([
+        window.electron.ipc.invoke('notifications:inbox'),
+        window.electron.ipc.invoke('todos:inbox'),
+      ])
+      setInboxCount(threads.filter((t) => t.unread).length + inboxTodos.filter((t) => !t.done).length)
     } catch (err) {
       console.error('[App] Failed to load inbox count:', err)
     }
@@ -53,8 +56,12 @@ export function App(): JSX.Element {
 
   useEffect(() => {
     void loadInboxCount()
-    const unsub = window.electron.onNotificationsUpdated(() => { void loadInboxCount() })
-    return unsub
+    const unsubNotif = window.electron.onNotificationsUpdated(() => { void loadInboxCount() })
+    const unsubTodos = window.electron.onTodosUpdated(() => { void loadInboxCount() })
+    return () => {
+      unsubNotif()
+      unsubTodos()
+    }
   }, [loadInboxCount])
 
   const loadAgentTaskCount = useCallback(async () => {

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -228,7 +228,7 @@ export function App(): JSX.Element {
         />
 
         {view === 'inbox' ? (
-          <InboxView onAssigned={() => { void refreshProjects(); void loadInboxCount() }} />
+          <InboxView onAssigned={() => { void refreshProjects(); void loadInboxCount() }} showUndo={showUndo} />
         ) : view === 'agent-tasks' ? (
           <AgentTasksView />
         ) : view === 'settings' ? (

--- a/src/renderer/src/components/WorkingColumn.module.css
+++ b/src/renderer/src/components/WorkingColumn.module.css
@@ -171,6 +171,63 @@
   margin: 8px 0;
 }
 
+/* Agent-todo affordances */
+.todoFilter {
+  display: flex;
+  gap: 6px;
+  padding: 4px 0 6px 26px;
+}
+
+.filterChip {
+  height: 22px;
+  padding: 0 9px;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  background: none;
+  border: 1px solid var(--border-muted);
+  border-radius: 11px;
+  font-family: var(--font-ui);
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--text-2);
+  cursor: pointer;
+  transition: color var(--transition), border-color var(--transition), background var(--transition);
+}
+
+.filterChip:hover {
+  color: var(--text);
+}
+
+.filterChip[aria-pressed='true'] {
+  color: var(--text);
+  border-color: var(--accent-text);
+  background: var(--bg-inset);
+}
+
+.originBadge {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  margin-left: 8px;
+  padding: 1px 6px;
+  border: 1px solid var(--border-muted);
+  border-radius: 9px;
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--accent-text);
+  vertical-align: middle;
+  white-space: nowrap;
+}
+
+.todoBody {
+  padding: 0 0 4px 26px;
+  font-size: 12px;
+  line-height: 1.45;
+  color: var(--text-2);
+  white-space: pre-wrap;
+}
+
 /* Notes */
 .notes {
   width: 100%;

--- a/src/renderer/src/components/WorkingColumn.tsx
+++ b/src/renderer/src/components/WorkingColumn.tsx
@@ -182,7 +182,9 @@ function TodosPanel({
           </button>
         </div>
       ))}
-      {visible.length === 0 && filter === 'copilot' && <div className={styles.empty}>No Copilot todos yet.</div>}
+      {visible.length === 0 && filter === 'copilot' && detail.todos.length > 0 && (
+        <div className={styles.empty}>No Copilot todos yet.</div>
+      )}
       {detail.todos.length === 0 && <div className={styles.empty}>No todos yet. Add the first one above.</div>}
     </div>
   )

--- a/src/renderer/src/components/WorkingColumn.tsx
+++ b/src/renderer/src/components/WorkingColumn.tsx
@@ -90,6 +90,12 @@ function TodosPanel({
   const [filter, setFilter] = useState<TodoFilter>('all')
 
   const copilotCount = detail.todos.filter((t) => t.origin === 'copilot').length
+  // The filter chips only show when copilotCount > 0, so if the last Copilot todo goes away
+  // while the Copilot filter is active, snap back to "all" — otherwise the user is stranded in
+  // an empty Copilot view with no chips to switch back.
+  useEffect(() => {
+    if (copilotCount === 0 && filter === 'copilot') setFilter('all')
+  }, [copilotCount, filter])
   const visible = filter === 'copilot' ? detail.todos.filter((t) => t.origin === 'copilot') : detail.todos
   const active = visible.filter((t) => !t.done)
   const done = visible.filter((t) => t.done)

--- a/src/renderer/src/components/WorkingColumn.tsx
+++ b/src/renderer/src/components/WorkingColumn.tsx
@@ -15,6 +15,7 @@ import {
   CircleAlert,
   Trash2,
   Sparkles,
+  ExternalLink,
 } from 'lucide-react'
 import type { NotificationThread, NotificationType, ProjectDetail, ProjectTodo, LaunchTarget, CopilotAppSession } from '@shared/ipc-channels'
 import type { LucideIcon } from 'lucide-react'
@@ -23,6 +24,7 @@ import { ResourcePanel } from './ResourcePanel'
 import { TodoSessionChip } from './TodoSessionChip'
 import { LinkifiedText } from './LinkifiedText'
 import { fire, openExternal } from '../ipc'
+import { isSafeExternalUrl } from '@shared/safe-url'
 import styles from './WorkingColumn.module.css'
 
 type TabId = 'todos' | 'notes' | 'resources' | 'notifications'
@@ -51,6 +53,31 @@ function relativeTime(iso: string): string {
 
 // ── Todos ─────────────────────────────────────────────────────────────────────
 
+type TodoFilter = 'all' | 'copilot'
+
+/** The link a copilot todo's one-tap "open" affordance should point at, if any. */
+function openableUrl(todo: ProjectTodo): string | null {
+  const action = todo.suggestedAction
+  if (action && (action.kind === 'pr_comment' || action.kind === 'open_url') && isSafeExternalUrl(action.url)) {
+    return action.url
+  }
+  return isSafeExternalUrl(todo.sourceUrl) ? todo.sourceUrl : null
+}
+
+/** The prompt to hand Copilot when delegating a todo — a delegate action's prompt, else the title. */
+function delegatePrompt(todo: ProjectTodo): string {
+  return todo.suggestedAction?.kind === 'delegate' ? todo.suggestedAction.prompt : todo.title ?? todo.text
+}
+
+function CopilotBadge(): JSX.Element {
+  return (
+    <span className={styles.originBadge} title="Created by Copilot">
+      <Icon icon={Sparkles} size={10} />
+      Copilot
+    </span>
+  )
+}
+
 function TodosPanel({
   detail,
   onCreateTodo,
@@ -60,8 +87,12 @@ function TodosPanel({
   appSessionsByTodo,
 }: Pick<WorkingColumnProps, 'detail' | 'onCreateTodo' | 'onToggleTodo' | 'onDeleteTodo' | 'onDelegate' | 'appSessionsByTodo'>): JSX.Element {
   const [text, setText] = useState('')
-  const active = detail.todos.filter((t) => !t.done)
-  const done = detail.todos.filter((t) => t.done)
+  const [filter, setFilter] = useState<TodoFilter>('all')
+
+  const copilotCount = detail.todos.filter((t) => t.origin === 'copilot').length
+  const visible = filter === 'copilot' ? detail.todos.filter((t) => t.origin === 'copilot') : detail.todos
+  const active = visible.filter((t) => !t.done)
+  const done = visible.filter((t) => t.done)
 
   const submit = (): void => {
     const trimmed = text.trim()
@@ -82,35 +113,76 @@ function TodosPanel({
           onKeyDown={(e) => e.key === 'Enter' && submit()}
         />
       </div>
-      {active.map((t) => (
-        <div key={t.id} className={styles.todoItem}>
-          <div className={styles.todoRow}>
-            <button type="button" className={styles.checkbox} onClick={() => onToggleTodo(t)} aria-label="Mark done" />
-            <span className={styles.todoText}><LinkifiedText text={t.text} /></span>
-            <button type="button" className={styles.rowAction} onClick={() => onDelegate(t.text, undefined, t.id)} aria-label="Delegate to Copilot" title="Delegate to Copilot">
-              <Icon icon={Sparkles} size={13} />
-            </button>
-            <button type="button" className={styles.rowAction} onClick={() => onDeleteTodo(t)} aria-label="Delete todo">
-              <Icon icon={Trash2} size={13} />
-            </button>
-          </div>
-          {(appSessionsByTodo.get(t.id) ?? []).map((s) => (
-            <TodoSessionChip key={s.id} session={s} />
-          ))}
+      {copilotCount > 0 && (
+        <div className={styles.todoFilter} role="group" aria-label="Filter todos">
+          <button
+            type="button"
+            className={styles.filterChip}
+            aria-pressed={filter === 'all'}
+            onClick={() => setFilter('all')}
+          >
+            All
+          </button>
+          <button
+            type="button"
+            className={styles.filterChip}
+            aria-pressed={filter === 'copilot'}
+            onClick={() => setFilter('copilot')}
+          >
+            <Icon icon={Sparkles} size={11} />
+            Copilot
+          </button>
         </div>
-      ))}
+      )}
+      {active.map((t) => {
+        const url = openableUrl(t)
+        return (
+          <div key={t.id} className={styles.todoItem}>
+            <div className={styles.todoRow}>
+              <button type="button" className={styles.checkbox} onClick={() => onToggleTodo(t)} aria-label="Mark done" />
+              <span className={styles.todoText}>
+                <LinkifiedText text={t.title ?? t.text} />
+                {t.origin === 'copilot' && <CopilotBadge />}
+              </span>
+              {url && (
+                <button type="button" className={styles.rowAction} onClick={() => openExternal(url)} aria-label="Open link" title="Open link">
+                  <Icon icon={ExternalLink} size={13} />
+                </button>
+              )}
+              <button type="button" className={styles.rowAction} onClick={() => onDelegate(delegatePrompt(t), undefined, t.id)} aria-label="Delegate to Copilot" title="Delegate to Copilot">
+                <Icon icon={Sparkles} size={13} />
+              </button>
+              <button type="button" className={styles.rowAction} onClick={() => onDeleteTodo(t)} aria-label="Delete todo">
+                <Icon icon={Trash2} size={13} />
+              </button>
+            </div>
+            {t.body && (
+              <div className={styles.todoBody}>
+                <LinkifiedText text={t.body} />
+              </div>
+            )}
+            {(appSessionsByTodo.get(t.id) ?? []).map((s) => (
+              <TodoSessionChip key={s.id} session={s} />
+            ))}
+          </div>
+        )
+      })}
       {done.length > 0 && <div className={styles.divider} />}
       {done.map((t) => (
         <div key={t.id} className={`${styles.todoRow} ${styles.todoDone}`}>
           <button type="button" className={`${styles.checkbox} ${styles.checkboxDone}`} onClick={() => onToggleTodo(t)} aria-label="Mark not done">
             <Icon icon={Check} size={11} strokeWidth={3} />
           </button>
-          <span className={`${styles.todoText} ${styles.struck}`}><LinkifiedText text={t.text} /></span>
+          <span className={`${styles.todoText} ${styles.struck}`}>
+            <LinkifiedText text={t.title ?? t.text} />
+            {t.origin === 'copilot' && <CopilotBadge />}
+          </span>
           <button type="button" className={styles.rowAction} onClick={() => onDeleteTodo(t)} aria-label="Delete todo">
             <Icon icon={Trash2} size={13} />
           </button>
         </div>
       ))}
+      {visible.length === 0 && filter === 'copilot' && <div className={styles.empty}>No Copilot todos yet.</div>}
       {detail.todos.length === 0 && <div className={styles.empty}>No todos yet. Add the first one above.</div>}
     </div>
   )

--- a/src/renderer/src/hooks/useProjectDetail.ts
+++ b/src/renderer/src/hooks/useProjectDetail.ts
@@ -80,6 +80,16 @@ export function useProjectDetail(
     }
   }, [projectId])
 
+  // Reload when an agent todo is created/updated out-of-band by the `add_todo` MCP tool, so
+  // it appears live. This fires only on real tool-driven todo changes (not the periodic drift
+  // tick), so it can't clobber the user's own in-flight optimistic todo mutations.
+  useEffect(() => {
+    const unsub = window.electron.onTodosUpdated(() => {
+      void reload()
+    })
+    return unsub
+  }, [reload])
+
   const updateProject = useCallback(
     async (patch: ProjectPatch): Promise<void> => {
       const updated = await window.electron.ipc.invoke('projects:update', projectId, patch)

--- a/src/renderer/src/pages/InboxView.module.css
+++ b/src/renderer/src/pages/InboxView.module.css
@@ -121,6 +121,30 @@
   font-size: 13px;
 }
 
+.sectionLabel {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 12px 0 6px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  color: var(--text-3);
+}
+
+.sectionLabel:first-child {
+  padding-top: 0;
+}
+
+.todoBody {
+  font-size: 12px;
+  line-height: 1.45;
+  color: var(--text-2);
+  margin-top: 3px;
+  white-space: pre-wrap;
+}
+
 .error {
   color: var(--danger);
 }

--- a/src/renderer/src/pages/InboxView.tsx
+++ b/src/renderer/src/pages/InboxView.tsx
@@ -101,14 +101,15 @@ export function InboxView({ onAssigned, showUndo }: InboxViewProps): JSX.Element
       setProjects(projectList.filter((p) => p.status === 'active'))
       setIsAuthenticated(authStatus.authenticated)
       setLastSyncTime(syncTime)
+      // Await so isLoading doesn't clear before inbox todos are known, otherwise the
+      // "Inbox is empty" copy can flash while loadTodos() is still in flight.
+      await loadTodos()
     } catch (err) {
       console.error('[Inbox] Failed to load:', err)
       if (mountedRef.current) setSyncError('Could not load the inbox. Try syncing again.')
     } finally {
       if (mountedRef.current) setIsLoading(false)
     }
-    // Inbox todos always flow through the single guarded loader.
-    void loadTodos()
   }, [loadTodos])
 
   useEffect(() => {

--- a/src/renderer/src/pages/InboxView.tsx
+++ b/src/renderer/src/pages/InboxView.tsx
@@ -65,6 +65,9 @@ export function InboxView({ onAssigned, showUndo }: InboxViewProps): JSX.Element
   const [isAuthenticated, setIsAuthenticated] = useState<boolean | null>(null)
   const [suggestion, setSuggestion] = useState<(RepoRuleSuggestion & { threadId: string }) | null>(null)
   const mountedRef = useRef(true)
+  // Monotonic request id so a slower in-flight inbox-todo fetch can't overwrite a newer one
+  // (e.g. a broad load() racing a todos:updated-triggered refresh).
+  const todosReqRef = useRef(0)
 
   useEffect(() => {
     mountedRef.current = true
@@ -74,9 +77,12 @@ export function InboxView({ onAssigned, showUndo }: InboxViewProps): JSX.Element
   }, [])
 
   const loadTodos = useCallback(async () => {
+    const reqId = ++todosReqRef.current
     try {
       const todos = await window.electron.ipc.invoke('todos:inbox')
-      if (mountedRef.current) setInboxTodos(todos.filter((t) => !t.done))
+      if (mountedRef.current && reqId === todosReqRef.current) {
+        setInboxTodos(todos.filter((t) => !t.done))
+      }
     } catch (err) {
       console.error('[Inbox] Failed to load agent todos:', err)
     }
@@ -84,26 +90,26 @@ export function InboxView({ onAssigned, showUndo }: InboxViewProps): JSX.Element
 
   const load = useCallback(async () => {
     try {
-      const [inbox, projectList, authStatus, syncTime, todos] = await Promise.all([
+      const [inbox, projectList, authStatus, syncTime] = await Promise.all([
         window.electron.ipc.invoke('notifications:inbox'),
         window.electron.ipc.invoke('projects:list'),
         window.electron.ipc.invoke('auth:status'),
         window.electron.ipc.invoke('notifications:last-sync-time'),
-        window.electron.ipc.invoke('todos:inbox'),
       ])
       if (!mountedRef.current) return
       setThreads(inbox)
       setProjects(projectList.filter((p) => p.status === 'active'))
       setIsAuthenticated(authStatus.authenticated)
       setLastSyncTime(syncTime)
-      setInboxTodos(todos.filter((t) => !t.done))
     } catch (err) {
       console.error('[Inbox] Failed to load:', err)
       if (mountedRef.current) setSyncError('Could not load the inbox. Try syncing again.')
     } finally {
       if (mountedRef.current) setIsLoading(false)
     }
-  }, [])
+    // Inbox todos always flow through the single guarded loader.
+    void loadTodos()
+  }, [loadTodos])
 
   useEffect(() => {
     void load()

--- a/src/renderer/src/pages/InboxView.tsx
+++ b/src/renderer/src/pages/InboxView.tsx
@@ -167,10 +167,15 @@ export function InboxView({ onAssigned, showUndo }: InboxViewProps): JSX.Element
       setInboxTodos((prev) => prev.filter((t) => t.id !== todo.id))
       onAssigned()
       showUndo('Marked done', () => {
-        void window.electron.ipc.invoke('todos:update', todo.id, { done: false }).then(() => {
-          onAssigned()
-          return loadTodos()
-        })
+        void (async () => {
+          try {
+            await window.electron.ipc.invoke('todos:update', todo.id, { done: false })
+            onAssigned()
+            await loadTodos()
+          } catch (err) {
+            console.error('[Inbox] Undo mark-done failed:', err)
+          }
+        })()
       })
     } catch (err) {
       console.error('[Inbox] Mark todo done failed:', err)
@@ -184,10 +189,15 @@ export function InboxView({ onAssigned, showUndo }: InboxViewProps): JSX.Element
       setInboxTodos((prev) => prev.filter((t) => t.id !== todo.id))
       onAssigned()
       showUndo('Todo dismissed', () => {
-        void window.electron.ipc.invoke('todos:restore', todo.id).then(() => {
-          onAssigned()
-          return loadTodos()
-        })
+        void (async () => {
+          try {
+            await window.electron.ipc.invoke('todos:restore', todo.id)
+            onAssigned()
+            await loadTodos()
+          } catch (err) {
+            console.error('[Inbox] Undo dismiss failed:', err)
+          }
+        })()
       })
     } catch (err) {
       console.error('[Inbox] Dismiss todo failed:', err)

--- a/src/renderer/src/pages/InboxView.tsx
+++ b/src/renderer/src/pages/InboxView.tsx
@@ -11,15 +11,20 @@ import {
   Bell,
   ExternalLink,
   Check,
+  Sparkles,
+  Trash2,
 } from 'lucide-react'
-import type { NotificationThread, NotificationType, Project, RepoRuleSuggestion } from '@shared/ipc-channels'
+import type { NotificationThread, NotificationType, Project, ProjectTodo, RepoRuleSuggestion } from '@shared/ipc-channels'
 import type { LucideIcon } from 'lucide-react'
 import { Icon } from '../components/Icon'
+import { LinkifiedText } from '../components/LinkifiedText'
 import { openExternal } from '../ipc'
+import { isSafeExternalUrl } from '@shared/safe-url'
 import styles from './InboxView.module.css'
 
 interface InboxViewProps {
   onAssigned: () => void
+  showUndo: (message: string, onUndo: () => void, actionLabel?: string) => void
 }
 
 const NOTIF_ICON: Record<NotificationType, LucideIcon> = {
@@ -40,8 +45,18 @@ function relativeTime(iso: string): string {
   }
 }
 
-export function InboxView({ onAssigned }: InboxViewProps): JSX.Element {
+/** The link an agent todo's one-tap "open" affordance should point at, if any. */
+function inboxTodoUrl(todo: ProjectTodo): string | null {
+  const action = todo.suggestedAction
+  if (action && (action.kind === 'pr_comment' || action.kind === 'open_url') && isSafeExternalUrl(action.url)) {
+    return action.url
+  }
+  return isSafeExternalUrl(todo.sourceUrl) ? todo.sourceUrl : null
+}
+
+export function InboxView({ onAssigned, showUndo }: InboxViewProps): JSX.Element {
   const [threads, setThreads] = useState<NotificationThread[]>([])
+  const [inboxTodos, setInboxTodos] = useState<ProjectTodo[]>([])
   const [projects, setProjects] = useState<Project[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const [isSyncing, setIsSyncing] = useState(false)
@@ -58,19 +73,30 @@ export function InboxView({ onAssigned }: InboxViewProps): JSX.Element {
     }
   }, [])
 
+  const loadTodos = useCallback(async () => {
+    try {
+      const todos = await window.electron.ipc.invoke('todos:inbox')
+      if (mountedRef.current) setInboxTodos(todos.filter((t) => !t.done))
+    } catch (err) {
+      console.error('[Inbox] Failed to load agent todos:', err)
+    }
+  }, [])
+
   const load = useCallback(async () => {
     try {
-      const [inbox, projectList, authStatus, syncTime] = await Promise.all([
+      const [inbox, projectList, authStatus, syncTime, todos] = await Promise.all([
         window.electron.ipc.invoke('notifications:inbox'),
         window.electron.ipc.invoke('projects:list'),
         window.electron.ipc.invoke('auth:status'),
         window.electron.ipc.invoke('notifications:last-sync-time'),
+        window.electron.ipc.invoke('todos:inbox'),
       ])
       if (!mountedRef.current) return
       setThreads(inbox)
       setProjects(projectList.filter((p) => p.status === 'active'))
       setIsAuthenticated(authStatus.authenticated)
       setLastSyncTime(syncTime)
+      setInboxTodos(todos.filter((t) => !t.done))
     } catch (err) {
       console.error('[Inbox] Failed to load:', err)
       if (mountedRef.current) setSyncError('Could not load the inbox. Try syncing again.')
@@ -81,9 +107,13 @@ export function InboxView({ onAssigned }: InboxViewProps): JSX.Element {
 
   useEffect(() => {
     void load()
-    const unsub = window.electron.onNotificationsUpdated(() => { void load() })
-    return unsub
-  }, [load])
+    const unsubNotif = window.electron.onNotificationsUpdated(() => { void load() })
+    const unsubTodos = window.electron.onTodosUpdated(() => { void loadTodos() })
+    return () => {
+      unsubNotif()
+      unsubTodos()
+    }
+  }, [load, loadTodos])
 
   const handleSync = useCallback(async () => {
     if (isSyncing) return
@@ -119,6 +149,30 @@ export function InboxView({ onAssigned }: InboxViewProps): JSX.Element {
       setThreads((prev) => prev.filter((t) => t.id !== threadId))
     } catch (err) {
       console.error('[Inbox] Mark read failed:', err)
+    }
+  }
+
+  const handleTodoDone = async (todo: ProjectTodo): Promise<void> => {
+    try {
+      await window.electron.ipc.invoke('todos:update', todo.id, { done: true })
+      setInboxTodos((prev) => prev.filter((t) => t.id !== todo.id))
+      showUndo('Marked done', () => {
+        void window.electron.ipc.invoke('todos:update', todo.id, { done: false }).then(() => loadTodos())
+      })
+    } catch (err) {
+      console.error('[Inbox] Mark todo done failed:', err)
+    }
+  }
+
+  const handleTodoDismiss = async (todo: ProjectTodo): Promise<void> => {
+    try {
+      await window.electron.ipc.invoke('todos:delete', todo.id)
+      setInboxTodos((prev) => prev.filter((t) => t.id !== todo.id))
+      showUndo('Todo dismissed', () => {
+        void window.electron.ipc.invoke('todos:restore', todo.id).then(() => loadTodos())
+      })
+    } catch (err) {
+      console.error('[Inbox] Dismiss todo failed:', err)
     }
   }
 
@@ -160,13 +214,52 @@ export function InboxView({ onAssigned }: InboxViewProps): JSX.Element {
       )}
 
       <div className={styles.content}>
+        {inboxTodos.length > 0 && (
+          <>
+            <div className={styles.sectionLabel}>
+              <Icon icon={Sparkles} size={13} />
+              From Copilot
+            </div>
+            {inboxTodos.map((t) => {
+              const url = inboxTodoUrl(t)
+              return (
+                <div key={t.id} className={styles.row}>
+                  <Icon icon={Sparkles} size={16} className={styles.rowIcon} />
+                  <div className={styles.rowBody}>
+                    <div className={styles.rowTitle}>{t.title ?? t.text}</div>
+                    {t.body && <div className={styles.todoBody}><LinkifiedText text={t.body} /></div>}
+                  </div>
+                  {url && (
+                    <button type="button" className={styles.rowAction} onClick={() => openExternal(url)} aria-label="Open link">
+                      <Icon icon={ExternalLink} size={14} />
+                    </button>
+                  )}
+                  <button type="button" className={styles.rowAction} onClick={() => void handleTodoDone(t)} aria-label="Mark done">
+                    <Icon icon={Check} size={14} />
+                  </button>
+                  <button type="button" className={styles.rowAction} onClick={() => void handleTodoDismiss(t)} aria-label="Dismiss todo">
+                    <Icon icon={Trash2} size={14} />
+                  </button>
+                </div>
+              )
+            })}
+          </>
+        )}
+
         {isLoading && <div className={styles.empty}>Loading…</div>}
         {!isLoading && syncError && <div className={styles.error}>{syncError}</div>}
         {!isLoading && isAuthenticated === false && (
           <div className={styles.empty}>Connect a GitHub token in Settings to fetch notifications.</div>
         )}
-        {!isLoading && isAuthenticated && threads.length === 0 && !syncError && (
+        {!isLoading && isAuthenticated && threads.length === 0 && inboxTodos.length === 0 && !syncError && (
           <div className={styles.empty}>Inbox is empty. Nothing needs routing.</div>
+        )}
+
+        {threads.length > 0 && inboxTodos.length > 0 && (
+          <div className={styles.sectionLabel}>
+            <Icon icon={Bell} size={13} />
+            Notifications
+          </div>
         )}
 
         {threads.map((t) => (

--- a/src/renderer/src/pages/InboxView.tsx
+++ b/src/renderer/src/pages/InboxView.tsx
@@ -161,9 +161,16 @@ export function InboxView({ onAssigned, showUndo }: InboxViewProps): JSX.Element
   const handleTodoDone = async (todo: ProjectTodo): Promise<void> => {
     try {
       await window.electron.ipc.invoke('todos:update', todo.id, { done: true })
+      // Invalidate any in-flight inbox-todo fetch so a stale result can't re-add this row,
+      // then optimistically drop it and refresh the rail badge.
+      todosReqRef.current += 1
       setInboxTodos((prev) => prev.filter((t) => t.id !== todo.id))
+      onAssigned()
       showUndo('Marked done', () => {
-        void window.electron.ipc.invoke('todos:update', todo.id, { done: false }).then(() => loadTodos())
+        void window.electron.ipc.invoke('todos:update', todo.id, { done: false }).then(() => {
+          onAssigned()
+          return loadTodos()
+        })
       })
     } catch (err) {
       console.error('[Inbox] Mark todo done failed:', err)
@@ -173,9 +180,14 @@ export function InboxView({ onAssigned, showUndo }: InboxViewProps): JSX.Element
   const handleTodoDismiss = async (todo: ProjectTodo): Promise<void> => {
     try {
       await window.electron.ipc.invoke('todos:delete', todo.id)
+      todosReqRef.current += 1
       setInboxTodos((prev) => prev.filter((t) => t.id !== todo.id))
+      onAssigned()
       showUndo('Todo dismissed', () => {
-        void window.electron.ipc.invoke('todos:restore', todo.id).then(() => loadTodos())
+        void window.electron.ipc.invoke('todos:restore', todo.id).then(() => {
+          onAssigned()
+          return loadTodos()
+        })
       })
     } catch (err) {
       console.error('[Inbox] Dismiss todo failed:', err)

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -267,13 +267,37 @@ export interface UnreadCount {
 
 export type ProjectPatch = Partial<Pick<Project, 'name' | 'notes' | 'nextAction' | 'status' | 'sortOrder'>>
 
+/** Where a todo came from: a human (`user`) or the Copilot agent via the `add_todo` MCP tool. */
+export type TodoOrigin = 'user' | 'copilot'
+
+/**
+ * A structured, one-tap action hint attached to an agent todo. Purely advisory — the
+ * app renders an affordance for it but NEVER performs a GitHub write on the agent's
+ * behalf; the human stays in the loop.
+ */
+export type SuggestedAction =
+  | { kind: 'pr_comment'; url: string; comment: string }
+  | { kind: 'delegate'; prompt: string }
+  | { kind: 'open_url'; url: string }
+
 export interface ProjectTodo {
   id: number
-  projectId: number
+  /** Owning project, or `null` when the todo sits in the Inbox (unresolved repo). */
+  projectId: number | null
   text: string
   done: boolean
   sortOrder: number
   createdAt: string
+  /** Agent-todo fields (null on plain user todos). */
+  title: string | null
+  /** Markdown instructions. Rendered as plain linkified text (never as raw HTML). */
+  body: string | null
+  /** Source PR/issue link — clickable and used for dedup. */
+  sourceUrl: string | null
+  suggestedAction: SuggestedAction | null
+  origin: TodoOrigin
+  /** Deterministic dedup key for agent todos; null for user todos (never deduped). */
+  idempotencyKey: string | null
 }
 
 export type ProjectTodoPatch = Partial<Pick<ProjectTodo, 'text' | 'done' | 'sortOrder'>>
@@ -580,6 +604,12 @@ export type IpcChannels = {
   'todos:delete': {
     args: [id: number]
     result: void
+  }
+
+  /** Lists Inbox todos (no owning project, not soft-deleted) — the agent-todo Inbox surface. */
+  'todos:inbox': {
+    args: []
+    result: ProjectTodo[]
   }
 
   // ── Links ──────────────────────────────────────────────────────────────────
@@ -1048,6 +1078,13 @@ export interface ElectronApi {
   onProjectsUpdated: (callback: () => void) => () => void
   /** Registers a callback that fires whenever a project's resource registry changes. Returns an unsubscribe fn. */
   onResourcesUpdated: (callback: () => void) => () => void
+  /**
+   * Registers a callback that fires when todos change out-of-band — specifically when the
+   * `add_todo` MCP tool inserts or updates an agent todo. Todo surfaces (a project's todo
+   * list, the Inbox agent-todo section) reload on this so an agent-created todo appears
+   * live. Returns an unsubscribe fn.
+   */
+  onTodosUpdated: (callback: () => void) => () => void
 }
 
 declare global {


### PR DESCRIPTION
Closes #102. Part of epic #98. Builds on #103 (inbound MCP server) and #99.

This is the first real tool on the inbound MCP server, so it sets the pattern the sibling issues (#100, #106) will copy.

## What this does

Copilot can now create a rich, human-gated todo in a project via an `add_todo` MCP tool. Example: after reviewing a PR, it proposes *"Approve and comment 'well thought out PR!' on <pr_url>"* which lands as an **approvable todo, never a GitHub write**.

### Todo model
`ProjectTodo` gains `title`, `body` (markdown), `sourceUrl`, `suggestedAction?` (a typed union: `pr_comment` / `delegate` / `open_url`), `origin: 'user' | 'copilot'`, and a deterministic `idempotencyKey`. `projectId` is now nullable (`null` = Inbox). Existing user todos stay valid (`origin: 'user'`, null new fields).

### `add_todo` tool
- Input `{ project?, repo?, title, body?, sourceUrl?, suggestedAction? }`.
- **Placement** reuses the exact notification precedence: explicit `project` name wins; else `repo` resolves through `repo_rules` -> `routing_rules` (via the existing `routingRuleMatches`, with a live-project gate); else the Inbox.
- **Never touches GitHub** - it only inserts/updates a todo row.
- **Idempotent**: key = `sha256(safe-href(sourceUrl) + full canonicalAction)`. A re-review of the same PR proposing the *same* action updates in place; a genuinely different action produces a distinct todo. On conflict, content is refreshed, `done`/`deleted_at` are preserved, and placement is sticky (except an explicit `project`, or rehoming off a soft-deleted project). The tool reports an honest status (`created` / `updated` / `updated_dismissed` / `updated_completed`).

### UI
- Project todos: a `Copilot` origin badge, rendered body, a one-tap open-link / delegate affordance, an All/Copilot filter, and the existing soft-delete + undo.
- A "From Copilot" section in the Inbox for todos whose repo didn't resolve (open / mark-done / dismiss + undo).
- Live refresh via a dedicated `todos:updated` event (not the 60s drift tick) so an agent-created todo appears without clobbering the user's own optimistic edits. The rail Inbox badge counts active Copilot inbox todos too.

### Migration
`020_agent_todos.sql` rebuilds `project_todos` to make `project_id` nullable and add the new columns + a partial unique index on `idempotency_key`. It preserves ids (and the `todo_copilot_app_sessions` FK) and the `sqlite_sequence` high-water mark, and the migration runner now rolls back + restores foreign-key enforcement on a failed migration.

## Design review
The plan and the implementation were both reviewed to convergence by an independent model (GPT-5.5) on a different lineage. Notable points it caught and I addressed: migration failure-safety, "explicit project must win" on idempotent conflict, not silently touching a dismissed/completed todo, deriving the dedup key from full action identity (not just kind) to avoid overwriting distinct todos, and two stale-in-flight-load races in the renderer (Inbox list + rail badge).

## How I verified

`bun run test` (typecheck + eslint + vitest) is green: **541 tests across 62 files** (47 new). Specifically:

- **Migration back-compat** (`migrate.integration.test.ts`): apply migrations 001-019, seed old-shape rows + a done + a soft-deleted todo + a `todo_copilot_app_sessions` link, apply 020, and assert ids/link preserved, `origin='user'` + null new fields defaulted, `done`/`deleted_at` preserved, `project_id` now accepts NULL, and `PRAGMA foreign_key_check` returns no rows. Plus a partial-unique-index test (rejects a duplicate non-null key, allows many null keys).
- **`addAgentTodo`** (`projects.integration.test.ts`): create, Inbox placement, idempotent upsert (repeat updates, count stays 1), null-key always inserts, action round-trip, explicit-move, sticky non-explicit, dead-project rehoming, and `updated_completed` / `updated_dismissed` status while preserving the human's decision. `listInboxTodos` + `getProjectNameById`.
- **Resolution** (`routing-rules.integration.test.ts`): repo rule wins, repo rule to a dead project -> Inbox, routing-rule fallback, org match, a type/reason-conditioned rule correctly does NOT match a bare repo, soft-deleted gating; `resolveProjectIdByName` case-insensitivity / miss / soft-delete exclusion / lowest-id tie.
- **Tool** (`add-todo.test.ts`): validation (missing title, non-http(s) `sourceUrl` and action urls, bad action kind, `pr_comment` without comment), resolution branches (explicit project, not-found -> error, repo, malformed repo -> Inbox, `github.com/…` prefix tolerance), and idempotency (same source+action dedups, distinct actions don't, host-case normalization dedups, no sourceUrl never dedups).
- **Real loopback MCP** (`server.integration.test.ts`): stand up the actual loopback server and drive it with an in-process `@modelcontextprotocol/sdk` client over Streamable HTTP; `add_todo` lands on the routed project, undo (soft-delete + restore) round-trips, and a repeat with the same source updates rather than duplicates. Plus `tools.test.ts` covers the `onTodoChanged` callback firing on success but not on error.

### Not verified
I could not exercise the real Copilot desktop app calling this tool end-to-end (no automation for that here). The MCP transport, tool surface, resolution, persistence, idempotency, and undo are all covered by the in-process real-SDK integration test, which is the same transport the shim uses.