### PR TITLE
Read-only context MCP tools: list_projects, get_project_context, get_reentry_digest (#106)

### DIFF
--- a/src/main/mcp-server/read-context.integration.test.ts
+++ b/src/main/mcp-server/read-context.integration.test.ts
@@ -164,13 +164,13 @@ describe('read-context tools over the real loopback server', () => {
     expect(result.isError).toBeFalsy()
 
     const appDigest = getDigest(p.id)
-    const digest = result.structuredContent as unknown as {
-      projectId: number
-      items: { kind: string }[]
+    const { projects } = result.structuredContent as unknown as {
+      projects: { projectId: number; items: { kind: string }[] }[]
     }
-    expect(digest.projectId).toBe(p.id)
-    expect(digest.items.map((i) => i.kind)).toEqual(appDigest.items.map((i) => i.kind))
-    expect(digest.items.length).toBeGreaterThan(0)
+    expect(projects).toHaveLength(1)
+    expect(projects[0].projectId).toBe(p.id)
+    expect(projects[0].items.map((i) => i.kind)).toEqual(appDigest.items.map((i) => i.kind))
+    expect(projects[0].items.length).toBeGreaterThan(0)
   })
 
   it('an unknown project yields an isError result (not a transport failure)', async () => {

--- a/src/main/mcp-server/read-context.integration.test.ts
+++ b/src/main/mcp-server/read-context.integration.test.ts
@@ -61,7 +61,7 @@ async function startServer(): Promise<{ handle: McpServerHandle; token: string }
   return { handle, token: endpoint.token }
 }
 
-function connectClient(port: number, token: string): Promise<Client> {
+async function connectClient(port: number, token: string): Promise<Client> {
   const transport = new StreamableHTTPClientTransport(new URL(`http://127.0.0.1:${port}/mcp`), {
     requestInit: { headers: { Authorization: `Bearer ${token}` } },
   })
@@ -69,7 +69,8 @@ function connectClient(port: number, token: string): Promise<Client> {
   cleanups.push(async () => {
     await client.close()
   })
-  return client.connect(transport).then(() => client)
+  await client.connect(transport)
+  return client
 }
 
 interface ProjectContextPayload {

--- a/src/main/mcp-server/read-context.integration.test.ts
+++ b/src/main/mcp-server/read-context.integration.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { Database as BunDb } from 'bun:sqlite'
+import type BetterSQLite3 from 'better-sqlite3'
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
+import { startMcpServer, type McpServerHandle } from './server'
+import { readRunFiles } from './runfiles'
+import {
+  LIST_PROJECTS_TOOL_NAME,
+  GET_PROJECT_CONTEXT_TOOL_NAME,
+  GET_REENTRY_DIGEST_TOOL_NAME,
+} from './tool-manifest'
+
+// The read-context tools reach the DB layer (and, through it, electron). Mock electron so
+// `runMigrations` resolves its dir, and mock the DB singleton so the in-process server's handlers
+// read from a real in-memory SQLite we seed and control.
+vi.mock('electron', () => ({
+  app: { isPackaged: false, getAppPath: () => process.cwd() },
+}))
+vi.mock('../db/index', () => ({ getDb: vi.fn() }))
+
+import { getDb } from '../db/index'
+import { runMigrations } from '../db/migrate'
+import { createProject, createTodo } from '../db/projects'
+import { upsertProjectCard, createResource, getProjectCardReadOnly } from '../context/registry'
+import { getDigest } from '../digest'
+
+const cleanups: Array<() => Promise<void> | void> = []
+
+afterEach(async () => {
+  for (const fn of cleanups.splice(0)) await fn()
+})
+
+let db: BunDb
+
+function isoDaysAgo(days: number): string {
+  return new Date(Date.now() - days * 86400000).toISOString()
+}
+
+beforeEach(() => {
+  db = new BunDb(':memory:')
+  db.exec('PRAGMA foreign_keys = ON')
+  const betterDb = db as unknown as BetterSQLite3.Database
+  runMigrations(betterDb)
+  vi.mocked(getDb).mockReturnValue(betterDb)
+})
+
+async function startServer(): Promise<{ handle: McpServerHandle; token: string }> {
+  const dir = mkdtempSync(join(tmpdir(), 'gh-mcp-read-'))
+  const handle = await startMcpServer({ runDir: dir })
+  cleanups.push(async () => {
+    await handle.close()
+    rmSync(dir, { recursive: true, force: true })
+  })
+  const endpoint = readRunFiles(dir)
+  if (endpoint === null) throw new Error('run files were not published')
+  return { handle, token: endpoint.token }
+}
+
+function connectClient(port: number, token: string): Promise<Client> {
+  const transport = new StreamableHTTPClientTransport(new URL(`http://127.0.0.1:${port}/mcp`), {
+    requestInit: { headers: { Authorization: `Bearer ${token}` } },
+  })
+  const client = new Client({ name: 'read-context-integration', version: '1.0.0' }, { capabilities: {} })
+  cleanups.push(async () => {
+    await client.close()
+  })
+  return client.connect(transport).then(() => client)
+}
+
+interface ProjectContextPayload {
+  project: { id: number; name: string }
+  card: { purpose: string; services: string[]; glossary: Record<string, string> }
+  openTodos: { text: string }[]
+  openTodoCount: number
+  resources: { title: string }[]
+  resourceCount: number
+}
+
+describe('read-context tools over the real loopback server', () => {
+  it('advertises all three read tools in tools/list', async () => {
+    const { handle, token } = await startServer()
+    const client = await connectClient(handle.port, token)
+    const names = (await client.listTools()).tools.map((t) => t.name)
+    expect(names).toEqual(
+      expect.arrayContaining([
+        LIST_PROJECTS_TOOL_NAME,
+        GET_PROJECT_CONTEXT_TOOL_NAME,
+        GET_REENTRY_DIGEST_TOOL_NAME,
+      ])
+    )
+  })
+
+  it('list_projects returns the seeded roster with open-todo counts', async () => {
+    const { handle, token } = await startServer()
+    const client = await connectClient(handle.port, token)
+
+    const p = createProject('Widgets')
+    createTodo(p.id, 'open one')
+
+    const result = (await client.callTool({ name: LIST_PROJECTS_TOOL_NAME })) as CallToolResult
+    expect(result.isError).toBeFalsy()
+    const projects = (result.structuredContent as { projects: { id: number; name: string; activeTodoCount: number }[] })
+      .projects
+    expect(projects).toHaveLength(1)
+    expect(projects[0]).toMatchObject({ id: p.id, name: 'Widgets', activeTodoCount: 1 })
+  })
+
+  it('get_project_context returns context equal to what the app computes', async () => {
+    const { handle, token } = await startServer()
+    const client = await connectClient(handle.port, token)
+
+    const p = createProject('Payments')
+    upsertProjectCard(p.id, {
+      purpose: 'Own billing',
+      services: ['billing-api'],
+      glossary: { MRR: 'Monthly recurring revenue' },
+    })
+    createTodo(p.id, 'wire the webhook')
+    createResource(p.id, { title: 'Latency board', kind: 'dashboard', source: 'datadog' })
+
+    const result = (await client.callTool({
+      name: GET_PROJECT_CONTEXT_TOOL_NAME,
+      arguments: { project: 'Payments' },
+    })) as CallToolResult
+    expect(result.isError).toBeFalsy()
+
+    const ctx = result.structuredContent as unknown as ProjectContextPayload
+    const appCard = getProjectCardReadOnly(p.id)
+    expect(ctx.project).toMatchObject({ id: p.id, name: 'Payments' })
+    expect(ctx.card.purpose).toBe(appCard.purpose)
+    expect(ctx.card.services).toEqual(appCard.services)
+    expect(ctx.card.glossary).toEqual(appCard.glossary)
+    expect(ctx.openTodos.map((t) => t.text)).toEqual(['wire the webhook'])
+    expect(ctx.openTodoCount).toBe(1)
+    expect(ctx.resources.map((r) => r.title)).toEqual(['Latency board'])
+    expect(ctx.resourceCount).toBe(1)
+  })
+
+  it('get_reentry_digest returns items equal to the app-computed digest', async () => {
+    const { handle, token } = await startServer()
+    const client = await connectClient(handle.port, token)
+
+    const p = createProject('Backend')
+    db.prepare('UPDATE projects SET created_at = ?, last_focused_at = ? WHERE id = ?').run(
+      isoDaysAgo(60),
+      isoDaysAgo(5),
+      p.id
+    )
+    db.prepare(
+      `INSERT INTO copilot_sessions (id, project_id, source, status, title, started_at, updated_at, linked_pr_url)
+       VALUES ('s1', ?, 'github', 'pr_ready', 'ship it', ?, ?, 'https://x/pull/9')`
+    ).run(p.id, isoDaysAgo(2), isoDaysAgo(1))
+
+    const result = (await client.callTool({
+      name: GET_REENTRY_DIGEST_TOOL_NAME,
+      arguments: { project: p.id },
+    })) as CallToolResult
+    expect(result.isError).toBeFalsy()
+
+    const appDigest = getDigest(p.id)
+    const digest = result.structuredContent as unknown as {
+      projectId: number
+      items: { kind: string }[]
+    }
+    expect(digest.projectId).toBe(p.id)
+    expect(digest.items.map((i) => i.kind)).toEqual(appDigest.items.map((i) => i.kind))
+    expect(digest.items.length).toBeGreaterThan(0)
+  })
+
+  it('an unknown project yields an isError result (not a transport failure)', async () => {
+    const { handle, token } = await startServer()
+    const client = await connectClient(handle.port, token)
+    const result = (await client.callTool({
+      name: GET_PROJECT_CONTEXT_TOOL_NAME,
+      arguments: { project: 'does-not-exist' },
+    })) as CallToolResult
+    expect(result.isError).toBe(true)
+  })
+})

--- a/src/main/mcp-server/read-context.test.ts
+++ b/src/main/mcp-server/read-context.test.ts
@@ -94,15 +94,15 @@ interface ProjectContextPayload {
 interface DigestItemLite {
   kind: string
 }
-interface DigestSinglePayload {
+interface DigestView {
   projectId: number
   name: string
   driftState: string
   asOf: string
   items: DigestItemLite[]
 }
-interface DigestGlobalPayload {
-  projects: { projectId: number; name: string; driftState: string; asOf: string; items: DigestItemLite[] }[]
+interface DigestPayload {
+  projects: DigestView[]
 }
 
 function payload<T>(result: CallToolResult): T {
@@ -310,10 +310,12 @@ describe('runGetReentryDigest — single project', () => {
     expect(runGetReentryDigest({ project: 'Nope' }).isError).toBe(true)
   })
 
-  it('returns computed digest items and drift for a project with activity', () => {
+  it('returns a one-element projects list with items and drift for a project with activity', () => {
     const id = seedProject('Active', 60, 5)
     seedRecentSession(id)
-    const digest = payload<DigestSinglePayload>(runGetReentryDigest({ project: id }))
+    const { projects } = payload<DigestPayload>(runGetReentryDigest({ project: id }))
+    expect(projects).toHaveLength(1)
+    const digest = projects[0]
     expect(digest.projectId).toBe(id)
     expect(digest.name).toBe('Active')
     expect(digest.items.length).toBeGreaterThan(0)
@@ -321,10 +323,12 @@ describe('runGetReentryDigest — single project', () => {
     expect(typeof digest.asOf).toBe('string')
   })
 
-  it('returns an empty item list for a quiet project', () => {
+  it('still returns the requested project (one element) even when it is quiet', () => {
     const id = seedProject('Quiet', 1, 0)
-    const digest = payload<DigestSinglePayload>(runGetReentryDigest({ project: id }))
-    expect(digest.items).toEqual([])
+    const { projects } = payload<DigestPayload>(runGetReentryDigest({ project: id }))
+    expect(projects).toHaveLength(1)
+    expect(projects[0].projectId).toBe(id)
+    expect(projects[0].items).toEqual([])
   })
 
   it('does not write to the database', () => {
@@ -343,7 +347,7 @@ describe('runGetReentryDigest — all projects', () => {
     seedProject('Quiet', 1, 0) // active, no activity → excluded
     seedProject('Drifting', 10, 10) // no activity but stale → included via drift
 
-    const { projects } = payload<DigestGlobalPayload>(runGetReentryDigest({}))
+    const { projects } = payload<DigestPayload>(runGetReentryDigest({}))
     const byName = new Map(projects.map((p) => [p.name, p]))
     expect(byName.has('Active')).toBe(true)
     expect(byName.has('Drifting')).toBe(true)
@@ -355,7 +359,7 @@ describe('runGetReentryDigest — all projects', () => {
 
   it('returns an empty list when nothing has activity or drift', () => {
     seedProject('Quiet', 1, 0)
-    expect(payload<DigestGlobalPayload>(runGetReentryDigest({})).projects).toEqual([])
+    expect(payload<DigestPayload>(runGetReentryDigest({})).projects).toEqual([])
   })
 
   it('does not write to the database', () => {

--- a/src/main/mcp-server/read-context.test.ts
+++ b/src/main/mcp-server/read-context.test.ts
@@ -1,0 +1,396 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Database as BunDb } from 'bun:sqlite'
+import type BetterSQLite3 from 'better-sqlite3'
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
+
+vi.mock('electron', () => ({
+  app: { isPackaged: false, getAppPath: () => process.cwd() },
+}))
+
+vi.mock('../db/index', () => ({ getDb: vi.fn() }))
+
+import { getDb } from '../db/index'
+import { runMigrations } from '../db/migrate'
+import { createProject, createTodo, updateTodo, addAgentTodo, createLink } from '../db/projects'
+import { upsertProjectCard, createResource } from '../context/registry'
+import { runListProjects, runGetProjectContext, runGetReentryDigest } from './read-context'
+import { buildToolHandlers } from './tools'
+import {
+  TOOL_MANIFEST,
+  ADD_TODO_TOOL_NAME,
+  LIST_PROJECTS_TOOL_NAME,
+  GET_PROJECT_CONTEXT_TOOL_NAME,
+  GET_REENTRY_DIGEST_TOOL_NAME,
+  findManifestTool,
+} from './tool-manifest'
+
+let db: BunDb
+
+function isoDaysAgo(days: number): string {
+  return new Date(Date.now() - days * 86400000).toISOString()
+}
+
+beforeEach(() => {
+  db = new BunDb(':memory:')
+  db.exec('PRAGMA foreign_keys = ON')
+  const betterDb = db as unknown as BetterSQLite3.Database
+  runMigrations(betterDb)
+  vi.mocked(getDb).mockReturnValue(betterDb)
+})
+
+// ── Payload shapes (test-local; the DTOs are main-only) ───────────────────────
+
+interface ListProjectsPayload {
+  projects: { id: number; name: string; status: string; nextAction: string; activeTodoCount: number }[]
+}
+interface ProjectContextPayload {
+  project: {
+    id: number
+    name: string
+    status: string
+    nextAction: string
+    driftState: string
+    activeTodoCount: number
+    unreadCount: number
+    updatedAt: string
+  }
+  card: {
+    purpose: string
+    repos: string[]
+    services: string[]
+    activeGoal: string
+    glossary: Record<string, string>
+    updatedAt: string
+  }
+  openTodos: {
+    id: number
+    title: string | null
+    text: string
+    sourceUrl: string | null
+    suggestedAction: unknown
+    origin: string
+    body: string | null
+    bodyTruncated: boolean
+  }[]
+  openTodoCount: number
+  openTodosTruncated: boolean
+  links: { id: number; label: string; url: string }[]
+  resources: {
+    id: number
+    title: string
+    kind: string
+    source: string
+    service: string
+    env: string
+    url: string | null
+    description: string
+    descriptionTruncated: boolean
+  }[]
+  resourceCount: number
+  resourcesTruncated: boolean
+}
+interface DigestItemLite {
+  kind: string
+}
+interface DigestSinglePayload {
+  projectId: number
+  name: string
+  driftState: string
+  asOf: string
+  items: DigestItemLite[]
+}
+interface DigestGlobalPayload {
+  projects: { projectId: number; name: string; driftState: string; asOf: string; items: DigestItemLite[] }[]
+}
+
+function payload<T>(result: CallToolResult): T {
+  return result.structuredContent as unknown as T
+}
+
+function totalChanges(): number {
+  return (db.prepare('SELECT total_changes() AS n').get() as { n: number }).n
+}
+
+// ── list_projects ─────────────────────────────────────────────────────────────
+
+describe('runListProjects', () => {
+  it('returns an empty roster when there are no projects', () => {
+    const result = runListProjects()
+    expect(result.isError).toBeUndefined()
+    expect(payload<ListProjectsPayload>(result).projects).toEqual([])
+  })
+
+  it('returns a lean row per project with the open-todo count', () => {
+    const alpha = createProject('Alpha')
+    createProject('Beta')
+    createTodo(alpha.id, 'open one')
+    createTodo(alpha.id, 'open two')
+    const done = createTodo(alpha.id, 'closed')
+    updateTodo(done.id, { done: true })
+
+    const { projects } = payload<ListProjectsPayload>(runListProjects())
+    expect(projects.map((p) => p.name)).toEqual(['Alpha', 'Beta'])
+    const alphaRow = projects.find((p) => p.name === 'Alpha')
+    expect(alphaRow).toMatchObject({ id: alpha.id, status: 'active', activeTodoCount: 2 })
+    expect(projects.find((p) => p.name === 'Beta')?.activeTodoCount).toBe(0)
+  })
+
+  it('exposes only the five spec fields (lean payload)', () => {
+    createProject('Solo')
+    const { projects } = payload<ListProjectsPayload>(runListProjects())
+    expect(Object.keys(projects[0]).sort()).toEqual(
+      ['activeTodoCount', 'id', 'name', 'nextAction', 'status'].sort()
+    )
+  })
+
+  it('does not write to the database', () => {
+    createProject('Alpha')
+    const before = totalChanges()
+    runListProjects()
+    expect(totalChanges()).toBe(before)
+  })
+})
+
+// ── get_project_context ────────────────────────────────────────────────────────
+
+describe('runGetProjectContext — resolution', () => {
+  it('errors on an unknown project name', () => {
+    const result = runGetProjectContext({ project: 'Ghost' })
+    expect(result.isError).toBe(true)
+  })
+
+  it('errors on an unknown project id', () => {
+    const result = runGetProjectContext({ project: 999 })
+    expect(result.isError).toBe(true)
+  })
+
+  it('errors on a non-integer / non-positive id', () => {
+    expect(runGetProjectContext({ project: 1.5 }).isError).toBe(true)
+    expect(runGetProjectContext({ project: 0 }).isError).toBe(true)
+    expect(runGetProjectContext({ project: -3 }).isError).toBe(true)
+  })
+
+  it('errors on a missing / empty project arg', () => {
+    expect(runGetProjectContext({}).isError).toBe(true)
+    expect(runGetProjectContext({ project: '   ' }).isError).toBe(true)
+  })
+
+  it('resolves by exact name (case-insensitive) and by numeric id', () => {
+    const p = createProject('Gamma')
+    expect(payload<ProjectContextPayload>(runGetProjectContext({ project: 'gamma' })).project.id).toBe(p.id)
+    expect(payload<ProjectContextPayload>(runGetProjectContext({ project: p.id })).project.id).toBe(p.id)
+  })
+
+  it('does not resolve a soft-deleted project', () => {
+    const p = createProject('Deleted')
+    db.prepare('UPDATE projects SET deleted_at = ? WHERE id = ?').run(isoDaysAgo(0), p.id)
+    expect(runGetProjectContext({ project: p.id }).isError).toBe(true)
+    expect(runGetProjectContext({ project: 'Deleted' }).isError).toBe(true)
+  })
+})
+
+describe('runGetProjectContext — shape', () => {
+  it('returns the card, open todos, links and resources', () => {
+    const p = createProject('Payments')
+    upsertProjectCard(p.id, {
+      purpose: 'Own billing',
+      repos: ['acme/pay'],
+      services: ['billing-api', 'ledger'],
+      activeGoal: 'Ship invoices',
+      glossary: { MRR: 'Monthly recurring revenue' },
+    })
+    createTodo(p.id, 'open task')
+    const done = createTodo(p.id, 'done task')
+    updateTodo(done.id, { done: true })
+    createLink(p.id, 'Runbook', 'https://example.com/runbook')
+    createResource(p.id, { title: 'Latency board', kind: 'dashboard', source: 'datadog', service: 'billing-api' })
+
+    const ctx = payload<ProjectContextPayload>(runGetProjectContext({ project: 'Payments' }))
+    expect(ctx.project).toMatchObject({ id: p.id, name: 'Payments', status: 'active' })
+    expect(ctx.card).toMatchObject({
+      purpose: 'Own billing',
+      repos: ['acme/pay'],
+      services: ['billing-api', 'ledger'],
+      activeGoal: 'Ship invoices',
+      glossary: { MRR: 'Monthly recurring revenue' },
+    })
+    // Only the open todo is surfaced.
+    expect(ctx.openTodos.map((t) => t.text)).toEqual(['open task'])
+    expect(ctx.openTodoCount).toBe(1)
+    expect(ctx.openTodosTruncated).toBe(false)
+    expect(ctx.links).toEqual([{ id: expect.any(Number), label: 'Runbook', url: 'https://example.com/runbook' }])
+    expect(ctx.resources).toHaveLength(1)
+    expect(ctx.resources[0]).toMatchObject({ title: 'Latency board', kind: 'dashboard', source: 'datadog' })
+  })
+
+  it('does not leak internal todo fields (idempotencyKey, sortOrder, done)', () => {
+    const p = createProject('Lean')
+    createTodo(p.id, 'a todo')
+    const ctx = payload<ProjectContextPayload>(runGetProjectContext({ project: p.id }))
+    expect(Object.keys(ctx.openTodos[0]).sort()).toEqual(
+      ['body', 'bodyTruncated', 'id', 'origin', 'sourceUrl', 'suggestedAction', 'text', 'title'].sort()
+    )
+  })
+
+  it('caps the open-todo and resource lists and flags truncation', () => {
+    const p = createProject('Busy')
+    for (let i = 0; i < 55; i++) createTodo(p.id, `todo ${i}`)
+    for (let i = 0; i < 35; i++) createResource(p.id, { title: `res ${i}` })
+
+    const ctx = payload<ProjectContextPayload>(runGetProjectContext({ project: p.id }))
+    expect(ctx.openTodos).toHaveLength(50)
+    expect(ctx.openTodoCount).toBe(55)
+    expect(ctx.openTodosTruncated).toBe(true)
+    expect(ctx.resources).toHaveLength(30)
+    expect(ctx.resourceCount).toBe(35)
+    expect(ctx.resourcesTruncated).toBe(true)
+  })
+
+  it('caps long todo body and resource description with a truncation flag', () => {
+    const p = createProject('Verbose')
+    addAgentTodo({
+      resolvedProjectId: p.id,
+      explicitPlacement: true,
+      title: 'Big',
+      body: 'x'.repeat(700),
+      sourceUrl: null,
+      suggestedAction: null,
+      idempotencyKey: null,
+    })
+    createResource(p.id, { title: 'Doc', description: 'y'.repeat(400) })
+
+    const ctx = payload<ProjectContextPayload>(runGetProjectContext({ project: p.id }))
+    const todo = ctx.openTodos[0]
+    expect(todo.bodyTruncated).toBe(true)
+    expect((todo.body ?? '').length).toBeLessThanOrEqual(600)
+    expect(ctx.resources[0].descriptionTruncated).toBe(true)
+    expect(ctx.resources[0].description.length).toBeLessThanOrEqual(300)
+  })
+
+  it('does not write — including never creating a project_cards row', () => {
+    const p = createProject('NoCard')
+    const before = totalChanges()
+    runGetProjectContext({ project: p.id })
+    expect(totalChanges()).toBe(before)
+    const cardRows = db
+      .prepare('SELECT COUNT(*) AS n FROM project_cards WHERE project_id = ?')
+      .get(p.id) as { n: number }
+    expect(cardRows.n).toBe(0)
+  })
+})
+
+// ── get_reentry_digest ─────────────────────────────────────────────────────────
+
+/** Seed a project whose created_at is old (so a recent session clears the watermark). */
+function seedProject(name: string, createdDaysAgo: number, lastFocusedDaysAgo: number | null): number {
+  const p = createProject(name)
+  db.prepare('UPDATE projects SET created_at = ?, last_focused_at = ? WHERE id = ?').run(
+    isoDaysAgo(createdDaysAgo),
+    lastFocusedDaysAgo === null ? null : isoDaysAgo(lastFocusedDaysAgo),
+    p.id
+  )
+  return p.id
+}
+
+function seedRecentSession(projectId: number): void {
+  db.prepare(
+    `INSERT INTO copilot_sessions (id, project_id, source, status, title, started_at, updated_at, linked_pr_url)
+     VALUES (?, ?, 'github', 'pr_ready', 'ship it', ?, ?, 'https://x/pull/1')`
+  ).run(`s-${projectId}`, projectId, isoDaysAgo(2), isoDaysAgo(1))
+}
+
+describe('runGetReentryDigest — single project', () => {
+  it('errors on an unknown project', () => {
+    expect(runGetReentryDigest({ project: 'Nope' }).isError).toBe(true)
+  })
+
+  it('returns computed digest items and drift for a project with activity', () => {
+    const id = seedProject('Active', 60, 5)
+    seedRecentSession(id)
+    const digest = payload<DigestSinglePayload>(runGetReentryDigest({ project: id }))
+    expect(digest.projectId).toBe(id)
+    expect(digest.name).toBe('Active')
+    expect(digest.items.length).toBeGreaterThan(0)
+    expect(digest.items[0].kind).toBe('agent-pr-ready')
+    expect(typeof digest.asOf).toBe('string')
+  })
+
+  it('returns an empty item list for a quiet project', () => {
+    const id = seedProject('Quiet', 1, 0)
+    const digest = payload<DigestSinglePayload>(runGetReentryDigest({ project: id }))
+    expect(digest.items).toEqual([])
+  })
+
+  it('does not write to the database', () => {
+    const id = seedProject('Active', 60, 5)
+    seedRecentSession(id)
+    const before = totalChanges()
+    runGetReentryDigest({ project: id })
+    expect(totalChanges()).toBe(before)
+  })
+})
+
+describe('runGetReentryDigest — all projects', () => {
+  it('includes projects with activity OR drift, and omits quiet active projects', () => {
+    const active = seedProject('Active', 60, 5) // has a recent session → included via items
+    seedRecentSession(active)
+    seedProject('Quiet', 1, 0) // active, no activity → excluded
+    seedProject('Drifting', 10, 10) // no activity but stale → included via drift
+
+    const { projects } = payload<DigestGlobalPayload>(runGetReentryDigest({}))
+    const byName = new Map(projects.map((p) => [p.name, p]))
+    expect(byName.has('Active')).toBe(true)
+    expect(byName.has('Drifting')).toBe(true)
+    expect(byName.has('Quiet')).toBe(false)
+    expect(byName.get('Active')?.items.length).toBeGreaterThan(0)
+    expect(byName.get('Drifting')?.driftState).toBe('drifting')
+    expect(byName.get('Drifting')?.items).toEqual([])
+  })
+
+  it('returns an empty list when nothing has activity or drift', () => {
+    seedProject('Quiet', 1, 0)
+    expect(payload<DigestGlobalPayload>(runGetReentryDigest({})).projects).toEqual([])
+  })
+
+  it('does not write to the database', () => {
+    const active = seedProject('Active', 60, 5)
+    seedRecentSession(active)
+    const before = totalChanges()
+    runGetReentryDigest({})
+    expect(totalChanges()).toBe(before)
+  })
+})
+
+// ── Manifest / registry hygiene ────────────────────────────────────────────────
+
+describe('read-context manifest wiring', () => {
+  it('advertises all three tools with the documented input schemas', () => {
+    for (const name of [LIST_PROJECTS_TOOL_NAME, GET_PROJECT_CONTEXT_TOOL_NAME, GET_REENTRY_DIGEST_TOOL_NAME]) {
+      expect(findManifestTool(name)).toBeDefined()
+    }
+    const ctx = findManifestTool(GET_PROJECT_CONTEXT_TOOL_NAME)
+    expect(ctx?.inputSchema.required).toEqual(['project'])
+    expect(ctx?.inputSchema.additionalProperties).toBe(false)
+    // get_reentry_digest's project is optional.
+    const digest = findManifestTool(GET_REENTRY_DIGEST_TOOL_NAME)
+    expect(digest?.inputSchema.required).toBeUndefined()
+    // project accepts a name (string) or an id (integer).
+    const projectSchema = ctx?.inputSchema.properties?.project as { type?: unknown }
+    expect(projectSchema.type).toEqual(['string', 'integer'])
+  })
+
+  it('has a handler registered for every advertised tool', () => {
+    const handlers = buildToolHandlers({ getSecrets: () => [] })
+    for (const tool of TOOL_MANIFEST) {
+      expect(handlers.has(tool.name)).toBe(true)
+    }
+  })
+
+  it('keeps add_todo name-only, so the roster must not promise ids to add_todo', () => {
+    // The read tools accept a name OR an integer id, but add_todo resolves by name only.
+    // Guard the contract list_projects documents: pass the NAME (not id) to add_todo.
+    const addTodo = findManifestTool(ADD_TODO_TOOL_NAME)
+    const projectSchema = addTodo?.inputSchema.properties?.project as { type?: unknown }
+    expect(projectSchema.type).toBe('string')
+  })
+})

--- a/src/main/mcp-server/read-context.test.ts
+++ b/src/main/mcp-server/read-context.test.ts
@@ -68,6 +68,7 @@ interface ProjectContextPayload {
     text: string
     sourceUrl: string | null
     suggestedAction: unknown
+    suggestedActionTruncated: boolean
     origin: string
     body: string | null
     bodyTruncated: boolean
@@ -230,7 +231,7 @@ describe('runGetProjectContext — shape', () => {
     createTodo(p.id, 'a todo')
     const ctx = payload<ProjectContextPayload>(runGetProjectContext({ project: p.id }))
     expect(Object.keys(ctx.openTodos[0]).sort()).toEqual(
-      ['body', 'bodyTruncated', 'id', 'origin', 'sourceUrl', 'suggestedAction', 'text', 'title'].sort()
+      ['body', 'bodyTruncated', 'id', 'origin', 'sourceUrl', 'suggestedAction', 'suggestedActionTruncated', 'text', 'title'].sort()
     )
   })
 
@@ -271,6 +272,25 @@ describe('runGetProjectContext — shape', () => {
     expect((todo.body ?? '').length).toBeLessThanOrEqual(600)
     expect(ctx.resources[0].descriptionTruncated).toBe(true)
     expect(ctx.resources[0].description.length).toBeLessThanOrEqual(300)
+  })
+
+  it('caps a long suggestedAction instruction and flags it', () => {
+    const p = createProject('Action')
+    addAgentTodo({
+      resolvedProjectId: p.id,
+      explicitPlacement: true,
+      title: 'Delegate',
+      body: null,
+      sourceUrl: null,
+      suggestedAction: { kind: 'delegate', prompt: 'z'.repeat(700) },
+      idempotencyKey: null,
+    })
+
+    const ctx = payload<ProjectContextPayload>(runGetProjectContext({ project: p.id }))
+    const action = ctx.openTodos[0].suggestedAction as { kind: string; prompt: string }
+    expect(action.kind).toBe('delegate')
+    expect(action.prompt.length).toBeLessThanOrEqual(600)
+    expect(ctx.openTodos[0].suggestedActionTruncated).toBe(true)
   })
 
   it('does not write — including never creating a project_cards row', () => {

--- a/src/main/mcp-server/read-context.test.ts
+++ b/src/main/mcp-server/read-context.test.ts
@@ -75,6 +75,8 @@ interface ProjectContextPayload {
   openTodoCount: number
   openTodosTruncated: boolean
   links: { id: number; label: string; url: string }[]
+  linkCount: number
+  linksTruncated: boolean
   resources: {
     id: number
     title: string
@@ -232,15 +234,19 @@ describe('runGetProjectContext — shape', () => {
     )
   })
 
-  it('caps the open-todo and resource lists and flags truncation', () => {
+  it('caps the open-todo, link and resource lists and flags truncation', () => {
     const p = createProject('Busy')
     for (let i = 0; i < 55; i++) createTodo(p.id, `todo ${i}`)
+    for (let i = 0; i < 35; i++) createLink(p.id, `link ${i}`, `https://example.com/${i}`)
     for (let i = 0; i < 35; i++) createResource(p.id, { title: `res ${i}` })
 
     const ctx = payload<ProjectContextPayload>(runGetProjectContext({ project: p.id }))
     expect(ctx.openTodos).toHaveLength(50)
     expect(ctx.openTodoCount).toBe(55)
     expect(ctx.openTodosTruncated).toBe(true)
+    expect(ctx.links).toHaveLength(30)
+    expect(ctx.linkCount).toBe(35)
+    expect(ctx.linksTruncated).toBe(true)
     expect(ctx.resources).toHaveLength(30)
     expect(ctx.resourceCount).toBe(35)
     expect(ctx.resourcesTruncated).toBe(true)
@@ -374,9 +380,15 @@ describe('read-context manifest wiring', () => {
     // get_reentry_digest's project is optional.
     const digest = findManifestTool(GET_REENTRY_DIGEST_TOOL_NAME)
     expect(digest?.inputSchema.required).toBeUndefined()
-    // project accepts a name (string) or an id (integer).
-    const projectSchema = ctx?.inputSchema.properties?.project as { type?: unknown }
+    // project accepts a name (string) or an id (integer), with bounds mirroring the handlers.
+    const projectSchema = ctx?.inputSchema.properties?.project as {
+      type?: unknown
+      minLength?: unknown
+      minimum?: unknown
+    }
     expect(projectSchema.type).toEqual(['string', 'integer'])
+    expect(projectSchema.minLength).toBe(1)
+    expect(projectSchema.minimum).toBe(1)
   })
 
   it('has a handler registered for every advertised tool', () => {

--- a/src/main/mcp-server/read-context.ts
+++ b/src/main/mcp-server/read-context.ts
@@ -42,6 +42,7 @@ import { getDigest } from '../digest'
 /** Hard caps on the list sections so a huge project can't produce a bloated payload. */
 const OPEN_TODO_LIMIT = 50
 const RESOURCE_LIMIT = 30
+const LINK_LIMIT = 30
 /** Intentional per-field caps on the genuinely-long markdown leaves. */
 const TODO_BODY_MAX = 600
 const RESOURCE_DESCRIPTION_MAX = 300
@@ -170,6 +171,9 @@ interface ProjectContext {
   openTodoCount: number
   openTodosTruncated: boolean
   links: LinkView[]
+  /** Total links (before the `LINK_LIMIT` cap). */
+  linkCount: number
+  linksTruncated: boolean
   resources: ResourceView[]
   /** Total live resources (before the `RESOURCE_LIMIT` cap). */
   resourceCount: number
@@ -264,6 +268,7 @@ export function runGetProjectContext(args: Record<string, unknown>): CallToolRes
 
   const openTodosAll = detail.todos.filter((t) => !t.done)
   const openTodos = openTodosAll.slice(0, OPEN_TODO_LIMIT).map(toOpenTodoView)
+  const links = detail.links.slice(0, LINK_LIMIT).map(toLinkView)
   const resources = allResources.slice(0, RESOURCE_LIMIT).map(toResourceView)
 
   const payload: ProjectContext = {
@@ -288,7 +293,9 @@ export function runGetProjectContext(args: Record<string, unknown>): CallToolRes
     openTodos,
     openTodoCount: openTodosAll.length,
     openTodosTruncated: openTodosAll.length > openTodos.length,
-    links: detail.links.map(toLinkView),
+    links,
+    linkCount: detail.links.length,
+    linksTruncated: detail.links.length > links.length,
     resources,
     resourceCount: allResources.length,
     resourcesTruncated: allResources.length > resources.length,

--- a/src/main/mcp-server/read-context.ts
+++ b/src/main/mcp-server/read-context.ts
@@ -323,6 +323,14 @@ function digestViewFor(id: number, name: string, driftState: DriftState): Projec
  * that either has digest activity OR is drifting (the resurface signal) — deliberately-parked
  * (snoozed, no activity) projects are omitted so we don't nag about what the user set aside.
  */
+/**
+ * `get_reentry_digest`: the blame-free "what changed while I was away / what should I pick up"
+ * digest. Always returns a uniform `{ projects: ProjectDigestView[] }` envelope so clients don't
+ * have to branch on the response shape. With a `project`, the list holds exactly that one project
+ * (even if it has no new activity — you asked for it). Without one, it holds every project that
+ * either has digest activity OR is drifting (the resurface signal); deliberately-parked (snoozed,
+ * no activity) projects are omitted so we don't nag about what the user set aside.
+ */
 export function runGetReentryDigest(args: Record<string, unknown>): CallToolResult {
   if (args.project !== undefined && args.project !== null) {
     const ref = resolveProjectRef(args.project)
@@ -338,7 +346,7 @@ export function runGetReentryDigest(args: Record<string, unknown>): CallToolResu
       view.items.length === 0
         ? `${ref.name}: nothing new since you were last here (drift: ${view.driftState}).`
         : `${ref.name}: ${view.items.length} update${view.items.length === 1 ? '' : 's'} since you were away (drift: ${view.driftState}).`
-    return ok(summary, view)
+    return ok(summary, { projects: [view] })
   }
 
   const projects = listProjects()

--- a/src/main/mcp-server/read-context.ts
+++ b/src/main/mcp-server/read-context.ts
@@ -46,6 +46,8 @@ const LINK_LIMIT = 30
 /** Intentional per-field caps on the genuinely-long markdown leaves. */
 const TODO_BODY_MAX = 600
 const RESOURCE_DESCRIPTION_MAX = 300
+/** Cap on a suggested action's free-text instruction (comment / prompt). */
+const SUGGESTED_ACTION_TEXT_MAX = 600
 
 // ── Result helpers ────────────────────────────────────────────────────────────
 
@@ -130,6 +132,8 @@ interface OpenTodoView {
   text: string
   sourceUrl: string | null
   suggestedAction: SuggestedAction | null
+  /** True when a `suggestedAction` free-text field (comment/prompt) was capped. */
+  suggestedActionTruncated: boolean
   origin: TodoOrigin
   /** Instructions, capped to keep the payload lean; `bodyTruncated` flags when shortened. */
   body: string | null
@@ -190,14 +194,39 @@ interface ProjectDigestView {
 
 // ── Mappers ───────────────────────────────────────────────────────────────────
 
+/**
+ * Cap the free-text instruction of a suggested action (a `pr_comment` comment or a `delegate`
+ * prompt) so a long action instruction can't be silently truncated by the output sanitizer — a
+ * truncated action instruction could mislead. `open_url` carries only a short URL.
+ */
+function capSuggestedAction(
+  action: SuggestedAction | null
+): { action: SuggestedAction | null; truncated: boolean } {
+  if (action === null) return { action: null, truncated: false }
+  switch (action.kind) {
+    case 'pr_comment': {
+      const comment = capText(action.comment, SUGGESTED_ACTION_TEXT_MAX)
+      return { action: { kind: 'pr_comment', url: action.url, comment: comment.text }, truncated: comment.truncated }
+    }
+    case 'delegate': {
+      const prompt = capText(action.prompt, SUGGESTED_ACTION_TEXT_MAX)
+      return { action: { kind: 'delegate', prompt: prompt.text }, truncated: prompt.truncated }
+    }
+    case 'open_url':
+      return { action, truncated: false }
+  }
+}
+
 function toOpenTodoView(todo: ProjectTodo): OpenTodoView {
   const body = todo.body === null ? null : capText(todo.body, TODO_BODY_MAX)
+  const suggested = capSuggestedAction(todo.suggestedAction)
   return {
     id: todo.id,
     title: todo.title,
     text: todo.text,
     sourceUrl: todo.sourceUrl,
-    suggestedAction: todo.suggestedAction,
+    suggestedAction: suggested.action,
+    suggestedActionTruncated: suggested.truncated,
     origin: todo.origin,
     body: body === null ? null : body.text,
     bodyTruncated: body?.truncated ?? false,

--- a/src/main/mcp-server/read-context.ts
+++ b/src/main/mcp-server/read-context.ts
@@ -319,12 +319,6 @@ function digestViewFor(id: number, name: string, driftState: DriftState): Projec
 
 /**
  * `get_reentry_digest`: the blame-free "what changed while I was away / what should I pick up"
- * digest. With a `project`, returns that one project's digest. Without one, returns every project
- * that either has digest activity OR is drifting (the resurface signal) — deliberately-parked
- * (snoozed, no activity) projects are omitted so we don't nag about what the user set aside.
- */
-/**
- * `get_reentry_digest`: the blame-free "what changed while I was away / what should I pick up"
  * digest. Always returns a uniform `{ projects: ProjectDigestView[] }` envelope so clients don't
  * have to branch on the response shape. With a `project`, the list holds exactly that one project
  * (even if it has no new activity — you asked for it). Without one, it holds every project that

--- a/src/main/mcp-server/read-context.ts
+++ b/src/main/mcp-server/read-context.ts
@@ -1,0 +1,349 @@
+/**
+ * The three READ-ONLY inbound MCP tools (#106): `list_projects`, `get_project_context`, and
+ * `get_reentry_digest`. They expose the app's OWN computed state so Copilot is situationally
+ * aware before it acts (the higher-value half of epic #98).
+ *
+ * Hard invariant: these NEVER write — not to GitHub (unsubscribe stays the only GitHub write),
+ * and not to the local DB. In particular they use `getProjectCardReadOnly` (which returns a
+ * default card without inserting a row), never the lazily-creating `getProjectCard`. A
+ * `total_changes()` regression test guards this.
+ *
+ * Payload shape: each tool returns `structuredContent` (the typed payload, the machine-readable
+ * source of truth with ids for follow-up tools) plus a short human/agent-scannable text summary.
+ * We deliberately do NOT stuff the whole payload into one text block: `sanitizeMcpText` caps every
+ * string leaf at 2000 chars, which would silently truncate — and thus corrupt — a whole-payload
+ * JSON string. Keeping the bulk in `structuredContent` means each leaf stays small and the
+ * structure survives. The genuinely-unbounded markdown fields (todo body, resource description)
+ * are capped intentionally here (not left to the sanitizer) and flagged.
+ *
+ * `project` accepts a NAME (JSON string, resolved via the same case-insensitive resolver
+ * `add_todo` uses) or an ID (JSON integer). String→name, number→id is unambiguous and mirrors the
+ * exact JSON types `list_projects` returns.
+ */
+
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
+import type {
+  DigestItem,
+  DriftState,
+  ProjectLink,
+  ProjectStatus,
+  ProjectTodo,
+  Resource,
+  ResourceKind,
+  SuggestedAction,
+  TodoOrigin,
+} from '../../shared/ipc-channels'
+import { getDb } from '../db'
+import { listProjects, getProject } from '../db/projects'
+import { resolveProjectIdByName } from '../db/routing-rules'
+import { getProjectCardReadOnly, listResources } from '../context/registry'
+import { getDigest } from '../digest'
+
+/** Hard caps on the list sections so a huge project can't produce a bloated payload. */
+const OPEN_TODO_LIMIT = 50
+const RESOURCE_LIMIT = 30
+/** Intentional per-field caps on the genuinely-long markdown leaves. */
+const TODO_BODY_MAX = 600
+const RESOURCE_DESCRIPTION_MAX = 300
+
+// ── Result helpers ────────────────────────────────────────────────────────────
+
+/** A successful read result: a short text summary + the typed payload as structuredContent. */
+function ok(summary: string, structured: object): CallToolResult {
+  return {
+    content: [{ type: 'text', text: summary }],
+    // The SDK types structuredContent as Record<string, unknown>; our typed DTOs are plain
+    // JSON objects, so this widening cast is safe (no `any`).
+    structuredContent: structured as unknown as Record<string, unknown>,
+  }
+}
+
+function errorResult(text: string): CallToolResult {
+  return { content: [{ type: 'text', text }], isError: true }
+}
+
+/** Cap a string to `max` chars, reporting whether it was shortened. */
+function capText(value: string, max: number): { text: string; truncated: boolean } {
+  if (value.length <= max) return { text: value, truncated: false }
+  return { text: `${value.slice(0, max - 1)}…`, truncated: true }
+}
+
+// ── Project reference resolution ──────────────────────────────────────────────
+
+interface LiveProjectRef {
+  id: number
+  name: string
+}
+
+/** Look up a live (non-deleted) project by id. */
+function getLiveProjectById(id: number): LiveProjectRef | null {
+  const row = getDb()
+    .prepare('SELECT id, name FROM projects WHERE id = ? AND deleted_at IS NULL')
+    .get(id) as { id: number; name: string } | undefined
+  return row ?? null
+}
+
+/**
+ * Resolve a `project` argument to a live project. A JSON string resolves by NAME (exact,
+ * case-insensitive — the same resolver `add_todo` uses); a positive-integer JSON number resolves
+ * by ID. Anything else (float, empty, unknown, soft-deleted) → null.
+ */
+function resolveProjectRef(value: unknown): LiveProjectRef | null {
+  if (typeof value === 'number') {
+    if (!Number.isInteger(value) || value <= 0) return null
+    return getLiveProjectById(value)
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    if (trimmed.length === 0) return null
+    const id = resolveProjectIdByName(trimmed)
+    // resolveProjectIdByName only returns live ids; re-read for the canonical name.
+    return id === null ? null : getLiveProjectById(id)
+  }
+  return null
+}
+
+// ── DTOs (main-only; nothing here crosses the IPC boundary to the renderer) ────
+
+interface ProjectSummary {
+  id: number
+  name: string
+  status: ProjectStatus
+  nextAction: string
+  activeTodoCount: number
+}
+
+interface ProjectCardView {
+  purpose: string
+  repos: string[]
+  services: string[]
+  activeGoal: string
+  glossary: Record<string, string>
+  updatedAt: string
+}
+
+interface OpenTodoView {
+  id: number
+  /** Agent-todo title, or null for a plain user todo (use `title ?? text` as the label). */
+  title: string | null
+  text: string
+  sourceUrl: string | null
+  suggestedAction: SuggestedAction | null
+  origin: TodoOrigin
+  /** Instructions, capped to keep the payload lean; `bodyTruncated` flags when shortened. */
+  body: string | null
+  bodyTruncated: boolean
+}
+
+interface LinkView {
+  id: number
+  label: string
+  url: string
+}
+
+interface ResourceView {
+  id: number
+  title: string
+  kind: ResourceKind
+  source: string
+  service: string
+  env: string
+  url: string | null
+  description: string
+  descriptionTruncated: boolean
+}
+
+interface ProjectContext {
+  project: {
+    id: number
+    name: string
+    status: ProjectStatus
+    nextAction: string
+    driftState: DriftState
+    activeTodoCount: number
+    unreadCount: number
+    updatedAt: string
+  }
+  card: ProjectCardView
+  openTodos: OpenTodoView[]
+  /** Total open todos (before the `OPEN_TODO_LIMIT` cap). */
+  openTodoCount: number
+  openTodosTruncated: boolean
+  links: LinkView[]
+  resources: ResourceView[]
+  /** Total live resources (before the `RESOURCE_LIMIT` cap). */
+  resourceCount: number
+  resourcesTruncated: boolean
+}
+
+interface ProjectDigestView {
+  projectId: number
+  name: string
+  driftState: DriftState
+  asOf: string
+  items: DigestItem[]
+}
+
+// ── Mappers ───────────────────────────────────────────────────────────────────
+
+function toOpenTodoView(todo: ProjectTodo): OpenTodoView {
+  const body = todo.body === null ? null : capText(todo.body, TODO_BODY_MAX)
+  return {
+    id: todo.id,
+    title: todo.title,
+    text: todo.text,
+    sourceUrl: todo.sourceUrl,
+    suggestedAction: todo.suggestedAction,
+    origin: todo.origin,
+    body: body === null ? null : body.text,
+    bodyTruncated: body?.truncated ?? false,
+  }
+}
+
+function toLinkView(link: ProjectLink): LinkView {
+  return { id: link.id, label: link.label, url: link.url }
+}
+
+function toResourceView(resource: Resource): ResourceView {
+  const description = capText(resource.description, RESOURCE_DESCRIPTION_MAX)
+  return {
+    id: resource.id,
+    title: resource.title,
+    kind: resource.kind,
+    source: resource.source,
+    service: resource.service,
+    env: resource.env,
+    url: resource.url,
+    description: description.text,
+    descriptionTruncated: description.truncated,
+  }
+}
+
+// ── Tools ───────────────────────────────────────────────────────────────────
+
+/**
+ * `list_projects`: the project roster so Copilot can pick a project to act on. One lean row per
+ * live project (snoozed included; `status` distinguishes them).
+ */
+export function runListProjects(): CallToolResult {
+  const projects: ProjectSummary[] = listProjects().map((p) => ({
+    id: p.id,
+    name: p.name,
+    status: p.status,
+    nextAction: p.nextAction,
+    activeTodoCount: p.activeTodoCount,
+  }))
+
+  const summary =
+    projects.length === 0
+      ? 'No projects yet.'
+      : `${projects.length} project${projects.length === 1 ? '' : 's'}: ${projects
+          .map((p) => `${p.name} (${p.status}, ${p.activeTodoCount} open todo${p.activeTodoCount === 1 ? '' : 's'})`)
+          .join('; ')}.`
+
+  return ok(summary, { projects })
+}
+
+/**
+ * `get_project_context`: the full situational brief for one project — its card (purpose, repos,
+ * services, active goal, glossary), open todos, links, and brain resources. `services` is the
+ * list of service names; per-service runbook BODIES attach later once #100 lands (kept decoupled
+ * so the two PRs don't block each other).
+ */
+export function runGetProjectContext(args: Record<string, unknown>): CallToolResult {
+  const ref = resolveProjectRef(args.project)
+  if (ref === null) {
+    return errorResult(
+      'No live project matches `project`. Pass an exact project name (string) or a project id (number) from list_projects.'
+    )
+  }
+
+  const detail = getProject(ref.id)
+  const card = getProjectCardReadOnly(ref.id)
+  const allResources = listResources(ref.id)
+
+  const openTodosAll = detail.todos.filter((t) => !t.done)
+  const openTodos = openTodosAll.slice(0, OPEN_TODO_LIMIT).map(toOpenTodoView)
+  const resources = allResources.slice(0, RESOURCE_LIMIT).map(toResourceView)
+
+  const payload: ProjectContext = {
+    project: {
+      id: detail.id,
+      name: detail.name,
+      status: detail.status,
+      nextAction: detail.nextAction,
+      driftState: detail.driftState,
+      activeTodoCount: detail.activeTodoCount,
+      unreadCount: detail.unreadCount,
+      updatedAt: detail.updatedAt,
+    },
+    card: {
+      purpose: card.purpose,
+      repos: card.repos,
+      services: card.services,
+      activeGoal: card.activeGoal,
+      glossary: card.glossary,
+      updatedAt: card.updatedAt,
+    },
+    openTodos,
+    openTodoCount: openTodosAll.length,
+    openTodosTruncated: openTodosAll.length > openTodos.length,
+    links: detail.links.map(toLinkView),
+    resources,
+    resourceCount: allResources.length,
+    resourcesTruncated: allResources.length > resources.length,
+  }
+
+  const summary =
+    `${detail.name} — ${card.purpose.trim().length > 0 ? card.purpose.trim() : 'no purpose set'}. ` +
+    `Active goal: ${card.activeGoal.trim().length > 0 ? card.activeGoal.trim() : 'none'}. ` +
+    `${payload.openTodoCount} open todo${payload.openTodoCount === 1 ? '' : 's'}, ` +
+    `${payload.resourceCount} resource${payload.resourceCount === 1 ? '' : 's'}. ` +
+    `Services: ${card.services.length > 0 ? card.services.join(', ') : 'none'}.`
+
+  return ok(summary, payload)
+}
+
+/** Build one project's digest view (name + drift + computed items). */
+function digestViewFor(id: number, name: string, driftState: DriftState): ProjectDigestView {
+  const digest = getDigest(id)
+  return { projectId: id, name, driftState, asOf: digest.asOf, items: digest.items }
+}
+
+/**
+ * `get_reentry_digest`: the blame-free "what changed while I was away / what should I pick up"
+ * digest. With a `project`, returns that one project's digest. Without one, returns every project
+ * that either has digest activity OR is drifting (the resurface signal) — deliberately-parked
+ * (snoozed, no activity) projects are omitted so we don't nag about what the user set aside.
+ */
+export function runGetReentryDigest(args: Record<string, unknown>): CallToolResult {
+  if (args.project !== undefined && args.project !== null) {
+    const ref = resolveProjectRef(args.project)
+    if (ref === null) {
+      return errorResult(
+        'No live project matches `project`. Pass an exact project name (string) or a project id (number) from list_projects, or omit `project` for a digest across all projects.'
+      )
+    }
+    // detail gives the drift classification the roster uses.
+    const detail = getProject(ref.id)
+    const view = digestViewFor(ref.id, ref.name, detail.driftState)
+    const summary =
+      view.items.length === 0
+        ? `${ref.name}: nothing new since you were last here (drift: ${view.driftState}).`
+        : `${ref.name}: ${view.items.length} update${view.items.length === 1 ? '' : 's'} since you were away (drift: ${view.driftState}).`
+    return ok(summary, view)
+  }
+
+  const projects = listProjects()
+    .map((p) => digestViewFor(p.id, p.name, p.driftState))
+    .filter((view) => view.items.length > 0 || view.driftState === 'drifting')
+
+  const summary =
+    projects.length === 0
+      ? 'Nothing to pick up — no project has new activity or drift.'
+      : `${projects.length} project${projects.length === 1 ? '' : 's'} to pick up: ${projects
+          .map((p) => `${p.name} (${p.items.length} update${p.items.length === 1 ? '' : 's'}, drift: ${p.driftState})`)
+          .join('; ')}.`
+
+  return ok(summary, { projects })
+}

--- a/src/main/mcp-server/tool-manifest.ts
+++ b/src/main/mcp-server/tool-manifest.ts
@@ -35,6 +35,25 @@ export const PING_TOOL_NAME = 'ping'
 /** The `add_todo` tool: Copilot creates a human-gated action-proposal todo in a project. */
 export const ADD_TODO_TOOL_NAME = 'add_todo'
 
+/** The `list_projects` tool: the read-only project roster (#106). */
+export const LIST_PROJECTS_TOOL_NAME = 'list_projects'
+
+/** The `get_project_context` tool: the read-only situational brief for one project (#106). */
+export const GET_PROJECT_CONTEXT_TOOL_NAME = 'get_project_context'
+
+/** The `get_reentry_digest` tool: the read-only "what changed while I was away" digest (#106). */
+export const GET_REENTRY_DIGEST_TOOL_NAME = 'get_reentry_digest'
+
+/**
+ * A `project` reference: an exact project NAME (JSON string, case-insensitive) or a project ID
+ * (JSON integer, as returned by `list_projects`). String→name, number→id — unambiguous.
+ */
+const PROJECT_REF_SCHEMA = {
+  type: ['string', 'integer'],
+  description:
+    'Project reference: an exact project name (string) or a project id (integer) from list_projects.',
+}
+
 /** The full inbound tool surface. Order is the advertised order. */
 export const TOOL_MANIFEST: readonly ManifestTool[] = [
   {
@@ -114,6 +133,45 @@ export const TOOL_MANIFEST: readonly ManifestTool[] = [
         },
       },
       required: ['title'],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: LIST_PROJECTS_TOOL_NAME,
+    title: 'List projects',
+    description:
+      'READ-ONLY. List the GH Projects roster so you know what exists before acting. Returns one ' +
+      'lean row per project — id, name, status (active/snoozed), next action, and open-todo count. ' +
+      'Mutates nothing. Use the returned id or name with get_project_context and get_reentry_digest; ' +
+      'pass the project NAME (not id) to add_todo.',
+    inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+  },
+  {
+    name: GET_PROJECT_CONTEXT_TOOL_NAME,
+    title: 'Get project context',
+    description:
+      "READ-ONLY. Get one project's situational brief so you act with context: its card (purpose, " +
+      'repos, services, active goal, glossary), open todos, links, and saved brain resources. ' +
+      '`services` lists the project\'s service names; per-service runbook bodies are surfaced ' +
+      'separately once available. Mutates nothing.',
+    inputSchema: {
+      type: 'object',
+      properties: { project: PROJECT_REF_SCHEMA },
+      required: ['project'],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: GET_REENTRY_DIGEST_TOOL_NAME,
+    title: 'Get re-entry digest',
+    description:
+      'READ-ONLY. Get the blame-free "what changed while I was away / what should I pick up" digest ' +
+      'the app computes (recent Copilot sessions + unread activity) plus each project\'s drift ' +
+      'state. Pass `project` for one project; omit it for every project with new activity or drift. ' +
+      'Mutates nothing.',
+    inputSchema: {
+      type: 'object',
+      properties: { project: PROJECT_REF_SCHEMA },
       additionalProperties: false,
     },
   },

--- a/src/main/mcp-server/tool-manifest.ts
+++ b/src/main/mcp-server/tool-manifest.ts
@@ -171,7 +171,8 @@ export const TOOL_MANIFEST: readonly ManifestTool[] = [
     description:
       'READ-ONLY. Get the blame-free "what changed while I was away / what should I pick up" digest ' +
       'the app computes (recent Copilot sessions + unread activity) plus each project\'s drift ' +
-      'state. Pass `project` for one project; omit it for every project with new activity or drift. ' +
+      'state. Always returns a `projects` list (uniform shape): pass `project` for a one-element ' +
+      'list with just that project; omit it for every project with new activity or drift. ' +
       'Mutates nothing.',
     inputSchema: {
       type: 'object',

--- a/src/main/mcp-server/tool-manifest.ts
+++ b/src/main/mcp-server/tool-manifest.ts
@@ -46,10 +46,14 @@ export const GET_REENTRY_DIGEST_TOOL_NAME = 'get_reentry_digest'
 
 /**
  * A `project` reference: an exact project NAME (JSON string, case-insensitive) or a project ID
- * (JSON integer, as returned by `list_projects`). String→name, number→id — unambiguous.
+ * (JSON integer, as returned by `list_projects`). String→name, number→id — unambiguous. The
+ * `minLength`/`minimum` bounds mirror what the handlers accept (a non-empty name, a positive id),
+ * so a client can fail fast before calling.
  */
 const PROJECT_REF_SCHEMA = {
   type: ['string', 'integer'],
+  minLength: 1,
+  minimum: 1,
   description:
     'Project reference: an exact project name (string) or a project id (integer) from list_projects.',
 }

--- a/src/main/mcp-server/tools.ts
+++ b/src/main/mcp-server/tools.ts
@@ -13,8 +13,14 @@ import type { Server } from '@modelcontextprotocol/sdk/server/index.js'
 import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js'
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
 import { ADD_TODO_TOOL_NAME, PING_TOOL_NAME, TOOL_MANIFEST } from './tool-manifest'
+import {
+  GET_PROJECT_CONTEXT_TOOL_NAME,
+  GET_REENTRY_DIGEST_TOOL_NAME,
+  LIST_PROJECTS_TOOL_NAME,
+} from './tool-manifest'
 import { sanitizeMcpJson } from './sanitize'
 import { runAddTodo } from './add-todo'
+import { runGetProjectContext, runGetReentryDigest, runListProjects } from './read-context'
 
 /** Dependencies a tool handler may need. */
 export interface ToolDeps {
@@ -45,6 +51,11 @@ export function buildToolHandlers(deps: ToolDeps): Map<string, ToolHandler> {
     if (result.isError !== true) deps.onTodoChanged?.()
     return result
   })
+  // Read-only context tools (#106): expose the app's own computed state. They mutate nothing,
+  // so they take no deps and never fire onTodoChanged.
+  handlers.set(LIST_PROJECTS_TOOL_NAME, () => runListProjects())
+  handlers.set(GET_PROJECT_CONTEXT_TOOL_NAME, (args) => runGetProjectContext(args))
+  handlers.set(GET_REENTRY_DIGEST_TOOL_NAME, (args) => runGetReentryDigest(args))
   return handlers
 }
 

--- a/src/main/mcp-server/tools.ts
+++ b/src/main/mcp-server/tools.ts
@@ -12,11 +12,13 @@
 import type { Server } from '@modelcontextprotocol/sdk/server/index.js'
 import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js'
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
-import { ADD_TODO_TOOL_NAME, PING_TOOL_NAME, TOOL_MANIFEST } from './tool-manifest'
 import {
+  ADD_TODO_TOOL_NAME,
   GET_PROJECT_CONTEXT_TOOL_NAME,
   GET_REENTRY_DIGEST_TOOL_NAME,
   LIST_PROJECTS_TOOL_NAME,
+  PING_TOOL_NAME,
+  TOOL_MANIFEST,
 } from './tool-manifest'
 import { sanitizeMcpJson } from './sanitize'
 import { runAddTodo } from './add-todo'


### PR DESCRIPTION
Closes #106. Part of epic #98.

## What & why
Three READ-ONLY inbound MCP tools so Copilot has situational awareness *before* it acts, sourced from the app's own computed state (the higher-value half of the epic). They build on the loopback MCP server (#103/#108) and copy the `add_todo` (#102) tool pattern.

- `list_projects()` -> one lean row per live project: `id`, `name`, `status`, `nextAction`, `activeTodoCount`.
- `get_project_context({ project })` -> the project's card (purpose, repos, services, active goal, glossary) + open todos + links + brain resources.
- `get_reentry_digest({ project? })` -> the app-computed re-entry digest + drift state. With `project`: that one project. Without: every project that has new activity **or** is drifting.

## Key decisions
- **Reuse, right layer.** These reuse the existing read-only primitives (`listProjects`, `getProject`, `getProjectCardReadOnly`, `listResources`, `getDigest`, `resolveProjectIdByName`). I deliberately did **not** use the question-driven `assemble()` retriever/ranker - `get_project_context` has no query and needs the whole card, not a ranked subset. (The issue's `prompt.ts` reference is stale - no such file exists.)
- **Read-only, hard.** Nothing mutates. In particular I use `getProjectCardReadOnly` (never the lazily-creating `getProjectCard`).
- **Payload shape.** Each tool returns `structuredContent` (typed payload with ids for follow-up tools) + a short text summary - not a single JSON-in-text blob, because the output sanitizer caps every string leaf at 2000 chars and would silently truncate/corrupt a whole-payload string. The genuinely-long markdown fields (todo `body`, resource `description`) are capped explicitly with truncation flags; list sections are capped with totals + `truncated` flags.
- **`project` ref.** A JSON string resolves by name (same case-insensitive resolver `add_todo` uses); a JSON integer resolves by id. Unambiguous, and matches the exact types `list_projects` returns.
- **Decoupled from #100 (parallel).** I ship `card.services` (the names); per-service runbook *bodies* attach later once #100 lands - no code dependency, so the two PRs don't block each other. `add_todo` stays name-only; `list_projects` tells the model to pass the project **name** (not id) to `add_todo`, guarded by a regression test.

## How I verified
- `bun run test` (typecheck + eslint + vitest) green - **578 tests pass**.
- **Unit tests** (`read-context.test.ts`): empty roster; per-project open-todo counts; lean field set (no `idempotencyKey`/`sortOrder`/`done` leak); ref resolution (name, id, and rejection of float/`0`/negative/empty/soft-deleted); card + open-todo (done excluded) + links + resources shaping; list caps (50 todos / 30 resources) with totals + truncation flags; long body/description capping; global-digest inclusion rule (active-with-activity + drifting included, quiet-active excluded, empty case); manifest hygiene (all 3 advertised with correct `required`/`additionalProperties`/`project` type; every manifest tool has a handler; `add_todo` stays name-only).
- **Read-only proof:** each read tool asserts `SELECT total_changes()` delta is 0 (verified in bun:sqlite to count INSERT+UPDATE+DELETE), plus a specific assertion that `get_project_context` on a card-less project creates **no** `project_cards` row.
- **Integration test** (`read-context.integration.test.ts`): stands up the **real** loopback MCP server and drives it with a **real** `@modelcontextprotocol/sdk` client over Streamable HTTP; asserts `tools/list` advertises all three and that each tool's returned `structuredContent` equals what the app computes (card purpose/services/glossary, digest item kinds, ids). This also confirms `structuredContent` survives the real client round-trip.

### Honest gap
I did not exercise the real Copilot desktop app invoking these tools end-to-end (no harness for that here). The integration test covers the full server + real MCP SDK client path, which is the strongest evidence available in-repo.

## Notes for reviewers
The plan and implementation were each reviewed by an independent model (GPT-5.5) to convergence, with emphasis on right-layer reuse and read-only safety.