### PR TITLE
Per-service markdown runbooks + read/write knowledge tools (ungated) (#100)

### DIFF
--- a/src/main/context/registry.ts
+++ b/src/main/context/registry.ts
@@ -135,6 +135,34 @@ export function listResources(projectId: number): Resource[] {
   return rows.map(toResource)
 }
 
+/** A live resource plus the name of its owning project. */
+export interface ServiceResource extends Resource {
+  projectName: string
+}
+
+/**
+ * Read-only lookup of live resources whose `service` matches (case-insensitively)
+ * — used by the `read_service_knowledge` tool so prose that references a resource
+ * by alias can resolve to the link truth. Each row carries its owning project's
+ * name so results are never silently conflated across projects; pass `projectId`
+ * to scope to a single project. Newest first.
+ */
+export function listResourcesByService(service: string, projectId?: number): ServiceResource[] {
+  const norm = service.trim().toLowerCase()
+  const params: unknown[] = [norm]
+  let sql =
+    'SELECT r.*, p.name AS project_name FROM resources r ' +
+    'JOIN projects p ON p.id = r.project_id ' +
+    'WHERE r.deleted_at IS NULL AND lower(r.service) = ?'
+  if (projectId !== undefined) {
+    sql += ' AND r.project_id = ?'
+    params.push(projectId)
+  }
+  sql += ' ORDER BY r.updated_at DESC, r.id DESC'
+  const rows = getDb().prepare(sql).all(...params) as Array<ResourceRow & { project_name: string }>
+  return rows.map((row) => ({ ...toResource(row), projectName: row.project_name }))
+}
+
 /** Fetches one live resource by id, or null when missing/deleted. */
 export function getResource(id: number): Resource | null {
   const row = getDb()

--- a/src/main/context/registry.ts
+++ b/src/main/context/registry.ts
@@ -153,7 +153,7 @@ export function listResourcesByService(service: string, projectId?: number): Ser
   let sql =
     'SELECT r.*, p.name AS project_name FROM resources r ' +
     'JOIN projects p ON p.id = r.project_id ' +
-    'WHERE r.deleted_at IS NULL AND lower(r.service) = ?'
+    'WHERE r.deleted_at IS NULL AND p.deleted_at IS NULL AND lower(r.service) = ?'
   if (projectId !== undefined) {
     sql += ' AND r.project_id = ?'
     params.push(projectId)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -46,6 +46,8 @@ import { refreshTodoAppSessionsForProject } from './agent/copilot-app/status'
 import { getAppDelegateEnabled, setAppDelegateEnabled, getReposRoot, setReposRoot } from './agent/copilot-app/settings'
 import { enableMcpServer, disableMcpServer, shutdownMcpServer } from './mcp-server/lifecycle'
 import { getMcpServerEnabled, setMcpServerEnabled } from './mcp-server/settings'
+import { listRunbooksForProject } from './knowledge/project-runbooks'
+import { revealablePathForService } from './knowledge/store'
 import type { ProjectPatch, ProjectTodoPatch, ProjectLinkPatch, SnoozeMode, SyncIntervalMinutes, MaxSyncDays, CreateRoutingRulePayload, LaunchAgentTaskPayload, ResourceInput, ResourcePatch, ProjectCardPatch, DelegatePayload } from '../shared/ipc-channels'
 import { SYNC_INTERVAL_OPTIONS, MAX_SYNC_DAYS_OPTIONS } from '../shared/ipc-channels'
 
@@ -448,6 +450,15 @@ app.whenReady().then(async () => {
   ipcMain.handle('resources:card-upsert', (_event, projectId: number, patch: ProjectCardPatch) =>
     upsertProjectCard(projectId, patch)
   )
+
+  // Service knowledge / runbooks (#100). Reads only; the loopback MCP server owns writes.
+  ipcMain.handle('knowledge:list-for-project', (_event, projectId: number) =>
+    listRunbooksForProject(projectId)
+  )
+  ipcMain.handle('knowledge:reveal', (_event, service: string) => {
+    const path = revealablePathForService(service)
+    if (path !== null) shell.showItemInFolder(path)
+  })
 
   startNotificationSync()
   startSnoozeWatcher()

--- a/src/main/knowledge/frontmatter.test.ts
+++ b/src/main/knowledge/frontmatter.test.ts
@@ -61,6 +61,14 @@ describe('parseKnowledge', () => {
     expect(frontmatter.service).toBeNull()
     expect(body).toBe(raw)
   })
+
+  it('parses CRLF (\\r\\n) frontmatter', () => {
+    const raw = '---\r\nservice: web\r\nenv: prod\r\n---\r\n\r\nbody line\r\n'
+    const { frontmatter, body } = parseKnowledge(raw)
+    expect(frontmatter.service).toBe('web')
+    expect(frontmatter.env).toBe('prod')
+    expect(body).toContain('body line')
+  })
 })
 
 describe('emitKnowledge', () => {

--- a/src/main/knowledge/frontmatter.test.ts
+++ b/src/main/knowledge/frontmatter.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest'
+import { parseKnowledge, emitKnowledge } from './frontmatter'
+
+describe('parseKnowledge', () => {
+  it('parses a standard frontmatter block + body', () => {
+    const raw = '---\nservice: web\nenv: prod\nupdated_at: 2026-07-09T00:00:00.000Z\nsource: copilot\n---\n\n# How to check health\n\nPing the /health endpoint.\n'
+    const { frontmatter, body } = parseKnowledge(raw)
+    expect(frontmatter).toEqual({
+      service: 'web',
+      env: 'prod',
+      updatedAt: '2026-07-09T00:00:00.000Z',
+      source: 'copilot',
+    })
+    expect(body).toContain('# How to check health')
+    expect(body).toContain('Ping the /health endpoint.')
+  })
+
+  it('tolerates quoted values and extra whitespace', () => {
+    const raw = "---\nservice:   \"web\"  \nsource: 'user'\n---\nbody"
+    const { frontmatter } = parseKnowledge(raw)
+    expect(frontmatter.service).toBe('web')
+    expect(frontmatter.source).toBe('user')
+  })
+
+  it('ignores unknown keys but still parses when a recognized key is present', () => {
+    const raw = '---\nservice: web\nowner: alice\n---\nbody'
+    const { frontmatter } = parseKnowledge(raw)
+    expect(frontmatter.service).toBe('web')
+  })
+
+  it('strips a leading BOM before detecting frontmatter', () => {
+    const raw = '\uFEFF---\nservice: web\n---\nbody'
+    expect(parseKnowledge(raw).frontmatter.service).toBe('web')
+  })
+
+  it('does NOT treat a body that opens with a --- horizontal rule as frontmatter', () => {
+    const raw = '---\nThis is a real paragraph, not key: value.\nMore prose here.\n---\nrest'
+    const { frontmatter, body } = parseKnowledge(raw)
+    expect(frontmatter.service).toBeNull()
+    // The whole input is preserved as body.
+    expect(body).toBe(raw)
+  })
+
+  it('does not treat a --- block with only unknown keys as our frontmatter', () => {
+    const raw = '---\nfoo: bar\nbaz: qux\n---\nbody'
+    const { frontmatter, body } = parseKnowledge(raw)
+    expect(frontmatter.service).toBeNull()
+    expect(body).toBe(raw)
+  })
+
+  it('returns all-null frontmatter and full body when there is no frontmatter', () => {
+    const raw = '# Just a heading\n\nSome prose.'
+    const { frontmatter, body } = parseKnowledge(raw)
+    expect(frontmatter).toEqual({ service: null, env: null, updatedAt: null, source: null })
+    expect(body).toBe(raw)
+  })
+
+  it('treats an unclosed fence as body (never throws)', () => {
+    const raw = '---\nservice: web\nno closing fence'
+    const { frontmatter, body } = parseKnowledge(raw)
+    expect(frontmatter.service).toBeNull()
+    expect(body).toBe(raw)
+  })
+})
+
+describe('emitKnowledge', () => {
+  it('emits recognized fields in fixed order with a body separator', () => {
+    const out = emitKnowledge(
+      { service: 'web', env: 'prod', updatedAt: '2026-07-09T00:00:00.000Z', source: 'copilot' },
+      'Body text',
+    )
+    expect(out).toBe(
+      '---\nservice: web\nenv: prod\nupdated_at: 2026-07-09T00:00:00.000Z\nsource: copilot\n---\n\nBody text',
+    )
+  })
+
+  it('omits null fields (e.g. no env)', () => {
+    const out = emitKnowledge({ service: 'web', env: null, updatedAt: '2026-07-09T00:00:00.000Z', source: 'copilot' }, 'x')
+    expect(out).not.toContain('env:')
+    expect(out).toContain('service: web')
+  })
+
+  it('trims leading blank lines from the body so repeated writes do not accumulate', () => {
+    const first = emitKnowledge({ service: 'web', env: null, updatedAt: 't', source: 'copilot' }, '\n\n\nBody')
+    const reparsed = parseKnowledge(first)
+    const second = emitKnowledge({ service: 'web', env: null, updatedAt: 't', source: 'copilot' }, reparsed.body)
+    expect(first).toBe(second)
+  })
+})
+
+describe('round-trip', () => {
+  it('parse(emit(x)) preserves recognized frontmatter and body', () => {
+    const fm = { service: 'payments-api', env: 'staging', updatedAt: '2026-07-09T12:00:00.000Z', source: 'user' as const }
+    const body = '# Runbook\n\n1. Check the [prod latency dashboard]\n2. Look at logs\n'
+    const parsed = parseKnowledge(emitKnowledge(fm, body))
+    expect(parsed.frontmatter).toEqual(fm)
+    expect(parsed.body).toContain('# Runbook')
+    expect(parsed.body).toContain('[prod latency dashboard]')
+  })
+})

--- a/src/main/knowledge/frontmatter.ts
+++ b/src/main/knowledge/frontmatter.ts
@@ -75,7 +75,7 @@ export function parseKnowledge(raw: string): ParsedKnowledge {
   if (open === null) return { frontmatter: { ...EMPTY_FRONTMATTER }, body: raw }
 
   // Walk subsequent lines, collecting inner lines until the closing `---` fence.
-  const lineRe = /([^\n]*)(\r?\n|$)/g
+  const lineRe = /([^\r\n]*)(\r?\n|$)/g
   lineRe.lastIndex = open[0].length
   const innerLines: string[] = []
   let closeEnd = -1

--- a/src/main/knowledge/frontmatter.ts
+++ b/src/main/knowledge/frontmatter.ts
@@ -1,0 +1,129 @@
+/**
+ * Light frontmatter for per-service runbooks (issue #100). NOT a general YAML
+ * parser — the schema is a fixed, tiny set of scalar string fields
+ * (`service`, `env`, `updated_at`, `source`), so a constrained line-based
+ * `key: value` reader is safer and dependency-free.
+ *
+ * Detection is deliberately CONSERVATIVE so we never mistake ordinary Markdown
+ * (a body that opens with a `---` horizontal rule, say) for frontmatter and
+ * silently eat it: a leading `---` block counts as frontmatter ONLY when it is
+ * the very first line (after an optional BOM), has a closing `---` fence, EVERY
+ * non-empty inner line is a scalar `key: value`, AND at least one recognized key
+ * is present. Anything else → the whole input is body.
+ *
+ * The read tool returns the file's raw bytes; parse/emit here are used to
+ * extract metadata for display and to re-stamp on write.
+ */
+
+/** Recognized frontmatter fields, mapped to camelCase. Values are raw strings. */
+export interface KnowledgeFrontmatter {
+  service: string | null
+  env: string | null
+  updatedAt: string | null
+  source: string | null
+}
+
+/** A parsed runbook: recognized frontmatter + the remaining body (verbatim). */
+export interface ParsedKnowledge {
+  frontmatter: KnowledgeFrontmatter
+  body: string
+}
+
+const EMPTY_FRONTMATTER: KnowledgeFrontmatter = {
+  service: null,
+  env: null,
+  updatedAt: null,
+  source: null,
+}
+
+/** File keys we understand (snake_case as written on disk). */
+const RECOGNIZED = new Set(['service', 'env', 'updated_at', 'source'])
+
+/** Strip a single pair of matching surrounding quotes, if present. */
+function stripQuotes(value: string): string {
+  if (value.length >= 2) {
+    const first = value[0]
+    const last = value[value.length - 1]
+    if ((first === '"' && last === '"') || (first === "'" && last === "'")) {
+      return value.slice(1, -1)
+    }
+  }
+  return value
+}
+
+function mapFrontmatter(parsed: Record<string, string>): KnowledgeFrontmatter {
+  return {
+    service: parsed.service ?? null,
+    env: parsed.env ?? null,
+    updatedAt: parsed.updated_at ?? null,
+    source: parsed.source ?? null,
+  }
+}
+
+/**
+ * Parse a runbook string into recognized frontmatter + body. When no valid
+ * frontmatter block is present the whole input is returned as `body` and
+ * `frontmatter` is all-null (never throws — a malformed file must not crash a
+ * read).
+ */
+export function parseKnowledge(raw: string): ParsedKnowledge {
+  // Strip a leading BOM for detection only.
+  const text = raw.charCodeAt(0) === 0xfeff ? raw.slice(1) : raw
+
+  // The opening fence must be the very first line.
+  const open = /^---[ \t]*\r?\n/.exec(text)
+  if (open === null) return { frontmatter: { ...EMPTY_FRONTMATTER }, body: raw }
+
+  // Walk subsequent lines, collecting inner lines until the closing `---` fence.
+  const lineRe = /([^\n]*)(\r?\n|$)/g
+  lineRe.lastIndex = open[0].length
+  const innerLines: string[] = []
+  let closeEnd = -1
+  let match: RegExpExecArray | null
+  while ((match = lineRe.exec(text)) !== null) {
+    const content = match[1]
+    const terminator = match[2]
+    if (content.replace(/[ \t]+$/, '') === '---') {
+      closeEnd = lineRe.lastIndex
+      break
+    }
+    innerLines.push(content)
+    // Reached EOF without a closing fence, or an empty zero-width match: stop.
+    if (terminator === '' || match[0] === '') break
+  }
+  if (closeEnd === -1) return { frontmatter: { ...EMPTY_FRONTMATTER }, body: raw }
+
+  // Every non-empty inner line must be a scalar `key: value`, else this is not
+  // our frontmatter — treat the entire input as body.
+  const parsed: Record<string, string> = {}
+  let recognized = 0
+  for (const line of innerLines) {
+    if (line.trim() === '') continue
+    const kv = /^[ \t]*([A-Za-z_][A-Za-z0-9_]*)[ \t]*:[ \t]?(.*)$/.exec(line)
+    if (kv === null) return { frontmatter: { ...EMPTY_FRONTMATTER }, body: raw }
+    const key = kv[1].toLowerCase()
+    parsed[key] = stripQuotes(kv[2].trim())
+    if (RECOGNIZED.has(key)) recognized++
+  }
+  if (recognized === 0) return { frontmatter: { ...EMPTY_FRONTMATTER }, body: raw }
+
+  return { frontmatter: mapFrontmatter(parsed), body: text.slice(closeEnd) }
+}
+
+/**
+ * Emit a runbook string: a frontmatter block (only non-null fields, fixed order)
+ * followed by a single blank-line separator and the body. Leading blank lines in
+ * `body` are trimmed so repeated writes don't accumulate whitespace; the result
+ * round-trips stably through {@link parseKnowledge}.
+ */
+export function emitKnowledge(frontmatter: KnowledgeFrontmatter, body: string): string {
+  const lines: string[] = []
+  if (frontmatter.service !== null) lines.push(`service: ${frontmatter.service}`)
+  if (frontmatter.env !== null) lines.push(`env: ${frontmatter.env}`)
+  if (frontmatter.updatedAt !== null) lines.push(`updated_at: ${frontmatter.updatedAt}`)
+  if (frontmatter.source !== null) lines.push(`source: ${frontmatter.source}`)
+
+  const block = `---\n${lines.join('\n')}\n---\n`
+  const trimmedBody = body.replace(/^(?:\r?\n)+/, '')
+  return trimmedBody.length > 0 ? `${block}\n${trimmedBody}` : block
+}

--- a/src/main/knowledge/paths.ts
+++ b/src/main/knowledge/paths.ts
@@ -1,0 +1,33 @@
+/**
+ * Filesystem locations for per-service knowledge (issue #100).
+ *
+ * Layout under the app-data root (`~/.gh-projects/`, mirroring `run/`):
+ *   knowledge/<service>.md              — one human-editable runbook per service
+ *   knowledge/.history/<service>/<ts>.md — timestamped backups made before each
+ *                                          overwrite (so an ungated write is
+ *                                          recoverable)
+ *
+ * The `GH_PROJECTS_KNOWLEDGE_DIR` env override lets tests point at an isolated
+ * temp dir instead of the real `~/.gh-projects/knowledge`, exactly like
+ * `GH_PROJECTS_RUN_DIR` does for the MCP run files. Dependency-free (node
+ * builtins only) so the store + tools stay cheap to unit test.
+ */
+
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+/** Directory holding the per-service markdown runbooks. */
+export function knowledgeDir(): string {
+  const override = process.env.GH_PROJECTS_KNOWLEDGE_DIR
+  if (override !== undefined && override.trim().length > 0) return override
+  return join(homedir(), '.gh-projects', 'knowledge')
+}
+
+/**
+ * Directory holding version-history backups. A hidden `.history` sibling of the
+ * runbooks — safe from collision because service keys can never begin with `.`
+ * (see `validateServiceName`), so no runbook file/dir can be named `.history`.
+ */
+export function historyDir(dir: string = knowledgeDir()): string {
+  return join(dir, '.history')
+}

--- a/src/main/knowledge/project-runbooks.test.ts
+++ b/src/main/knowledge/project-runbooks.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import type { ProjectCard } from '../../shared/ipc-channels'
+
+// Control the project card without a DB; use the real store against a temp dir.
+const { getProjectCardReadOnly } = vi.hoisted(() => ({
+  getProjectCardReadOnly: vi.fn<(projectId: number) => ProjectCard>(),
+}))
+vi.mock('../context/registry', () => ({ getProjectCardReadOnly }))
+
+import { listRunbooksForProject } from './project-runbooks'
+import { writeServiceKnowledge } from './store'
+
+let dir = ''
+let prevEnv: string | undefined
+
+beforeEach(() => {
+  prevEnv = process.env.GH_PROJECTS_KNOWLEDGE_DIR
+  dir = mkdtempSync(join(tmpdir(), 'gh-runbooks-'))
+  process.env.GH_PROJECTS_KNOWLEDGE_DIR = dir
+  getProjectCardReadOnly.mockReset()
+})
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true })
+  if (prevEnv === undefined) delete process.env.GH_PROJECTS_KNOWLEDGE_DIR
+  else process.env.GH_PROJECTS_KNOWLEDGE_DIR = prevEnv
+})
+
+function card(services: string[]): ProjectCard {
+  return { projectId: 1, purpose: '', repos: [], services, activeGoal: '', glossary: {}, updatedAt: 'now' }
+}
+
+describe('listRunbooksForProject', () => {
+  it('returns a runbook per service with correct statuses', async () => {
+    await writeServiceKnowledge({ service: 'web', markdown: 'web runbook' }, dir)
+    getProjectCardReadOnly.mockReturnValue(card(['web', 'payments-api']))
+
+    const out = listRunbooksForProject(1)
+    expect(out).toHaveLength(2)
+    const web = out.find((r) => r.service === 'web')
+    const pay = out.find((r) => r.service === 'payments-api')
+    expect(web?.status).toBe('ok')
+    expect(web?.markdown).toContain('web runbook')
+    expect(pay?.status).toBe('missing')
+  })
+
+  it('dedupes services that fold to the same key', () => {
+    getProjectCardReadOnly.mockReturnValue(card(['API', 'api', ' api ']))
+    const out = listRunbooksForProject(1)
+    expect(out).toHaveLength(1)
+    expect(out[0].key).toBe('api')
+  })
+
+  it('marks an invalid service name honestly instead of failing', () => {
+    getProjectCardReadOnly.mockReturnValue(card(['Bad Name', '../evil']))
+    const out = listRunbooksForProject(1)
+    expect(out).toHaveLength(2)
+    for (const r of out) {
+      expect(r.status).toBe('invalid')
+      expect(r.key).toBeNull()
+      expect(r.reason).toBeTruthy()
+    }
+  })
+
+  it('skips blank service entries', () => {
+    getProjectCardReadOnly.mockReturnValue(card(['', '   ', 'web']))
+    const out = listRunbooksForProject(1)
+    expect(out.map((r) => r.service)).toEqual(['web'])
+  })
+})

--- a/src/main/knowledge/project-runbooks.ts
+++ b/src/main/knowledge/project-runbooks.ts
@@ -1,0 +1,82 @@
+/**
+ * Builds the per-project Runbooks view (#100): one {@link ServiceRunbook} per
+ * service on the project card, read fresh from disk. Deduped by normalized key so
+ * `API` and `api` don't show twice, and honest about services whose card name
+ * isn't a valid runbook key. Read-only (uses the non-lazy card read) so surfacing
+ * runbooks never mutates state.
+ */
+
+import type { ServiceRunbook } from '../../shared/ipc-channels'
+import { normalizeServiceName, validateServiceName } from '../../shared/service-name'
+import { getProjectCardReadOnly } from '../context/registry'
+import { readServiceKnowledge } from './store'
+
+export function listRunbooksForProject(projectId: number): ServiceRunbook[] {
+  const card = getProjectCardReadOnly(projectId)
+  const seen = new Set<string>()
+  const out: ServiceRunbook[] = []
+
+  for (const raw of card.services) {
+    const trimmed = raw.trim()
+    if (trimmed.length === 0) continue
+    const v = validateServiceName(trimmed)
+    // Dedupe by the filename key when valid; otherwise by the folded raw name so
+    // repeated invalid entries collapse too.
+    const dedupeKey = v.ok ? v.key : `invalid:${normalizeServiceName(trimmed)}`
+    if (seen.has(dedupeKey)) continue
+    seen.add(dedupeKey)
+
+    if (!v.ok) {
+      out.push({
+        service: trimmed,
+        key: null,
+        status: 'invalid',
+        reason: v.reason,
+        markdown: null,
+        env: null,
+        updatedAt: null,
+        source: null,
+      })
+      continue
+    }
+
+    const res = readServiceKnowledge(trimmed)
+    switch (res.status) {
+      case 'ok':
+        out.push({
+          service: trimmed,
+          key: v.key,
+          status: 'ok',
+          reason: null,
+          markdown: res.knowledge.markdown,
+          env: res.knowledge.env,
+          updatedAt: res.knowledge.updatedAt,
+          source: res.knowledge.source,
+        })
+        break
+      case 'missing':
+        out.push({ service: trimmed, key: v.key, status: 'missing', reason: null, markdown: null, env: null, updatedAt: null, source: null })
+        break
+      case 'too_large':
+        out.push({
+          service: trimmed,
+          key: v.key,
+          status: 'too_large',
+          reason: `File is ${res.size} bytes, too large to display here — edit it on disk.`,
+          markdown: null,
+          env: null,
+          updatedAt: null,
+          source: null,
+        })
+        break
+      case 'blocked':
+        out.push({ service: trimmed, key: v.key, status: 'blocked', reason: res.reason, markdown: null, env: null, updatedAt: null, source: null })
+        break
+      case 'invalid_service':
+        out.push({ service: trimmed, key: null, status: 'invalid', reason: res.reason, markdown: null, env: null, updatedAt: null, source: null })
+        break
+    }
+  }
+
+  return out
+}

--- a/src/main/knowledge/store.test.ts
+++ b/src/main/knowledge/store.test.ts
@@ -124,6 +124,16 @@ describe('size bounds', () => {
     expect(existsSync(join(dir, 'web.md'))).toBe(false)
   })
 
+  it('rejects a write whose stamped content would exceed the cap (final-size check)', async () => {
+    const dir = freshDir()
+    // Body is exactly at the cap; stamped frontmatter pushes the final file over,
+    // so the read path would otherwise reject it — the write must fail first.
+    const body = 'x'.repeat(KNOWLEDGE_MAX_BYTES)
+    const w = await writeServiceKnowledge({ service: 'web', markdown: body }, dir)
+    expect(w.status).toBe('too_large')
+    expect(existsSync(join(dir, 'web.md'))).toBe(false)
+  })
+
   it('reports too_large for a hand-edited oversized file instead of truncating', () => {
     const dir = freshDir()
     writeFileSync(join(dir, 'web.md'), 'x'.repeat(KNOWLEDGE_MAX_BYTES + 1))

--- a/src/main/knowledge/store.test.ts
+++ b/src/main/knowledge/store.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, readdirSync, symlinkSync, existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  readServiceKnowledge,
+  writeServiceKnowledge,
+  listServiceHistory,
+  knowledgeFilePathForService,
+  KNOWLEDGE_MAX_BYTES,
+  MAX_HISTORY_VERSIONS,
+} from './store'
+
+const dirs: string[] = []
+function freshDir(): string {
+  const d = mkdtempSync(join(tmpdir(), 'gh-knowledge-'))
+  dirs.push(d)
+  return d
+}
+afterEach(() => {
+  for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true })
+})
+
+describe('read missing', () => {
+  it('reports missing for a service with no file', () => {
+    const dir = freshDir()
+    const res = readServiceKnowledge('web', dir)
+    expect(res.status).toBe('missing')
+  })
+})
+
+describe('write then read (round-trip + stamping)', () => {
+  it('writes, stamps source/updated_at, and reads back', async () => {
+    const dir = freshDir()
+    const w = await writeServiceKnowledge({ service: 'web', markdown: '# Health\n\nHit /health.' }, dir)
+    expect(w.status).toBe('ok')
+
+    const r = readServiceKnowledge('web', dir)
+    expect(r.status).toBe('ok')
+    if (r.status !== 'ok') return
+    expect(r.knowledge.source).toBe('copilot')
+    expect(r.knowledge.updatedAt).not.toBeNull()
+    expect(r.knowledge.frontmatter.service).toBe('web')
+    expect(r.knowledge.markdown).toContain('Hit /health.')
+  })
+
+  it('normalizes the service name to a single file (case folding)', async () => {
+    const dir = freshDir()
+    await writeServiceKnowledge({ service: 'API', markdown: 'body' }, dir)
+    const r = readServiceKnowledge('api', dir)
+    expect(r.status).toBe('ok')
+    // Check the actual on-disk name (APFS is case-insensitive, so existsSync of a
+    // different-case name would be misleading).
+    const files = readdirSync(dir).filter((n) => n.endsWith('.md'))
+    expect(files).toEqual(['api.md'])
+  })
+
+  it('sees an out-of-band human edit on the next read', async () => {
+    const dir = freshDir()
+    await writeServiceKnowledge({ service: 'web', markdown: 'original' }, dir)
+    // Human edits the file directly on disk.
+    const filePath = join(dir, 'web.md')
+    const current = readFileSync(filePath, 'utf8')
+    writeFileSync(filePath, current + '\nhuman added line\n')
+    const r = readServiceKnowledge('web', dir)
+    expect(r.status).toBe('ok')
+    if (r.status === 'ok') expect(r.knowledge.markdown).toContain('human added line')
+  })
+})
+
+describe('env preservation', () => {
+  it('preserves a human-set env on a body-only rewrite', async () => {
+    const dir = freshDir()
+    // Human writes a file with env in frontmatter.
+    writeFileSync(join(dir, 'web.md'), '---\nservice: web\nenv: prod\nsource: user\n---\n\nhuman body\n')
+    // Copilot rewrites with body only (no frontmatter).
+    const w = await writeServiceKnowledge({ service: 'web', markdown: 'new copilot body' }, dir)
+    expect(w.status).toBe('ok')
+    const r = readServiceKnowledge('web', dir)
+    if (r.status === 'ok') {
+      expect(r.knowledge.env).toBe('prod')
+      expect(r.knowledge.source).toBe('copilot')
+      expect(r.knowledge.markdown).toContain('new copilot body')
+    }
+  })
+
+  it('lets an incoming frontmatter env override the existing one', async () => {
+    const dir = freshDir()
+    writeFileSync(join(dir, 'web.md'), '---\nservice: web\nenv: prod\n---\nx')
+    await writeServiceKnowledge({ service: 'web', markdown: '---\nenv: staging\n---\ny' }, dir)
+    const r = readServiceKnowledge('web', dir)
+    if (r.status === 'ok') expect(r.knowledge.env).toBe('staging')
+  })
+})
+
+describe('version history / recoverability', () => {
+  it('backs up the prior version before overwriting', async () => {
+    const dir = freshDir()
+    await writeServiceKnowledge({ service: 'web', markdown: 'v1 content' }, dir)
+    expect(listServiceHistory('web', dir)).toHaveLength(0) // first write: no backup
+
+    const w2 = await writeServiceKnowledge({ service: 'web', markdown: 'v2 content' }, dir)
+    expect(w2.status === 'ok' && w2.backedUp).toBe(true)
+    const history = listServiceHistory('web', dir)
+    expect(history).toHaveLength(1)
+    expect(readFileSync(history[0], 'utf8')).toContain('v1 content')
+  })
+
+  it('prunes history to the most recent N versions', async () => {
+    const dir = freshDir()
+    for (let i = 0; i < MAX_HISTORY_VERSIONS + 5; i++) {
+      await writeServiceKnowledge({ service: 'web', markdown: `version ${i}` }, dir)
+    }
+    expect(listServiceHistory('web', dir).length).toBeLessThanOrEqual(MAX_HISTORY_VERSIONS)
+  })
+})
+
+describe('size bounds', () => {
+  it('rejects an oversized write', async () => {
+    const dir = freshDir()
+    const big = 'x'.repeat(KNOWLEDGE_MAX_BYTES + 1)
+    const w = await writeServiceKnowledge({ service: 'web', markdown: big }, dir)
+    expect(w.status).toBe('too_large')
+    expect(existsSync(join(dir, 'web.md'))).toBe(false)
+  })
+
+  it('reports too_large for a hand-edited oversized file instead of truncating', () => {
+    const dir = freshDir()
+    writeFileSync(join(dir, 'web.md'), 'x'.repeat(KNOWLEDGE_MAX_BYTES + 1))
+    const r = readServiceKnowledge('web', dir)
+    expect(r.status).toBe('too_large')
+  })
+})
+
+describe('service-name safety (SECURITY)', () => {
+  it.each(['../evil', '/etc/passwd', 'a/b', '..', '.hidden', 'has space'])(
+    'rejects an unsafe service name %j on write',
+    async (bad) => {
+      const dir = freshDir()
+      const w = await writeServiceKnowledge({ service: bad, markdown: 'x' }, dir)
+      expect(w.status).toBe('invalid_service')
+    },
+  )
+
+  it.each(['../evil', '/etc/passwd', 'a/b', '..'])('rejects an unsafe service name %j on read', (bad) => {
+    const dir = freshDir()
+    const r = readServiceKnowledge(bad, dir)
+    expect(r.status).toBe('invalid_service')
+  })
+
+  it('never writes outside the knowledge dir for a traversal attempt', async () => {
+    const dir = freshDir()
+    const outside = join(dir, '..', 'escaped.md')
+    await writeServiceKnowledge({ service: '../escaped', markdown: 'pwned' }, dir)
+    expect(existsSync(outside)).toBe(false)
+  })
+
+  it('knowledgeFilePathForService returns null for an unsafe name', () => {
+    const dir = freshDir()
+    expect(knowledgeFilePathForService('../x', dir)).toBeNull()
+    expect(knowledgeFilePathForService('web', dir)).toBe(join(dir, 'web.md'))
+  })
+})
+
+describe('symlink refusal (SECURITY)', () => {
+  it('refuses to read a symlinked runbook', () => {
+    const dir = freshDir()
+    const secret = join(dir, 'secret.txt')
+    writeFileSync(secret, 'TOP SECRET')
+    symlinkSync(secret, join(dir, 'web.md'))
+    const r = readServiceKnowledge('web', dir)
+    expect(r.status).toBe('blocked')
+  })
+
+  it('refuses to overwrite a symlinked runbook', async () => {
+    const dir = freshDir()
+    const target = join(dir, 'target.txt')
+    writeFileSync(target, 'original target')
+    symlinkSync(target, join(dir, 'web.md'))
+    const w = await writeServiceKnowledge({ service: 'web', markdown: 'x' }, dir)
+    expect(w.status).toBe('blocked')
+    // The symlink target must be untouched.
+    expect(readFileSync(target, 'utf8')).toBe('original target')
+  })
+
+  it('refuses to back up into a symlinked history dir', async () => {
+    const dir = freshDir()
+    await writeServiceKnowledge({ service: 'web', markdown: 'v1' }, dir)
+    // Replace .history with a symlink to an outside dir.
+    const outside = freshDir()
+    rmSync(join(dir, '.history'), { recursive: true, force: true })
+    symlinkSync(outside, join(dir, '.history'))
+    const w = await writeServiceKnowledge({ service: 'web', markdown: 'v2' }, dir)
+    expect(w.status).toBe('backup_failed')
+    // The original file must be intact (write aborted).
+    const r = readServiceKnowledge('web', dir)
+    expect(r.status === 'ok' && r.knowledge.markdown.includes('v1')).toBe(true)
+  })
+})
+
+describe('concurrent writes', () => {
+  it('serializes concurrent writes and keeps recoverable history', async () => {
+    const dir = freshDir()
+    await writeServiceKnowledge({ service: 'web', markdown: 'seed' }, dir)
+    // Fire several writes at once.
+    await Promise.all(
+      Array.from({ length: 8 }, (_v, i) => writeServiceKnowledge({ service: 'web', markdown: `concurrent ${i}` }, dir)),
+    )
+    const r = readServiceKnowledge('web', dir)
+    expect(r.status).toBe('ok')
+    // 1 seed + 8 concurrent = 9 writes; 8 of them overwrote an existing file, so
+    // 8 backups (all unique, none lost to a race), capped by pruning.
+    const history = listServiceHistory('web', dir)
+    expect(history.length).toBeGreaterThan(0)
+    expect(new Set(history).size).toBe(history.length) // unique backup names
+  })
+})
+
+describe('history dir does not collide with a runbook', () => {
+  it('a service literally named "history" is fine; .history stays separate', async () => {
+    const dir = freshDir()
+    await writeServiceKnowledge({ service: 'history', markdown: 'v1' }, dir)
+    await writeServiceKnowledge({ service: 'history', markdown: 'v2' }, dir)
+    expect(existsSync(join(dir, 'history.md'))).toBe(true)
+    expect(existsSync(join(dir, '.history', 'history'))).toBe(true)
+    expect(readServiceKnowledge('history', dir).status).toBe('ok')
+  })
+})

--- a/src/main/knowledge/store.test.ts
+++ b/src/main/knowledge/store.test.ts
@@ -207,6 +207,15 @@ describe('symlink refusal (SECURITY)', () => {
     const r = readServiceKnowledge('web', dir)
     expect(r.status === 'ok' && r.knowledge.markdown.includes('v1')).toBe(true)
   })
+
+  it('refuses to read through a symlinked knowledge directory', () => {
+    const real = freshDir()
+    writeFileSync(join(real, 'web.md'), 'secret runbook')
+    const linkDir = join(freshDir(), 'knowledge-link')
+    symlinkSync(real, linkDir)
+    const r = readServiceKnowledge('web', linkDir)
+    expect(r.status).toBe('blocked')
+  })
 })
 
 describe('concurrent writes', () => {

--- a/src/main/knowledge/store.test.ts
+++ b/src/main/knowledge/store.test.ts
@@ -183,6 +183,11 @@ describe('service-name safety (SECURITY)', () => {
     expect(knowledgeFilePathForService('../x', dir)).toBeNull()
     expect(knowledgeFilePathForService('web', dir)).toBe(join(dir, 'web.md'))
   })
+
+  it('resolves a valid path even for a root knowledge dir (no double-separator false block)', () => {
+    // Pure path computation, no filesystem access.
+    expect(knowledgeFilePathForService('web', '/')).toBe('/web.md')
+  })
 })
 
 describe('symlink refusal (SECURITY)', () => {

--- a/src/main/knowledge/store.test.ts
+++ b/src/main/knowledge/store.test.ts
@@ -142,6 +142,17 @@ describe('size bounds', () => {
     const r = readServiceKnowledge('web', dir)
     expect(r.status).toBe('too_large')
   })
+
+  it('refuses to overwrite an existing oversized file (no huge read into memory)', async () => {
+    const dir = freshDir()
+    const big = 'x'.repeat(KNOWLEDGE_MAX_BYTES + 1)
+    writeFileSync(join(dir, 'web.md'), big)
+    const w = await writeServiceKnowledge({ service: 'web', markdown: 'small new body' }, dir)
+    expect(w.status).toBe('blocked')
+    // The oversized file must be left untouched (not overwritten, not backed up).
+    expect(readFileSync(join(dir, 'web.md'), 'utf8')).toBe(big)
+    expect(listServiceHistory('web', dir)).toHaveLength(0)
+  })
 })
 
 describe('service-name safety (SECURITY)', () => {

--- a/src/main/knowledge/store.test.ts
+++ b/src/main/knowledge/store.test.ts
@@ -7,6 +7,7 @@ import {
   writeServiceKnowledge,
   listServiceHistory,
   knowledgeFilePathForService,
+  revealablePathForService,
   pendingWriteChainCount,
   KNOWLEDGE_MAX_BYTES,
   MAX_HISTORY_VERSIONS,
@@ -215,6 +216,23 @@ describe('symlink refusal (SECURITY)', () => {
     symlinkSync(real, linkDir)
     const r = readServiceKnowledge('web', linkDir)
     expect(r.status).toBe('blocked')
+  })
+
+  it('revealablePathForService returns a real file path but null for symlinked file/dir', () => {
+    const dir = freshDir()
+    writeFileSync(join(dir, 'web.md'), 'body')
+    expect(revealablePathForService('web', dir)).toBe(join(dir, 'web.md'))
+    expect(revealablePathForService('ghost', dir)).toBeNull() // missing
+
+    // Symlinked file -> null.
+    const symDir = freshDir()
+    symlinkSync(join(dir, 'web.md'), join(symDir, 'web.md'))
+    expect(revealablePathForService('web', symDir)).toBeNull()
+
+    // Symlinked knowledge dir -> null.
+    const linkDir = join(freshDir(), 'link')
+    symlinkSync(dir, linkDir)
+    expect(revealablePathForService('web', linkDir)).toBeNull()
   })
 })
 

--- a/src/main/knowledge/store.test.ts
+++ b/src/main/knowledge/store.test.ts
@@ -7,6 +7,7 @@ import {
   writeServiceKnowledge,
   listServiceHistory,
   knowledgeFilePathForService,
+  pendingWriteChainCount,
   KNOWLEDGE_MAX_BYTES,
   MAX_HISTORY_VERSIONS,
 } from './store'
@@ -223,6 +224,16 @@ describe('concurrent writes', () => {
     const history = listServiceHistory('web', dir)
     expect(history.length).toBeGreaterThan(0)
     expect(new Set(history).size).toBe(history.length) // unique backup names
+  })
+
+  it('does not leak write-chain entries after writes settle (bounded map)', async () => {
+    const dir = freshDir()
+    await Promise.all(
+      Array.from({ length: 12 }, (_v, i) => writeServiceKnowledge({ service: `svc-${i}`, markdown: 'x' }, dir)),
+    )
+    // Allow the settle-cleanup microtasks to run.
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(pendingWriteChainCount()).toBe(0)
   })
 })
 

--- a/src/main/knowledge/store.ts
+++ b/src/main/knowledge/store.ts
@@ -125,6 +125,19 @@ export function readServiceKnowledge(service: string, dir: string = knowledgeDir
   const filePath = safeServiceFilePath(dir, key)
   if (filePath === null) return { status: 'blocked', reason: 'Resolved path escaped the knowledge directory.' }
 
+  // Guard the knowledge dir itself: a symlinked (or non-directory) dir could make
+  // `<key>.md` resolve outside the intended tree. A missing dir just means the
+  // runbook is missing.
+  let dirStat: ReturnType<typeof lstatSync>
+  try {
+    dirStat = lstatSync(dir)
+  } catch {
+    return { status: 'missing', service: key, path: filePath }
+  }
+  if (dirStat.isSymbolicLink() || !dirStat.isDirectory()) {
+    return { status: 'blocked', reason: 'Knowledge directory is a symlink or not a directory.' }
+  }
+
   let st: ReturnType<typeof lstatSync>
   try {
     st = lstatSync(filePath) // lstat: does NOT follow a symlink
@@ -243,11 +256,22 @@ function pruneHistory(hDir: string): void {
   }
 }
 
-/** Atomically write `content` to `filePath` via an exclusive temp file + rename. */
+/** Atomically write `content` to `filePath` via an exclusive temp file + rename.
+ * Cleans up the temp file if the write/rename fails, so a failed ungated write
+ * never leaves a stray `.tmp-*` behind. */
 function atomicWriteFile(filePath: string, content: string): void {
   const tmp = `${filePath}.tmp-${process.pid}-${Math.random().toString(36).slice(2)}`
-  writeFileSync(tmp, content, { encoding: 'utf8', mode: 0o600, flag: 'wx' })
-  renameSync(tmp, filePath)
+  try {
+    writeFileSync(tmp, content, { encoding: 'utf8', mode: 0o600, flag: 'wx' })
+    renameSync(tmp, filePath)
+  } catch (err) {
+    try {
+      rmSync(tmp, { force: true })
+    } catch {
+      /* best-effort cleanup */
+    }
+    throw err
+  }
 }
 
 export interface WriteInput {
@@ -319,7 +343,13 @@ export function writeServiceKnowledge(input: WriteInput, dir: string = knowledge
       }
     }
 
-    atomicWriteFile(filePath, content)
+    try {
+      atomicWriteFile(filePath, content)
+    } catch {
+      // A backup (if any) already succeeded, so the prior version is recoverable;
+      // surface a controlled, path-free failure instead of a generic "Tool failed".
+      return { status: 'blocked', reason: 'Could not write the runbook to disk.' }
+    }
     return { status: 'ok', service: key, path: filePath, backedUp, updatedAt }
   })
 }

--- a/src/main/knowledge/store.ts
+++ b/src/main/knowledge/store.ts
@@ -181,23 +181,24 @@ function backupStamp(): string {
   return new Date().toISOString().replace(/[:.]/g, '-')
 }
 
-/** mkdir a real directory, rejecting a symlinked path (returns false = blocked). */
+/** mkdir a real directory, returning false (never throwing) on any failure — a
+ * symlinked path, a non-directory in the way, or a permission/IO error — so
+ * callers always get a controlled result instead of an exception. */
 function ensureRealDir(dirPath: string): boolean {
-  mkdirSync(dirPath, { recursive: true, mode: 0o700 })
   try {
-    if (lstatSync(dirPath).isSymbolicLink()) return false
+    mkdirSync(dirPath, { recursive: true, mode: 0o700 })
+    return !lstatSync(dirPath).isSymbolicLink()
   } catch {
     return false
   }
-  return true
 }
 
 /** Copy `content` into `.history/<key>/<stamp>.md` (exclusive create), then prune. */
 function backupBuffer(dir: string, key: string, content: Buffer): void {
   const hRoot = historyDir(dir)
-  if (!ensureRealDir(hRoot)) throw new Error('history dir is a symlink')
+  if (!ensureRealDir(hRoot)) throw new Error('history directory is a symlink or unwritable')
   const hDir = join(hRoot, key)
-  if (!ensureRealDir(hDir)) throw new Error('service history dir is a symlink')
+  if (!ensureRealDir(hDir)) throw new Error('service history directory is a symlink or unwritable')
   const name = `${backupStamp()}-${backupCounter++}.md`
   writeFileSync(join(hDir, name), content, { flag: 'wx', mode: 0o600 })
   pruneHistory(hDir)
@@ -264,7 +265,7 @@ export function writeServiceKnowledge(input: WriteInput, dir: string = knowledge
   }
 
   return serializeWrite(key, async (): Promise<WriteResult> => {
-    if (!ensureRealDir(dir)) return { status: 'blocked', reason: 'Knowledge directory is a symlink.' }
+    if (!ensureRealDir(dir)) return { status: 'blocked', reason: 'Could not prepare the knowledge directory (it may be a symlink or unwritable).' }
     const filePath = safeServiceFilePath(dir, key)
     if (filePath === null) return { status: 'blocked', reason: 'Resolved path escaped the knowledge directory.' }
 

--- a/src/main/knowledge/store.ts
+++ b/src/main/knowledge/store.ts
@@ -86,6 +86,23 @@ function safeServiceFilePath(dir: string, key: string): string | null {
 }
 
 /**
+ * Classify the knowledge directory. `ok` = a real directory we may traverse;
+ * `missing` = it doesn't exist (so any runbook is simply missing); `unsafe` = a
+ * symlink or a non-directory, which could make `<key>.md` resolve outside the
+ * intended tree. Every path-resolving caller (read, reveal, write via
+ * ensureRealDir) applies this same boundary.
+ */
+function knowledgeDirState(dir: string): 'ok' | 'missing' | 'unsafe' {
+  let st: ReturnType<typeof lstatSync>
+  try {
+    st = lstatSync(dir)
+  } catch {
+    return 'missing'
+  }
+  return st.isSymbolicLink() || !st.isDirectory() ? 'unsafe' : 'ok'
+}
+
+/**
  * Public helper for callers that just need the on-disk path for a service (e.g.
  * reveal-in-Finder). Returns null for an invalid/unsafe service name.
  */
@@ -96,13 +113,15 @@ export function knowledgeFilePathForService(service: string, dir: string = knowl
 }
 
 /**
- * Path to a service's runbook only when it exists as a real (non-symlink) file —
- * for reveal-in-Finder. Returns null when the name is invalid, the file is
- * missing, or the path is a symlink.
+ * Path to a service's runbook only when it exists as a real (non-symlink) file
+ * under a real (non-symlink) knowledge directory — for reveal-in-Finder. Returns
+ * null when the name is invalid, the dir is unsafe, the file is missing, or the
+ * path is a symlink.
  */
 export function revealablePathForService(service: string, dir: string = knowledgeDir()): string | null {
   const path = knowledgeFilePathForService(service, dir)
   if (path === null) return null
+  if (knowledgeDirState(dir) !== 'ok') return null
   try {
     const st = lstatSync(path)
     if (st.isSymbolicLink() || !st.isFile()) return null
@@ -128,13 +147,9 @@ export function readServiceKnowledge(service: string, dir: string = knowledgeDir
   // Guard the knowledge dir itself: a symlinked (or non-directory) dir could make
   // `<key>.md` resolve outside the intended tree. A missing dir just means the
   // runbook is missing.
-  let dirStat: ReturnType<typeof lstatSync>
-  try {
-    dirStat = lstatSync(dir)
-  } catch {
-    return { status: 'missing', service: key, path: filePath }
-  }
-  if (dirStat.isSymbolicLink() || !dirStat.isDirectory()) {
+  const dirState = knowledgeDirState(dir)
+  if (dirState === 'missing') return { status: 'missing', service: key, path: filePath }
+  if (dirState === 'unsafe') {
     return { status: 'blocked', reason: 'Knowledge directory is a symlink or not a directory.' }
   }
 

--- a/src/main/knowledge/store.ts
+++ b/src/main/knowledge/store.ts
@@ -1,0 +1,338 @@
+/**
+ * On-disk store for per-service knowledge runbooks (issue #100). All filesystem
+ * I/O lives here (off the render thread), so both the MCP tools and the app IPC
+ * go through one place — which is where the safety and recoverability guarantees
+ * are enforced:
+ *
+ *   - SECURITY: the service name is validated to a safe slug (shared validator)
+ *     AND the resolved path is re-checked to stay inside the knowledge dir; reads
+ *     and overwrites refuse to follow a symlinked runbook or a symlinked history
+ *     dir, so a write can never escape `~/.gh-projects/knowledge/`.
+ *   - UNGATED BUT RECOVERABLE: every overwrite first copies the prior file to a
+ *     uniquely-named `.history/<service>/<ts>.md` backup (created exclusively);
+ *     the write is aborted if that backup fails. History is pruned to the most
+ *     recent N versions.
+ *   - CONSISTENT: writes are atomic (temp file + rename) and serialized per
+ *     service, so concurrent writes can't corrupt a file or lose a backup, and a
+ *     concurrent reader always sees a whole old-or-new file (never a torn one).
+ *   - BOUNDED: writes over `KNOWLEDGE_MAX_BYTES` are rejected; a hand-edited file
+ *     over that size reads back as `too_large` rather than being silently
+ *     truncated downstream.
+ */
+
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs'
+import { join, resolve, sep } from 'node:path'
+import { validateServiceName } from '../../shared/service-name'
+import type { KnowledgeFrontmatter } from './frontmatter'
+import { emitKnowledge, parseKnowledge } from './frontmatter'
+import { historyDir, knowledgeDir } from './paths'
+
+/** Max runbook size (bytes). Comfortably fits a long runbook; bounds pathological input. */
+export const KNOWLEDGE_MAX_BYTES = 256 * 1024
+
+/** How many historical backups to keep per service. Older ones are pruned. */
+export const MAX_HISTORY_VERSIONS = 20
+
+/** Structured `source` values we stamp/understand. Humans may write anything. */
+export type KnowledgeSource = 'user' | 'copilot'
+
+/** A read runbook. `markdown` is the file's exact bytes; the rest is parsed metadata. */
+export interface ServiceKnowledge {
+  service: string
+  markdown: string
+  frontmatter: KnowledgeFrontmatter
+  env: string | null
+  updatedAt: string | null
+  source: string | null
+  /** Absolute path on disk (for reveal-in-Finder). */
+  path: string
+}
+
+export type ReadResult =
+  | { status: 'ok'; knowledge: ServiceKnowledge }
+  | { status: 'missing'; service: string; path: string }
+  | { status: 'too_large'; service: string; size: number }
+  | { status: 'invalid_service'; reason: string }
+  | { status: 'blocked'; reason: string }
+
+export type WriteResult =
+  | { status: 'ok'; service: string; path: string; backedUp: boolean; updatedAt: string }
+  | { status: 'too_large'; service: string; size: number }
+  | { status: 'invalid_service'; reason: string }
+  | { status: 'blocked'; reason: string }
+  | { status: 'backup_failed'; reason: string }
+
+// ── Path safety ───────────────────────────────────────────────────────────────
+
+/**
+ * Resolve `<dir>/<key>.md` and re-assert it stays within `dir` (defense-in-depth
+ * behind the slug validator). Returns null if containment somehow fails.
+ */
+function safeServiceFilePath(dir: string, key: string): string | null {
+  const base = resolve(dir)
+  const full = resolve(base, `${key}.md`)
+  if (full !== `${base}${sep}${key}.md`) return null
+  return full
+}
+
+/**
+ * Public helper for callers that just need the on-disk path for a service (e.g.
+ * reveal-in-Finder). Returns null for an invalid/unsafe service name.
+ */
+export function knowledgeFilePathForService(service: string, dir: string = knowledgeDir()): string | null {
+  const v = validateServiceName(service)
+  if (!v.ok) return null
+  return safeServiceFilePath(dir, v.key)
+}
+
+/**
+ * Path to a service's runbook only when it exists as a real (non-symlink) file —
+ * for reveal-in-Finder. Returns null when the name is invalid, the file is
+ * missing, or the path is a symlink.
+ */
+export function revealablePathForService(service: string, dir: string = knowledgeDir()): string | null {
+  const path = knowledgeFilePathForService(service, dir)
+  if (path === null) return null
+  try {
+    const st = lstatSync(path)
+    if (st.isSymbolicLink() || !st.isFile()) return null
+    return path
+  } catch {
+    return null
+  }
+}
+
+// ── Reads ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Read a service's runbook fresh from disk (so out-of-band human edits are always
+ * seen). Refuses to follow a symlink; reports missing / oversized explicitly.
+ */
+export function readServiceKnowledge(service: string, dir: string = knowledgeDir()): ReadResult {
+  const v = validateServiceName(service)
+  if (!v.ok) return { status: 'invalid_service', reason: v.reason }
+  const key = v.key
+  const filePath = safeServiceFilePath(dir, key)
+  if (filePath === null) return { status: 'blocked', reason: 'Resolved path escaped the knowledge directory.' }
+
+  let st: ReturnType<typeof lstatSync>
+  try {
+    st = lstatSync(filePath) // lstat: does NOT follow a symlink
+  } catch {
+    return { status: 'missing', service: key, path: filePath }
+  }
+  if (st.isSymbolicLink()) return { status: 'blocked', reason: 'Refusing to follow a symlinked runbook.' }
+  if (!st.isFile()) return { status: 'missing', service: key, path: filePath }
+  if (st.size > KNOWLEDGE_MAX_BYTES) return { status: 'too_large', service: key, size: st.size }
+
+  const markdown = readFileSync(filePath, 'utf8')
+  const parsed = parseKnowledge(markdown)
+  return {
+    status: 'ok',
+    knowledge: {
+      service: key,
+      markdown,
+      frontmatter: parsed.frontmatter,
+      env: parsed.frontmatter.env,
+      updatedAt: parsed.frontmatter.updatedAt,
+      source: parsed.frontmatter.source,
+      path: filePath,
+    },
+  }
+}
+
+// ── Writes (serialized per service) ───────────────────────────────────────────
+
+/**
+ * Per-service write queue. All writes for a given key run strictly one after the
+ * other so backups, prunes, and the atomic rename can't interleave. Bounded by
+ * the (small) number of distinct services.
+ */
+const writeChains = new Map<string, Promise<unknown>>()
+
+function serializeWrite<T>(key: string, op: () => Promise<T>): Promise<T> {
+  const prev = writeChains.get(key) ?? Promise.resolve()
+  const run = prev.then(op, op) // run regardless of the previous op's outcome
+  writeChains.set(
+    key,
+    run.then(
+      () => {},
+      () => {}
+    )
+  )
+  return run
+}
+
+/** Monotonic per-process counter to keep backup filenames unique within a ms. */
+let backupCounter = 0
+
+/** Filesystem-safe timestamp for backup filenames (no `:` / `.`). */
+function backupStamp(): string {
+  return new Date().toISOString().replace(/[:.]/g, '-')
+}
+
+/** mkdir a real directory, rejecting a symlinked path (returns false = blocked). */
+function ensureRealDir(dirPath: string): boolean {
+  mkdirSync(dirPath, { recursive: true, mode: 0o700 })
+  try {
+    if (lstatSync(dirPath).isSymbolicLink()) return false
+  } catch {
+    return false
+  }
+  return true
+}
+
+/** Copy `content` into `.history/<key>/<stamp>.md` (exclusive create), then prune. */
+function backupBuffer(dir: string, key: string, content: Buffer): void {
+  const hRoot = historyDir(dir)
+  if (!ensureRealDir(hRoot)) throw new Error('history dir is a symlink')
+  const hDir = join(hRoot, key)
+  if (!ensureRealDir(hDir)) throw new Error('service history dir is a symlink')
+  const name = `${backupStamp()}-${backupCounter++}.md`
+  writeFileSync(join(hDir, name), content, { flag: 'wx', mode: 0o600 })
+  pruneHistory(hDir)
+}
+
+/** Keep only the most recent MAX_HISTORY_VERSIONS backups (by mtime). */
+function pruneHistory(hDir: string): void {
+  let entries: string[]
+  try {
+    entries = readdirSync(hDir).filter((n) => n.endsWith('.md'))
+  } catch {
+    return
+  }
+  if (entries.length <= MAX_HISTORY_VERSIONS) return
+  const withTime = entries.map((name) => {
+    const p = join(hDir, name)
+    let mtimeMs = 0
+    try {
+      mtimeMs = statSync(p).mtimeMs
+    } catch {
+      /* treat as oldest */
+    }
+    return { p, mtimeMs }
+  })
+  withTime.sort((a, b) => b.mtimeMs - a.mtimeMs) // newest first
+  for (const { p } of withTime.slice(MAX_HISTORY_VERSIONS)) {
+    try {
+      rmSync(p, { force: true })
+    } catch {
+      /* best-effort */
+    }
+  }
+}
+
+/** Atomically write `content` to `filePath` via an exclusive temp file + rename. */
+function atomicWriteFile(filePath: string, content: string): void {
+  const tmp = `${filePath}.tmp-${process.pid}-${Math.random().toString(36).slice(2)}`
+  writeFileSync(tmp, content, { encoding: 'utf8', mode: 0o600, flag: 'wx' })
+  renameSync(tmp, filePath)
+}
+
+export interface WriteInput {
+  service: string
+  markdown: string
+  /** Structured source stamp. Defaults to 'copilot' (the ungated MCP write path). */
+  source?: KnowledgeSource
+}
+
+/**
+ * Write a service's runbook straight through (ungated). Stamps `service`,
+ * `updated_at`, and `source`, preserves a human's `env` when the incoming
+ * markdown doesn't set one, backs up any prior version first, and writes
+ * atomically. Serialized per service.
+ */
+export function writeServiceKnowledge(input: WriteInput, dir: string = knowledgeDir()): Promise<WriteResult> {
+  const { service, markdown, source = 'copilot' } = input
+  const v = validateServiceName(service)
+  if (!v.ok) return Promise.resolve({ status: 'invalid_service', reason: v.reason })
+  const key = v.key
+
+  const bytes = Buffer.byteLength(markdown, 'utf8')
+  if (bytes > KNOWLEDGE_MAX_BYTES) {
+    return Promise.resolve({ status: 'too_large', service: key, size: bytes })
+  }
+
+  return serializeWrite(key, async (): Promise<WriteResult> => {
+    if (!ensureRealDir(dir)) return { status: 'blocked', reason: 'Knowledge directory is a symlink.' }
+    const filePath = safeServiceFilePath(dir, key)
+    if (filePath === null) return { status: 'blocked', reason: 'Resolved path escaped the knowledge directory.' }
+
+    // Inspect any existing file: reject a symlink, capture its bytes for backup +
+    // its env for the metadata merge.
+    let existing: Buffer | null = null
+    if (existsSync(filePath)) {
+      let st: ReturnType<typeof lstatSync>
+      try {
+        st = lstatSync(filePath)
+      } catch {
+        return { status: 'blocked', reason: 'Could not stat the existing runbook.' }
+      }
+      if (st.isSymbolicLink()) return { status: 'blocked', reason: 'Refusing to overwrite a symlinked runbook.' }
+      if (!st.isFile()) return { status: 'blocked', reason: 'A non-file exists at the runbook path.' }
+      existing = readFileSync(filePath)
+    }
+
+    const existingEnv = existing !== null ? parseKnowledge(existing.toString('utf8')).frontmatter.env : null
+
+    // Recoverability: back up the prior version BEFORE overwriting. Abort on failure.
+    let backedUp = false
+    if (existing !== null) {
+      try {
+        backupBuffer(dir, key, existing)
+        backedUp = true
+      } catch (err) {
+        return { status: 'backup_failed', reason: err instanceof Error ? err.message : 'backup failed' }
+      }
+    }
+
+    // Build the stamped content. Force service/source/updated_at; preserve env
+    // unless the incoming markdown explicitly supplies one.
+    const parsedIncoming = parseKnowledge(markdown)
+    const env = parsedIncoming.frontmatter.env ?? existingEnv
+    const updatedAt = new Date().toISOString()
+    const frontmatter: KnowledgeFrontmatter = { service: key, env, updatedAt, source }
+    const content = emitKnowledge(frontmatter, parsedIncoming.body)
+
+    atomicWriteFile(filePath, content)
+    return { status: 'ok', service: key, path: filePath, backedUp, updatedAt }
+  })
+}
+
+// ── History inspection (tests / recovery) ─────────────────────────────────────
+
+/** Absolute paths of a service's backups, newest first. Empty when none. */
+export function listServiceHistory(service: string, dir: string = knowledgeDir()): string[] {
+  const v = validateServiceName(service)
+  if (!v.ok) return []
+  const hDir = join(historyDir(dir), v.key)
+  let entries: string[]
+  try {
+    entries = readdirSync(hDir).filter((n) => n.endsWith('.md'))
+  } catch {
+    return []
+  }
+  return entries
+    .map((name) => join(hDir, name))
+    .map((p) => ({ p, mtimeMs: safeMtime(p) }))
+    .sort((a, b) => b.mtimeMs - a.mtimeMs)
+    .map(({ p }) => p)
+}
+
+function safeMtime(p: string): number {
+  try {
+    return statSync(p).mtimeMs
+  } catch {
+    return 0
+  }
+}

--- a/src/main/knowledge/store.ts
+++ b/src/main/knowledge/store.ts
@@ -87,19 +87,27 @@ function safeServiceFilePath(dir: string, key: string): string | null {
 
 /**
  * Classify the knowledge directory. `ok` = a real directory we may traverse;
- * `missing` = it doesn't exist (so any runbook is simply missing); `unsafe` = a
- * symlink or a non-directory, which could make `<key>.md` resolve outside the
- * intended tree. Every path-resolving caller (read, reveal, write via
- * ensureRealDir) applies this same boundary.
+ * `missing` = it genuinely doesn't exist (ENOENT), so any runbook is simply
+ * missing; `unsafe` = a symlink, a non-directory, or a dir we can't stat
+ * (permission/IO error) — anything we can't prove is a real traversable dir.
+ * Every path-resolving caller (read, reveal, write via ensureRealDir) applies
+ * this same boundary.
  */
 function knowledgeDirState(dir: string): 'ok' | 'missing' | 'unsafe' {
   let st: ReturnType<typeof lstatSync>
   try {
     st = lstatSync(dir)
-  } catch {
-    return 'missing'
+  } catch (err) {
+    // Only a genuinely absent dir is "missing"; a permission/IO error is unsafe
+    // (we can't prove the dir is a real, traversable directory).
+    return isEnoent(err) ? 'missing' : 'unsafe'
   }
   return st.isSymbolicLink() || !st.isDirectory() ? 'unsafe' : 'ok'
+}
+
+/** True when a thrown filesystem error is a "no such file/dir" (ENOENT). */
+function isEnoent(err: unknown): boolean {
+  return typeof err === 'object' && err !== null && (err as { code?: unknown }).code === 'ENOENT'
 }
 
 /**
@@ -150,7 +158,7 @@ export function readServiceKnowledge(service: string, dir: string = knowledgeDir
   const dirState = knowledgeDirState(dir)
   if (dirState === 'missing') return { status: 'missing', service: key, path: filePath }
   if (dirState === 'unsafe') {
-    return { status: 'blocked', reason: 'Knowledge directory is a symlink or not a directory.' }
+    return { status: 'blocked', reason: 'Knowledge directory is a symlink, not a directory, or is unreadable.' }
   }
 
   let st: ReturnType<typeof lstatSync>

--- a/src/main/knowledge/store.ts
+++ b/src/main/knowledge/store.ts
@@ -163,18 +163,28 @@ const writeChains = new Map<string, Promise<unknown>>()
 function serializeWrite<T>(key: string, op: () => Promise<T>): Promise<T> {
   const prev = writeChains.get(key) ?? Promise.resolve()
   const run = prev.then(op, op) // run regardless of the previous op's outcome
-  writeChains.set(
-    key,
-    run.then(
-      () => {},
-      () => {}
-    )
+  const tail = run.then(
+    () => {},
+    () => {}
   )
+  writeChains.set(key, tail)
+  // Drop the entry once this tail settles, UNLESS a newer write already chained
+  // onto it (in which case that newer tail is now stored and owns cleanup). This
+  // keeps the map bounded even if many distinct services are written over time,
+  // while preserving strict per-service serialization.
+  void tail.finally(() => {
+    if (writeChains.get(key) === tail) writeChains.delete(key)
+  })
   return run
 }
 
 /** Monotonic per-process counter to keep backup filenames unique within a ms. */
 let backupCounter = 0
+
+/** Test/inspection helper: number of services with a live (pending) write chain. */
+export function pendingWriteChainCount(): number {
+  return writeChains.size
+}
 
 /** Filesystem-safe timestamp for backup filenames (no `:` / `.`). */
 function backupStamp(): string {

--- a/src/main/knowledge/store.ts
+++ b/src/main/knowledge/store.ts
@@ -111,6 +111,22 @@ function isEnoent(err: unknown): boolean {
 }
 
 /**
+ * A path-free reason string for a thrown error, safe to return in MCP tool
+ * output. Node filesystem errors embed absolute paths in `message`, so prefer the
+ * errno `code` (e.g. "EACCES", "ENOSPC"); fall back to `message` only for our own
+ * thrown errors (which carry no `code` and no path).
+ */
+function safeErrorReason(err: unknown): string {
+  if (typeof err === 'object' && err !== null) {
+    const code = (err as { code?: unknown }).code
+    if (typeof code === 'string' && code.length > 0) return code
+    const message = (err as { message?: unknown }).message
+    if (typeof message === 'string' && message.length > 0) return message
+  }
+  return 'unknown error'
+}
+
+/**
  * Public helper for callers that just need the on-disk path for a service (e.g.
  * reveal-in-Finder). Returns null for an invalid/unsafe service name.
  */
@@ -362,7 +378,7 @@ export function writeServiceKnowledge(input: WriteInput, dir: string = knowledge
         backupBuffer(dir, key, existing)
         backedUp = true
       } catch (err) {
-        return { status: 'backup_failed', reason: err instanceof Error ? err.message : 'backup failed' }
+        return { status: 'backup_failed', reason: safeErrorReason(err) }
       }
     }
 

--- a/src/main/knowledge/store.ts
+++ b/src/main/knowledge/store.ts
@@ -31,7 +31,7 @@ import {
   statSync,
   writeFileSync,
 } from 'node:fs'
-import { join, resolve, sep } from 'node:path'
+import { join, resolve } from 'node:path'
 import { validateServiceName } from '../../shared/service-name'
 import type { KnowledgeFrontmatter } from './frontmatter'
 import { emitKnowledge, parseKnowledge } from './frontmatter'
@@ -80,9 +80,12 @@ export type WriteResult =
  */
 function safeServiceFilePath(dir: string, key: string): string | null {
   const base = resolve(dir)
+  // Compare the resolved path against a `join`-built expected path. `join` avoids
+  // double-separator edge cases (e.g. base === '/', where string concat would
+  // produce `//key.md`) while still rejecting any resolution that lands elsewhere.
+  const expected = join(base, `${key}.md`)
   const full = resolve(base, `${key}.md`)
-  if (full !== `${base}${sep}${key}.md`) return null
-  return full
+  return full === expected ? full : null
 }
 
 /**

--- a/src/main/knowledge/store.ts
+++ b/src/main/knowledge/store.ts
@@ -285,6 +285,18 @@ export function writeServiceKnowledge(input: WriteInput, dir: string = knowledge
 
     const existingEnv = existing !== null ? parseKnowledge(existing.toString('utf8')).frontmatter.env : null
 
+    // Build the stamped content first: force service/source/updated_at; preserve
+    // env unless the incoming markdown explicitly supplies one. Re-check the FINAL
+    // size (stamped frontmatter adds bytes) so we never write a file the read path
+    // would then reject as too_large — and reject BEFORE taking a backup.
+    const parsedIncoming = parseKnowledge(markdown)
+    const env = parsedIncoming.frontmatter.env ?? existingEnv
+    const updatedAt = new Date().toISOString()
+    const frontmatter: KnowledgeFrontmatter = { service: key, env, updatedAt, source }
+    const content = emitKnowledge(frontmatter, parsedIncoming.body)
+    const finalBytes = Buffer.byteLength(content, 'utf8')
+    if (finalBytes > KNOWLEDGE_MAX_BYTES) return { status: 'too_large', service: key, size: finalBytes }
+
     // Recoverability: back up the prior version BEFORE overwriting. Abort on failure.
     let backedUp = false
     if (existing !== null) {
@@ -295,14 +307,6 @@ export function writeServiceKnowledge(input: WriteInput, dir: string = knowledge
         return { status: 'backup_failed', reason: err instanceof Error ? err.message : 'backup failed' }
       }
     }
-
-    // Build the stamped content. Force service/source/updated_at; preserve env
-    // unless the incoming markdown explicitly supplies one.
-    const parsedIncoming = parseKnowledge(markdown)
-    const env = parsedIncoming.frontmatter.env ?? existingEnv
-    const updatedAt = new Date().toISOString()
-    const frontmatter: KnowledgeFrontmatter = { service: key, env, updatedAt, source }
-    const content = emitKnowledge(frontmatter, parsedIncoming.body)
 
     atomicWriteFile(filePath, content)
     return { status: 'ok', service: key, path: filePath, backedUp, updatedAt }

--- a/src/main/knowledge/store.ts
+++ b/src/main/knowledge/store.ts
@@ -354,6 +354,14 @@ export function writeServiceKnowledge(input: WriteInput, dir: string = knowledge
       }
       if (st.isSymbolicLink()) return { status: 'blocked', reason: 'Refusing to overwrite a symlinked runbook.' }
       if (!st.isFile()) return { status: 'blocked', reason: 'A non-file exists at the runbook path.' }
+      // Guard against loading a hand-edited oversized (or binary) file into memory
+      // just to back it up / parse env. Refuse the overwrite instead.
+      if (st.size > KNOWLEDGE_MAX_BYTES) {
+        return {
+          status: 'blocked',
+          reason: `The existing runbook is too large (${st.size} bytes) to overwrite safely; reduce it on disk first.`,
+        }
+      }
       existing = readFileSync(filePath)
     }
 

--- a/src/main/knowledge/store.ts
+++ b/src/main/knowledge/store.ts
@@ -183,8 +183,11 @@ export function readServiceKnowledge(service: string, dir: string = knowledgeDir
   let st: ReturnType<typeof lstatSync>
   try {
     st = lstatSync(filePath) // lstat: does NOT follow a symlink
-  } catch {
-    return { status: 'missing', service: key, path: filePath }
+  } catch (err) {
+    // Only a genuinely absent file is "missing"; a permission/IO error is a
+    // blocked/unavailable state, not a missing runbook.
+    if (isEnoent(err)) return { status: 'missing', service: key, path: filePath }
+    return { status: 'blocked', reason: 'The runbook file could not be read (permission or I/O error).' }
   }
   if (st.isSymbolicLink()) return { status: 'blocked', reason: 'Refusing to follow a symlinked runbook.' }
   if (!st.isFile()) return { status: 'missing', service: key, path: filePath }

--- a/src/main/mcp-server/knowledge.integration.test.ts
+++ b/src/main/mcp-server/knowledge.integration.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest'
+import { mkdtempSync, rmSync, readFileSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { Database as BunDb } from 'bun:sqlite'
+import type BetterSQLite3 from 'better-sqlite3'
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
+import { startMcpServer, type McpServerHandle } from './server'
+import { readRunFiles } from './runfiles'
+import { READ_SERVICE_KNOWLEDGE_TOOL_NAME, WRITE_SERVICE_KNOWLEDGE_TOOL_NAME } from './tool-manifest'
+
+// The knowledge read tool reaches the DB layer (for linked resources), so mock
+// electron + the DB singleton exactly like the add_todo integration test does.
+vi.mock('electron', () => ({
+  app: { isPackaged: false, getAppPath: () => process.cwd() },
+}))
+vi.mock('../db/index', () => ({ getDb: vi.fn() }))
+
+import { getDb } from '../db/index'
+import { runMigrations } from '../db/migrate'
+import { createProject } from '../db/projects'
+import { createResource } from '../context/registry'
+
+/**
+ * Stand up the REAL loopback MCP server + a REAL SDK client and drive the
+ * service-knowledge tools end to end. Uses an isolated temp knowledge dir (via
+ * GH_PROJECTS_KNOWLEDGE_DIR) so the developer's real ~/.gh-projects is untouched.
+ */
+
+const cleanups: Array<() => Promise<void> | void> = []
+let knowledgeDir = ''
+let prevKnowledgeEnv: string | undefined
+
+afterEach(async () => {
+  for (const fn of cleanups.splice(0)) await fn()
+  if (prevKnowledgeEnv === undefined) delete process.env.GH_PROJECTS_KNOWLEDGE_DIR
+  else process.env.GH_PROJECTS_KNOWLEDGE_DIR = prevKnowledgeEnv
+})
+
+beforeEach(() => {
+  const db = new BunDb(':memory:')
+  db.exec('PRAGMA foreign_keys = ON')
+  const betterDb = db as unknown as BetterSQLite3.Database
+  runMigrations(betterDb)
+  vi.mocked(getDb).mockReturnValue(betterDb)
+
+  prevKnowledgeEnv = process.env.GH_PROJECTS_KNOWLEDGE_DIR
+  knowledgeDir = mkdtempSync(join(tmpdir(), 'gh-knowledge-int-'))
+  process.env.GH_PROJECTS_KNOWLEDGE_DIR = knowledgeDir
+  cleanups.push(() => rmSync(knowledgeDir, { recursive: true, force: true }))
+})
+
+async function startServer(): Promise<{ handle: McpServerHandle; token: string }> {
+  const dir = mkdtempSync(join(tmpdir(), 'gh-mcp-srv-'))
+  const handle = await startMcpServer({ runDir: dir })
+  cleanups.push(async () => {
+    await handle.close()
+    rmSync(dir, { recursive: true, force: true })
+  })
+  const endpoint = readRunFiles(dir)
+  if (endpoint === null) throw new Error('run files were not published')
+  return { handle, token: endpoint.token }
+}
+
+function connectClient(port: number, token: string): Promise<Client> {
+  const transport = new StreamableHTTPClientTransport(new URL(`http://127.0.0.1:${port}/mcp`), {
+    requestInit: { headers: { Authorization: `Bearer ${token}` } },
+  })
+  const client = new Client({ name: 'knowledge-int-test', version: '1.0.0' }, { capabilities: {} })
+  cleanups.push(async () => {
+    await client.close()
+  })
+  return client.connect(transport).then(() => client)
+}
+
+function textOf(result: CallToolResult): string {
+  return result.content.map((c) => (c.type === 'text' ? c.text : '')).join('\n')
+}
+
+function callRead(client: Client, args: Record<string, unknown>): Promise<CallToolResult> {
+  return client.callTool({ name: READ_SERVICE_KNOWLEDGE_TOOL_NAME, arguments: args }) as Promise<CallToolResult>
+}
+function callWrite(client: Client, args: Record<string, unknown>): Promise<CallToolResult> {
+  return client.callTool({ name: WRITE_SERVICE_KNOWLEDGE_TOOL_NAME, arguments: args }) as Promise<CallToolResult>
+}
+
+describe('service-knowledge tools over the real loopback server', () => {
+  it('advertises both knowledge tools in tools/list', async () => {
+    const { handle, token } = await startServer()
+    const client = await connectClient(handle.port, token)
+    const { tools } = await client.listTools()
+    const names = tools.map((t) => t.name)
+    expect(names).toContain(READ_SERVICE_KNOWLEDGE_TOOL_NAME)
+    expect(names).toContain(WRITE_SERVICE_KNOWLEDGE_TOOL_NAME)
+  })
+
+  it('writes a runbook and reads it back (stamped source: copilot)', async () => {
+    const { handle, token } = await startServer()
+    const client = await connectClient(handle.port, token)
+
+    const write = await callWrite(client, { service: 'web', markdown: '# Health\n\nHit /health and check 200.' })
+    expect(write.isError).toBeFalsy()
+    expect(textOf(write)).toMatch(/Wrote the runbook for service "web"/)
+
+    const read = await callRead(client, { service: 'web' })
+    expect(read.isError).toBeFalsy()
+    const body = textOf(read)
+    expect(body).toContain('Hit /health and check 200.')
+    expect(body).toContain('source: copilot')
+  })
+
+  it('sees a human edit made directly on disk (the core acceptance test)', async () => {
+    const { handle, token } = await startServer()
+    const client = await connectClient(handle.port, token)
+
+    await callWrite(client, { service: 'payments', markdown: 'original runbook' })
+
+    // Simulate the human opening the file and editing it by hand.
+    const filePath = join(knowledgeDir, 'payments.md')
+    const current = readFileSync(filePath, 'utf8')
+    writeFileSync(filePath, `${current}\n\n## Oncall\nPage the on-call engineer.\n`)
+
+    const read = await callRead(client, { service: 'payments' })
+    expect(textOf(read)).toContain('Page the on-call engineer.')
+  })
+
+  it('returns a friendly note (not an error) when no runbook exists yet', async () => {
+    const { handle, token } = await startServer()
+    const client = await connectClient(handle.port, token)
+    const read = await callRead(client, { service: 'ghost' })
+    expect(read.isError).toBeFalsy()
+    expect(textOf(read)).toMatch(/No runbook yet/)
+  })
+
+  it('rejects a path-traversal service name on write and read (SECURITY)', async () => {
+    const { handle, token } = await startServer()
+    const client = await connectClient(handle.port, token)
+
+    const write = await callWrite(client, { service: '../escape', markdown: 'pwned' })
+    expect(write.isError).toBe(true)
+    expect(textOf(write)).toMatch(/Invalid service name/)
+
+    const read = await callRead(client, { service: '../../etc/passwd' })
+    expect(read.isError).toBe(true)
+  })
+
+  it('optionally lists linked resources with their project (no cross-project conflation)', async () => {
+    const { handle, token } = await startServer()
+    const client = await connectClient(handle.port, token)
+
+    const project = createProject('Storefront')
+    createResource(project.id, {
+      title: 'Prod latency dashboard',
+      kind: 'dashboard',
+      source: 'datadog',
+      service: 'web',
+      url: 'https://app.datadoghq.com/dashboard/web-latency',
+      aliases: ['prod latency dashboard'],
+    })
+    await callWrite(client, { service: 'web', markdown: 'See [prod latency dashboard].' })
+
+    const read = await callRead(client, { service: 'web', includeResources: true })
+    const body = textOf(read)
+    expect(body).toContain('Prod latency dashboard')
+    expect(body).toContain('Storefront') // project context is shown
+    expect(body).toContain('https://app.datadoghq.com/dashboard/web-latency')
+  })
+})

--- a/src/main/mcp-server/knowledge.integration.test.ts
+++ b/src/main/mcp-server/knowledge.integration.test.ts
@@ -20,7 +20,7 @@ vi.mock('../db/index', () => ({ getDb: vi.fn() }))
 
 import { getDb } from '../db/index'
 import { runMigrations } from '../db/migrate'
-import { createProject } from '../db/projects'
+import { createProject, deleteProject } from '../db/projects'
 import { createResource } from '../context/registry'
 
 /**
@@ -166,5 +166,34 @@ describe('service-knowledge tools over the real loopback server', () => {
     expect(body).toContain('Prod latency dashboard')
     expect(body).toContain('Storefront') // project context is shown
     expect(body).toContain('https://app.datadoghq.com/dashboard/web-latency')
+  })
+
+  it('does not surface resources from a soft-deleted project', async () => {
+    const { handle, token } = await startServer()
+    const client = await connectClient(handle.port, token)
+
+    const project = createProject('Doomed')
+    createResource(project.id, { title: 'Old dashboard', service: 'web', url: 'https://example.com/old' })
+    await callWrite(client, { service: 'web', markdown: 'runbook' })
+    deleteProject(project.id)
+
+    const read = await callRead(client, { service: 'web', includeResources: true })
+    const body = textOf(read)
+    expect(body).not.toContain('Old dashboard')
+    expect(body).toMatch(/No saved resources match this service\./)
+  })
+
+  it('does not broaden to all projects when an explicit project is unknown', async () => {
+    const { handle, token } = await startServer()
+    const client = await connectClient(handle.port, token)
+
+    const project = createProject('Real')
+    createResource(project.id, { title: 'Real dashboard', service: 'web', url: 'https://example.com/real' })
+    await callWrite(client, { service: 'web', markdown: 'runbook' })
+
+    const read = await callRead(client, { service: 'web', includeResources: true, project: 'Nonexistent' })
+    const body = textOf(read)
+    expect(body).not.toContain('Real dashboard') // must not leak the other project's resource
+    expect(body).toMatch(/No active project named "Nonexistent"/)
   })
 })

--- a/src/main/mcp-server/lifecycle.ts
+++ b/src/main/mcp-server/lifecycle.ts
@@ -86,11 +86,26 @@ function broadcastTodoChanged(): void {
   }
 }
 
+/**
+ * Push a `knowledge:updated` event to every renderer when the `write_service_knowledge` tool
+ * writes a runbook, so open project runbook surfaces reload live. Kept here (not in the tool)
+ * so the tool stays free of Electron/UI concerns.
+ */
+function broadcastKnowledgeChanged(): void {
+  for (const win of BrowserWindow.getAllWindows()) {
+    win.webContents.send('knowledge:updated')
+  }
+}
+
 /** Start the loopback server (if not already running) and register the shim. */
 export function enableMcpServer(): Promise<void> {
   return serialize(async () => {
     if (handle === null) {
-      handle = await startMcpServer({ extraSecrets, onTodoChanged: broadcastTodoChanged })
+      handle = await startMcpServer({
+        extraSecrets,
+        onTodoChanged: broadcastTodoChanged,
+        onKnowledgeChanged: broadcastKnowledgeChanged,
+      })
     }
     // Only register in ~/.mcp.json when the shim bundle actually exists, so we
     // never point Copilot at a missing command (e.g. in dev before build:shim).

--- a/src/main/mcp-server/read-service-knowledge.ts
+++ b/src/main/mcp-server/read-service-knowledge.ts
@@ -73,18 +73,18 @@ export function runReadServiceKnowledge(args: Record<string, unknown>): CallTool
       const blocks: string[] = [res.knowledge.markdown]
       if (args.includeResources === true) {
         const project = optionalString(args.project)
-        let projectId: number | undefined
-        let note = ''
         if (project !== null) {
           const id = resolveProjectIdByName(project)
           if (id === null) {
-            note = `\n\n_(No active project named "${project}"; listing resources across all projects.)_`
+            // An explicit-but-unknown project must NOT broaden to every project
+            // (that would leak unrelated resources); report it and list nothing.
+            blocks.push(`_(No active project named "${project}"; no linked resources shown.)_`)
           } else {
-            projectId = id
+            blocks.push(formatResources(listResourcesByService(res.knowledge.service, id), true))
           }
+        } else {
+          blocks.push(formatResources(listResourcesByService(res.knowledge.service), false))
         }
-        const resources = listResourcesByService(res.knowledge.service, projectId)
-        blocks.push(`${formatResources(resources, projectId !== undefined)}${note}`)
       }
       return { content: blocks.map((text) => ({ type: 'text', text })) }
     }

--- a/src/main/mcp-server/read-service-knowledge.ts
+++ b/src/main/mcp-server/read-service-knowledge.ts
@@ -1,0 +1,92 @@
+/**
+ * The `read_service_knowledge` MCP tool handler (#100). Returns a service's
+ * human-editable markdown runbook, read fresh from disk each call so out-of-band
+ * hand edits are always seen. Optionally appends a listing of registry resources
+ * whose service matches, so prose that references a dashboard/query by name can
+ * resolve to the real link.
+ *
+ * Read-only: never writes. Path safety + symlink refusal + size bounds live in
+ * the store; this handler only maps store results to MCP text.
+ */
+
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
+import { knowledgeFilePathForService, readServiceKnowledge } from '../knowledge/store'
+import { listResourcesByService, type ServiceResource } from '../context/registry'
+import { resolveProjectIdByName } from '../db/routing-rules'
+
+function textResult(text: string): CallToolResult {
+  return { content: [{ type: 'text', text }] }
+}
+
+function errorResult(text: string): CallToolResult {
+  return { content: [{ type: 'text', text }], isError: true }
+}
+
+/** Coerce an optional arg to a trimmed non-empty string, or null. */
+function optionalString(value: unknown): string | null {
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+/** Render matching resources as a compact markdown list the model can resolve aliases against. */
+function formatResources(resources: readonly ServiceResource[], scoped: boolean): string {
+  if (resources.length === 0) {
+    return scoped
+      ? 'No saved resources match this service in that project.'
+      : 'No saved resources match this service.'
+  }
+  const lines = resources.map((r) => {
+    const parts = [`- **${r.title}** _(project: ${r.projectName})_`]
+    if (r.url !== null && r.url.length > 0) parts.push(`— ${r.url}`)
+    if (r.aliases.length > 0) parts.push(`— aliases: ${r.aliases.join(', ')}`)
+    return parts.join(' ')
+  })
+  return `## Linked resources\n${lines.join('\n')}`
+}
+
+/** Run the `read_service_knowledge` tool. Read-only. */
+export function runReadServiceKnowledge(args: Record<string, unknown>): CallToolResult {
+  const service = optionalString(args.service)
+  if (service === null) {
+    return errorResult('`service` is required and must be a non-empty string (a slug like "payments-api").')
+  }
+
+  const res = readServiceKnowledge(service)
+  switch (res.status) {
+    case 'invalid_service':
+      return errorResult(`Invalid service name: ${res.reason}`)
+    case 'blocked':
+      return errorResult(res.reason)
+    case 'too_large': {
+      const path = knowledgeFilePathForService(res.service)
+      const where = path === null ? 'on disk' : `on disk at ${path}`
+      return textResult(
+        `The runbook for "${res.service}" is ${res.size} bytes, which is too large to return via this tool. Edit it ${where}.`
+      )
+    }
+    case 'missing':
+      return textResult(
+        `No runbook yet for service "${res.service}". Use write_service_knowledge to create one.`
+      )
+    case 'ok': {
+      const blocks: string[] = [res.knowledge.markdown]
+      if (args.includeResources === true) {
+        const project = optionalString(args.project)
+        let projectId: number | undefined
+        let note = ''
+        if (project !== null) {
+          const id = resolveProjectIdByName(project)
+          if (id === null) {
+            note = `\n\n_(No active project named "${project}"; listing resources across all projects.)_`
+          } else {
+            projectId = id
+          }
+        }
+        const resources = listResourcesByService(res.knowledge.service, projectId)
+        blocks.push(`${formatResources(resources, projectId !== undefined)}${note}`)
+      }
+      return { content: blocks.map((text) => ({ type: 'text', text })) }
+    }
+  }
+}

--- a/src/main/mcp-server/read-service-knowledge.ts
+++ b/src/main/mcp-server/read-service-knowledge.ts
@@ -83,7 +83,7 @@ export function runReadServiceKnowledge(args: Record<string, unknown>): CallTool
           blocks.push(formatResources(listResourcesByService(res.knowledge.service), false))
         }
       }
-      return { content: blocks.map((text) => ({ type: 'text', text })) }
+      return { content: [{ type: 'text', text: blocks.join('\n\n') }] }
     }
   }
 }

--- a/src/main/mcp-server/read-service-knowledge.ts
+++ b/src/main/mcp-server/read-service-knowledge.ts
@@ -10,7 +10,7 @@
  */
 
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
-import { knowledgeFilePathForService, readServiceKnowledge } from '../knowledge/store'
+import { readServiceKnowledge } from '../knowledge/store'
 import { listResourcesByService, type ServiceResource } from '../context/registry'
 import { resolveProjectIdByName } from '../db/routing-rules'
 
@@ -58,13 +58,10 @@ export function runReadServiceKnowledge(args: Record<string, unknown>): CallTool
       return errorResult(`Invalid service name: ${res.reason}`)
     case 'blocked':
       return errorResult(res.reason)
-    case 'too_large': {
-      const path = knowledgeFilePathForService(res.service)
-      const where = path === null ? 'on disk' : `on disk at ${path}`
+    case 'too_large':
       return textResult(
-        `The runbook for "${res.service}" is ${res.size} bytes, which is too large to return via this tool. Edit it ${where}.`
+        `The runbook for "${res.service}" is ${res.size} bytes, which is too large to return via this tool. Edit "${res.service}.md" on disk in the knowledge directory.`
       )
-    }
     case 'missing':
       return textResult(
         `No runbook yet for service "${res.service}". Use write_service_knowledge to create one.`

--- a/src/main/mcp-server/sanitize.test.ts
+++ b/src/main/mcp-server/sanitize.test.ts
@@ -27,6 +27,17 @@ describe('sanitizeMcpText', () => {
   it('leaves clean text untouched', () => {
     expect(sanitizeMcpText('nothing to hide', [TOKEN])).toBe('nothing to hide')
   })
+
+  it('honors a larger maxLen for legitimately large output', () => {
+    const big = 'x'.repeat(5000)
+    // Default cap truncates; an explicit larger cap does not.
+    expect(sanitizeMcpText(big, []).length).toBeLessThanOrEqual(2000)
+    expect(sanitizeMcpText(big, [], 10000)).toBe(big)
+  })
+
+  it('still redacts secrets before applying a larger cap', () => {
+    expect(sanitizeMcpText(`x ${TOKEN} y`, [TOKEN], 10000)).toBe('x [redacted] y')
+  })
 })
 
 describe('sanitizeMcpJson', () => {

--- a/src/main/mcp-server/sanitize.ts
+++ b/src/main/mcp-server/sanitize.ts
@@ -15,7 +15,7 @@
 const MIN_SECRET_LEN = 4
 
 /** Cap on any single sanitized string. */
-const MAX_TEXT_LEN = 2000
+export const MAX_TEXT_LEN = 2000
 
 /** Max recursion depth for `sanitizeMcpJson` (guards pathological structures). */
 const MAX_DEPTH = 24
@@ -23,32 +23,40 @@ const MAX_DEPTH = 24
 /**
  * Redact every known secret value from `message` and cap its length. `secrets`
  * is the list of raw secret strings to scrub (token, PAT, …); empty/short
- * entries are ignored.
+ * entries are ignored. `maxLen` defaults to `MAX_TEXT_LEN` (2000); tools whose
+ * output is legitimately large (e.g. reading a runbook) pass a larger cap.
+ * Secret redaction always runs BEFORE truncation.
  */
-export function sanitizeMcpText(message: string, secrets: readonly string[]): string {
+export function sanitizeMcpText(
+  message: string,
+  secrets: readonly string[],
+  maxLen: number = MAX_TEXT_LEN
+): string {
   let out = message
   for (const secret of secrets) {
     if (secret.length >= MIN_SECRET_LEN) out = out.split(secret).join('[redacted]')
   }
-  return out.length > MAX_TEXT_LEN ? `${out.slice(0, MAX_TEXT_LEN - 1)}…` : out
+  return out.length > maxLen ? `${out.slice(0, maxLen - 1)}…` : out
 }
 
 /**
  * Recursively scrub known secret values from every string leaf AND object KEY of
  * a JSON value. Depth-capped so a deeply nested structure can't blow the stack.
+ * `maxLen` bounds each scrubbed string leaf (default `MAX_TEXT_LEN`).
  */
 export function sanitizeMcpJson(
   value: unknown,
   secrets: readonly string[],
+  maxLen: number = MAX_TEXT_LEN,
   depth = 0
 ): unknown {
   if (depth > MAX_DEPTH) return undefined
-  if (typeof value === 'string') return sanitizeMcpText(value, secrets)
-  if (Array.isArray(value)) return value.map((v) => sanitizeMcpJson(v, secrets, depth + 1))
+  if (typeof value === 'string') return sanitizeMcpText(value, secrets, maxLen)
+  if (Array.isArray(value)) return value.map((v) => sanitizeMcpJson(v, secrets, maxLen, depth + 1))
   if (value !== null && typeof value === 'object') {
     const out: Record<string, unknown> = {}
     for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
-      out[sanitizeMcpText(k, secrets)] = sanitizeMcpJson(v, secrets, depth + 1)
+      out[sanitizeMcpText(k, secrets, maxLen)] = sanitizeMcpJson(v, secrets, maxLen, depth + 1)
     }
     return out
   }

--- a/src/main/mcp-server/server.ts
+++ b/src/main/mcp-server/server.ts
@@ -41,6 +41,8 @@ export interface StartMcpServerOptions {
   generateTokenFn?: () => string
   /** Called after a tool successfully mutates todo state, so the app can push `todos:updated`. */
   onTodoChanged?: () => void
+  /** Called after a tool successfully writes service knowledge, so the app can push `knowledge:updated`. */
+  onKnowledgeChanged?: () => void
 }
 
 export interface McpServerHandle {
@@ -137,6 +139,7 @@ export function startMcpServer(options: StartMcpServerOptions = {}): Promise<Mcp
   const toolDeps: ToolDeps = {
     getSecrets: () => [token, ...(options.extraSecrets?.() ?? [])],
     onTodoChanged: options.onTodoChanged,
+    onKnowledgeChanged: options.onKnowledgeChanged,
   }
 
   const httpServer: HttpServer = createServer((req, res) => {

--- a/src/main/mcp-server/tool-manifest.ts
+++ b/src/main/mcp-server/tool-manifest.ts
@@ -27,6 +27,12 @@ export interface ManifestTool {
   title?: string
   description: string
   inputSchema: JsonSchemaObject
+  /**
+   * Optional per-tool cap (chars) for scrubbed output leaves. Omitted = the
+   * default sanitize cap. Only tools whose output is legitimately large (reading
+   * a runbook) opt into a larger value; every other tool keeps the small default.
+   */
+  maxOutputLen?: number
 }
 
 /** The `ping` tool: no input, exercises the surface end-to-end. */
@@ -57,6 +63,19 @@ const PROJECT_REF_SCHEMA = {
   description:
     'Project reference: an exact project name (string) or a project id (integer) from list_projects.',
 }
+
+/** The `read_service_knowledge` tool: read a service's markdown runbook. */
+export const READ_SERVICE_KNOWLEDGE_TOOL_NAME = 'read_service_knowledge'
+
+/** The `write_service_knowledge` tool: write a service's markdown runbook (ungated). */
+export const WRITE_SERVICE_KNOWLEDGE_TOOL_NAME = 'write_service_knowledge'
+
+/**
+ * Output cap for `read_service_knowledge` (512 KiB). A runbook is bounded to
+ * 256 KiB on disk, so this comfortably fits the markdown plus any linked-resource
+ * listing while still bounding pathological output.
+ */
+export const READ_SERVICE_KNOWLEDGE_MAX_OUTPUT_LEN = 512 * 1024
 
 /** The full inbound tool surface. Order is the advertised order. */
 export const TOOL_MANIFEST: readonly ManifestTool[] = [
@@ -177,6 +196,65 @@ export const TOOL_MANIFEST: readonly ManifestTool[] = [
     inputSchema: {
       type: 'object',
       properties: { project: PROJECT_REF_SCHEMA },
+      additionalProperties: false,
+    },
+  },
+  {
+    name: READ_SERVICE_KNOWLEDGE_TOOL_NAME,
+    title: 'Read service knowledge',
+    description:
+      'Read the human-editable markdown runbook for a service (how to check health, monitor ' +
+      'links, oncall notes). Reads fresh from disk, so any hand edits are always reflected. ' +
+      'The `service` is a slug like "payments-api" (lowercase letters/digits with "-", "_", "."). ' +
+      'Set `includeResources: true` to also list saved registry resources whose service matches, ' +
+      'so prose that references a dashboard/query by name resolves to its real link; optionally ' +
+      'scope those to one project with `project`. Returns a friendly note (not an error) when no ' +
+      'runbook exists yet.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        service: {
+          type: 'string',
+          description: 'Service slug to read (e.g. "payments-api"). Required.',
+        },
+        includeResources: {
+          type: 'boolean',
+          description: 'When true, also list saved registry resources whose service matches (with their project + link).',
+        },
+        project: {
+          type: 'string',
+          description: 'Optional exact project name to scope the linked-resource listing to.',
+        },
+      },
+      required: ['service'],
+      additionalProperties: false,
+    },
+    maxOutputLen: READ_SERVICE_KNOWLEDGE_MAX_OUTPUT_LEN,
+  },
+  {
+    name: WRITE_SERVICE_KNOWLEDGE_TOOL_NAME,
+    title: 'Write service knowledge',
+    description:
+      'Create or overwrite the markdown runbook for a service. This writes STRAIGHT THROUGH ' +
+      '(ungated) — no approval step — but is recoverable: the prior version is backed up before ' +
+      'each overwrite. The tool stamps `service`, `updated_at`, and `source: copilot` into the ' +
+      'frontmatter and preserves a human-set `env`, so send `markdown` as the runbook body (with ' +
+      'or without frontmatter). The `service` is a slug like "payments-api". Prefer referencing ' +
+      'dashboards/queries by their saved resource name/alias in prose rather than pasting URLs ' +
+      'that rot. Reads are the way to see the current content before rewriting.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        service: {
+          type: 'string',
+          description: 'Service slug to write (e.g. "payments-api"). Required.',
+        },
+        markdown: {
+          type: 'string',
+          description: 'The runbook markdown (body, optionally with frontmatter). Required. Frontmatter is re-stamped by the app.',
+        },
+      },
+      required: ['service', 'markdown'],
       additionalProperties: false,
     },
   },

--- a/src/main/mcp-server/tools.ts
+++ b/src/main/mcp-server/tools.ts
@@ -18,11 +18,16 @@ import {
   GET_REENTRY_DIGEST_TOOL_NAME,
   LIST_PROJECTS_TOOL_NAME,
   PING_TOOL_NAME,
+  READ_SERVICE_KNOWLEDGE_TOOL_NAME,
+  WRITE_SERVICE_KNOWLEDGE_TOOL_NAME,
   TOOL_MANIFEST,
+  findManifestTool,
 } from './tool-manifest'
-import { sanitizeMcpJson } from './sanitize'
+import { MAX_TEXT_LEN, sanitizeMcpJson } from './sanitize'
 import { runAddTodo } from './add-todo'
 import { runGetProjectContext, runGetReentryDigest, runListProjects } from './read-context'
+import { runReadServiceKnowledge } from './read-service-knowledge'
+import { runWriteServiceKnowledge } from './write-service-knowledge'
 
 /** Dependencies a tool handler may need. */
 export interface ToolDeps {
@@ -37,6 +42,12 @@ export interface ToolDeps {
    * and the shim can omit it.
    */
   onTodoChanged?: () => void
+  /**
+   * Fired after a tool successfully writes service knowledge (`write_service_knowledge`). The
+   * app uses this to push a `knowledge:updated` event so open project runbook surfaces reload
+   * live. Optional so tests and the shim can omit it.
+   */
+  onKnowledgeChanged?: () => void
 }
 
 /** A tool handler: validated args in, an MCP `CallToolResult` out. */
@@ -58,6 +69,12 @@ export function buildToolHandlers(deps: ToolDeps): Map<string, ToolHandler> {
   handlers.set(LIST_PROJECTS_TOOL_NAME, () => runListProjects())
   handlers.set(GET_PROJECT_CONTEXT_TOOL_NAME, (args) => runGetProjectContext(args))
   handlers.set(GET_REENTRY_DIGEST_TOOL_NAME, (args) => runGetReentryDigest(args))
+  handlers.set(READ_SERVICE_KNOWLEDGE_TOOL_NAME, (args) => runReadServiceKnowledge(args))
+  handlers.set(WRITE_SERVICE_KNOWLEDGE_TOOL_NAME, async (args) => {
+    const result = await runWriteServiceKnowledge(args)
+    if (result.isError !== true) deps.onKnowledgeChanged?.()
+    return result
+  })
   return handlers
 }
 
@@ -87,12 +104,15 @@ export function registerTools(server: Server, deps: ToolDeps): void {
     } catch (err) {
       // A tool handler that throws (e.g. a DB error) must surface as a clean isError result,
       // not a transport-level failure. Never echo the error detail — it could carry a secret
-      // or an internal path. (onTodoChanged lives inside the handler and only fires on a
-      // successful result, so a throw here never triggers it.)
+      // or an internal path. (onTodoChanged/onKnowledgeChanged live inside the handler and only
+      // fire on a successful result, so a throw here never triggers them.)
       console.error(`[mcp-server] tool "${name}" threw:`, err instanceof Error ? err.name : 'error')
       result = { content: [{ type: 'text', text: `Tool "${name}" failed.` }], isError: true }
     }
-    // Defense-in-depth: scrub any known secret that slipped into the output.
-    return sanitizeMcpJson(result, deps.getSecrets()) as CallToolResult
+    // Defense-in-depth: scrub any known secret that slipped into the output. Most
+    // tools keep the small default cap; a tool with legitimately large output
+    // (reading a runbook) opts into a larger `maxOutputLen` via the manifest.
+    const maxOutputLen = findManifestTool(name)?.maxOutputLen ?? MAX_TEXT_LEN
+    return sanitizeMcpJson(result, deps.getSecrets(), maxOutputLen) as CallToolResult
   })
 }

--- a/src/main/mcp-server/write-service-knowledge.ts
+++ b/src/main/mcp-server/write-service-knowledge.ts
@@ -1,0 +1,63 @@
+/**
+ * The `write_service_knowledge` MCP tool handler (#100). Writes a service's
+ * markdown runbook STRAIGHT THROUGH — ungated, no propose/accept step (the
+ * owner's decision) — but recoverable: the store backs up the prior version
+ * before every overwrite and refuses to overwrite if that backup fails.
+ *
+ * The handler validates its input and delegates all filesystem work (service-name
+ * safety, symlink refusal, size bounds, atomic write, per-service serialization,
+ * metadata stamping) to the store. Its text output is deliberately path-free.
+ */
+
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
+import { KNOWLEDGE_MAX_BYTES, writeServiceKnowledge } from '../knowledge/store'
+
+function textResult(text: string): CallToolResult {
+  return { content: [{ type: 'text', text }] }
+}
+
+function errorResult(text: string): CallToolResult {
+  return { content: [{ type: 'text', text }], isError: true }
+}
+
+/** Coerce an optional arg to a trimmed non-empty string, or null. */
+function optionalString(value: unknown): string | null {
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+/** Run the `write_service_knowledge` tool. Writes through the store (off the render thread). */
+export async function runWriteServiceKnowledge(args: Record<string, unknown>): Promise<CallToolResult> {
+  const service = optionalString(args.service)
+  if (service === null) {
+    return errorResult('`service` is required and must be a non-empty string (a slug like "payments-api").')
+  }
+  // `markdown` may be an empty string (intentionally clearing a runbook), so
+  // only require that it is a string — don't reject empty.
+  if (typeof args.markdown !== 'string') {
+    return errorResult('`markdown` is required and must be a string.')
+  }
+
+  const res = await writeServiceKnowledge({ service, markdown: args.markdown })
+  switch (res.status) {
+    case 'invalid_service':
+      return errorResult(`Invalid service name: ${res.reason}`)
+    case 'blocked':
+      return errorResult(res.reason)
+    case 'backup_failed':
+      return errorResult(
+        `Refused to write: could not back up the current version (${res.reason}). No changes were made.`
+      )
+    case 'too_large':
+      return errorResult(
+        `Runbook is too large (${res.size} bytes). The maximum is ${KNOWLEDGE_MAX_BYTES} bytes.`
+      )
+    case 'ok': {
+      const backup = res.backedUp ? ' Previous version backed up.' : ''
+      return textResult(
+        `Wrote the runbook for service "${res.service}" (stamped source: copilot, updated_at: ${res.updatedAt}).${backup}`
+      )
+    }
+  }
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -40,6 +40,11 @@ const api: ElectronApi = {
     const handler = () => callback()
     ipcRenderer.on('todos:updated', handler)
     return () => { ipcRenderer.removeListener('todos:updated', handler) }
+  },
+  onKnowledgeUpdated: (callback: () => void) => {
+    const handler = () => callback()
+    ipcRenderer.on('knowledge:updated', handler)
+    return () => { ipcRenderer.removeListener('knowledge:updated', handler) }
   }
 }
 

--- a/src/renderer/src/components/RunbooksPanel.module.css
+++ b/src/renderer/src/components/RunbooksPanel.module.css
@@ -1,0 +1,109 @@
+.panel {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.empty {
+  padding: 16px;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--text-3);
+  background: var(--bg-inset);
+  border: 1px solid var(--border-muted);
+  border-radius: var(--radius);
+}
+
+.card {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px;
+  background: var(--bg-inset);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+}
+
+.cardHead {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.cardIcon {
+  color: var(--text-3);
+  flex: none;
+}
+
+.cardTitle {
+  font-size: 13.5px;
+  font-weight: 600;
+  color: var(--text);
+  flex: 1;
+}
+
+.revealBtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+  padding: 2px 7px;
+  font-size: 11.5px;
+  color: var(--text-2);
+  background: var(--bg-inset);
+  border: 1px solid var(--border-muted);
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: background 150ms, border-color 150ms;
+}
+
+.revealBtn:hover {
+  border-color: var(--text-3);
+  color: var(--text);
+}
+
+.meta {
+  font-size: 11.5px;
+  color: var(--text-3);
+}
+
+.body {
+  margin: 0;
+  padding: 10px 12px;
+  max-height: 360px;
+  overflow: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: 12.5px;
+  line-height: 1.5;
+  color: var(--text);
+  background: var(--bg);
+  border: 1px solid var(--border-muted);
+  border-radius: var(--radius);
+}
+
+.muted {
+  font-size: 12.5px;
+  color: var(--text-3);
+}
+
+.muted code {
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: 12px;
+  color: var(--text-2);
+}
+
+.warn {
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+  font-size: 12.5px;
+  color: var(--text-2);
+}
+
+.warnIcon {
+  color: var(--warning, #d29922);
+  flex: none;
+  margin-top: 1px;
+}

--- a/src/renderer/src/components/RunbooksPanel.test.tsx
+++ b/src/renderer/src/components/RunbooksPanel.test.tsx
@@ -80,4 +80,14 @@ describe('RunbooksPanel', () => {
     render(<RunbooksPanel projectId={1} />)
     await waitFor(() => expect(onKnowledgeUpdated).toHaveBeenCalled())
   })
+
+  it('shows an error message (not the empty state) when the load fails', async () => {
+    invoke.mockImplementation((channel: string) => {
+      if (channel === 'knowledge:list-for-project') return Promise.reject(new Error('boom'))
+      return Promise.resolve(undefined)
+    })
+    render(<RunbooksPanel projectId={1} />)
+    expect(await screen.findByText(/Couldn’t load runbooks/i)).toBeTruthy()
+    expect(screen.queryByText(/lists no services yet/i)).toBeNull()
+  })
 })

--- a/src/renderer/src/components/RunbooksPanel.test.tsx
+++ b/src/renderer/src/components/RunbooksPanel.test.tsx
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import type { ServiceRunbook } from '@shared/ipc-channels'
+import { RunbooksPanel } from './RunbooksPanel'
+
+const invoke = vi.fn()
+const onKnowledgeUpdated = vi.fn(() => () => {})
+
+function setRunbooks(list: ServiceRunbook[]): void {
+  invoke.mockImplementation((channel: string) => {
+    if (channel === 'knowledge:list-for-project') return Promise.resolve(list)
+    return Promise.resolve(undefined)
+  })
+}
+
+beforeEach(() => {
+  invoke.mockReset()
+  onKnowledgeUpdated.mockClear()
+  setRunbooks([])
+  ;(globalThis as unknown as { window: Window }).window.electron = {
+    ipc: { invoke },
+    openExternal: vi.fn(() => Promise.resolve()),
+    onKnowledgeUpdated,
+  } as unknown as Window['electron']
+})
+
+function rb(partial: Partial<ServiceRunbook> & Pick<ServiceRunbook, 'service' | 'status'>): ServiceRunbook {
+  return {
+    service: partial.service,
+    key: partial.key ?? partial.service,
+    status: partial.status,
+    reason: partial.reason ?? null,
+    markdown: partial.markdown ?? null,
+    env: partial.env ?? null,
+    updatedAt: partial.updatedAt ?? null,
+    source: partial.source ?? null,
+  }
+}
+
+describe('RunbooksPanel', () => {
+  it('renders an empty state when the project has no services', async () => {
+    setRunbooks([])
+    render(<RunbooksPanel projectId={1} />)
+    expect(await screen.findByText(/lists no services yet/i)).toBeTruthy()
+  })
+
+  it('renders a written runbook body and its metadata', async () => {
+    setRunbooks([
+      rb({ service: 'web', status: 'ok', markdown: '# Health\n\nHit /health.', env: 'prod', source: 'copilot', updatedAt: '2026-07-09T00:00:00.000Z' }),
+    ])
+    render(<RunbooksPanel projectId={1} />)
+    expect(await screen.findByText('web')).toBeTruthy()
+    expect(screen.getByText(/Hit \/health\./)).toBeTruthy()
+    expect(screen.getByText(/source: copilot/)).toBeTruthy()
+  })
+
+  it('shows a friendly note for a service with no runbook yet', async () => {
+    setRunbooks([rb({ service: 'payments-api', status: 'missing' })])
+    render(<RunbooksPanel projectId={1} />)
+    expect(await screen.findByText(/No runbook yet/i)).toBeTruthy()
+  })
+
+  it('surfaces an invalid service name honestly', async () => {
+    setRunbooks([rb({ service: 'Bad Name', key: null, status: 'invalid', reason: 'Service must be a slug.' })])
+    render(<RunbooksPanel projectId={1} />)
+    expect(await screen.findByText(/Service must be a slug\./)).toBeTruthy()
+  })
+
+  it('reveals a runbook file on the reveal button', async () => {
+    setRunbooks([rb({ service: 'web', status: 'ok', markdown: 'body' })])
+    render(<RunbooksPanel projectId={1} />)
+    const revealBtn = await screen.findByTitle('Reveal file in Finder')
+    fireEvent.click(revealBtn)
+    await waitFor(() => expect(invoke).toHaveBeenCalledWith('knowledge:reveal', 'web'))
+  })
+
+  it('subscribes to knowledge updates', async () => {
+    setRunbooks([])
+    render(<RunbooksPanel projectId={1} />)
+    await waitFor(() => expect(onKnowledgeUpdated).toHaveBeenCalled())
+  })
+})

--- a/src/renderer/src/components/RunbooksPanel.tsx
+++ b/src/renderer/src/components/RunbooksPanel.tsx
@@ -61,6 +61,7 @@ function RunbookCard({ rb }: { rb: ServiceRunbook }): JSX.Element {
 export function RunbooksPanel({ projectId }: RunbooksPanelProps): JSX.Element {
   const [runbooks, setRunbooks] = useState<ServiceRunbook[]>([])
   const [loaded, setLoaded] = useState(false)
+  const [error, setError] = useState(false)
 
   useEffect(() => {
     let active = true
@@ -69,11 +70,15 @@ export function RunbooksPanel({ projectId }: RunbooksPanelProps): JSX.Element {
         const list = await window.electron.ipc.invoke('knowledge:list-for-project', projectId)
         if (active) {
           setRunbooks(list)
+          setError(false)
           setLoaded(true)
         }
       } catch (err) {
         console.error('[Runbooks] load failed:', err)
-        if (active) setLoaded(true)
+        if (active) {
+          setError(true)
+          setLoaded(true)
+        }
       }
     }
     void load()
@@ -83,6 +88,10 @@ export function RunbooksPanel({ projectId }: RunbooksPanelProps): JSX.Element {
       unsub()
     }
   }, [projectId])
+
+  if (loaded && error) {
+    return <div className={styles.empty}>Couldn’t load runbooks for this project. Try again in a moment.</div>
+  }
 
   if (loaded && runbooks.length === 0) {
     return (

--- a/src/renderer/src/components/RunbooksPanel.tsx
+++ b/src/renderer/src/components/RunbooksPanel.tsx
@@ -1,0 +1,102 @@
+import { useEffect, useState } from 'react'
+import { BookOpen, FolderOpen, AlertTriangle } from 'lucide-react'
+import type { ServiceRunbook } from '@shared/ipc-channels'
+import { Icon } from './Icon'
+import { LinkifiedText } from './LinkifiedText'
+import { fire } from '../ipc'
+import styles from './RunbooksPanel.module.css'
+
+interface RunbooksPanelProps {
+  projectId: number
+}
+
+function metaLine(rb: ServiceRunbook): string {
+  const parts: string[] = []
+  if (rb.env !== null && rb.env.length > 0) parts.push(rb.env)
+  if (rb.source !== null && rb.source.length > 0) parts.push(`source: ${rb.source}`)
+  if (rb.updatedAt !== null && rb.updatedAt.length > 0) parts.push(`updated ${rb.updatedAt}`)
+  return parts.join(' · ')
+}
+
+function RunbookCard({ rb }: { rb: ServiceRunbook }): JSX.Element {
+  const reveal = (): void => {
+    fire(window.electron.ipc.invoke('knowledge:reveal', rb.service), 'knowledge:reveal')
+  }
+  return (
+    <div className={styles.card}>
+      <div className={styles.cardHead}>
+        <Icon icon={BookOpen} size={14} className={styles.cardIcon} />
+        <span className={styles.cardTitle}>{rb.service}</span>
+        {rb.status === 'ok' && (
+          <button type="button" className={styles.revealBtn} onClick={reveal} title="Reveal file in Finder">
+            <Icon icon={FolderOpen} size={12} /> Reveal
+          </button>
+        )}
+      </div>
+
+      {rb.status === 'ok' && (
+        <>
+          {metaLine(rb).length > 0 && <div className={styles.meta}>{metaLine(rb)}</div>}
+          <pre className={styles.body}>
+            <LinkifiedText text={rb.markdown ?? ''} />
+          </pre>
+        </>
+      )}
+
+      {rb.status === 'missing' && (
+        <div className={styles.muted}>No runbook yet. Ask Copilot to write one, or create <code>{rb.key}.md</code> on disk.</div>
+      )}
+
+      {(rb.status === 'invalid' || rb.status === 'blocked' || rb.status === 'too_large') && (
+        <div className={styles.warn}>
+          <Icon icon={AlertTriangle} size={13} className={styles.warnIcon} />
+          <span>{rb.reason ?? 'Runbook unavailable.'}</span>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export function RunbooksPanel({ projectId }: RunbooksPanelProps): JSX.Element {
+  const [runbooks, setRunbooks] = useState<ServiceRunbook[]>([])
+  const [loaded, setLoaded] = useState(false)
+
+  useEffect(() => {
+    let active = true
+    const load = async (): Promise<void> => {
+      try {
+        const list = await window.electron.ipc.invoke('knowledge:list-for-project', projectId)
+        if (active) {
+          setRunbooks(list)
+          setLoaded(true)
+        }
+      } catch (err) {
+        console.error('[Runbooks] load failed:', err)
+        if (active) setLoaded(true)
+      }
+    }
+    void load()
+    const unsub = window.electron.onKnowledgeUpdated(() => { void load() })
+    return () => {
+      active = false
+      unsub()
+    }
+  }, [projectId])
+
+  if (loaded && runbooks.length === 0) {
+    return (
+      <div className={styles.empty}>
+        This project lists no services yet. Add services to the project card, then Copilot can keep a per-service
+        runbook (how to check health, monitor links, oncall notes).
+      </div>
+    )
+  }
+
+  return (
+    <div className={styles.panel}>
+      {runbooks.map((rb) => (
+        <RunbookCard key={rb.key ?? `invalid:${rb.service}`} rb={rb} />
+      ))}
+    </div>
+  )
+}

--- a/src/renderer/src/components/RunbooksPanel.tsx
+++ b/src/renderer/src/components/RunbooksPanel.tsx
@@ -22,6 +22,7 @@ function RunbookCard({ rb }: { rb: ServiceRunbook }): JSX.Element {
   const reveal = (): void => {
     fire(window.electron.ipc.invoke('knowledge:reveal', rb.service), 'knowledge:reveal')
   }
+  const meta = rb.status === 'ok' ? metaLine(rb) : ''
   return (
     <div className={styles.card}>
       <div className={styles.cardHead}>
@@ -36,7 +37,7 @@ function RunbookCard({ rb }: { rb: ServiceRunbook }): JSX.Element {
 
       {rb.status === 'ok' && (
         <>
-          {metaLine(rb).length > 0 && <div className={styles.meta}>{metaLine(rb)}</div>}
+          {meta.length > 0 && <div className={styles.meta}>{meta}</div>}
           <pre className={styles.body}>
             <LinkifiedText text={rb.markdown ?? ''} />
           </pre>

--- a/src/renderer/src/components/WorkingColumn.tsx
+++ b/src/renderer/src/components/WorkingColumn.tsx
@@ -4,6 +4,7 @@ import {
   CheckSquare,
   FileText,
   Database,
+  BookOpen,
   Bell,
   Plus,
   Check,
@@ -21,13 +22,14 @@ import type { NotificationThread, NotificationType, ProjectDetail, ProjectTodo, 
 import type { LucideIcon } from 'lucide-react'
 import { Icon } from './Icon'
 import { ResourcePanel } from './ResourcePanel'
+import { RunbooksPanel } from './RunbooksPanel'
 import { TodoSessionChip } from './TodoSessionChip'
 import { LinkifiedText } from './LinkifiedText'
 import { fire, openExternal } from '../ipc'
 import { isSafeExternalUrl } from '@shared/safe-url'
 import styles from './WorkingColumn.module.css'
 
-type TabId = 'todos' | 'notes' | 'resources' | 'notifications'
+type TabId = 'todos' | 'notes' | 'resources' | 'runbooks' | 'notifications'
 
 interface WorkingColumnProps {
   detail: ProjectDetail
@@ -289,6 +291,7 @@ const TABS: { id: TabId; label: string; icon: LucideIcon }[] = [
   { id: 'todos', label: 'Todos', icon: CheckSquare },
   { id: 'notes', label: 'Notes', icon: FileText },
   { id: 'resources', label: 'Resources', icon: Database },
+  { id: 'runbooks', label: 'Runbooks', icon: BookOpen },
   { id: 'notifications', label: 'Notifications', icon: Bell },
 ]
 
@@ -328,6 +331,7 @@ export function WorkingColumn(props: WorkingColumnProps): JSX.Element {
         )}
         {tab === 'notes' && <NotesPanel detail={props.detail} onSaveNotes={props.onSaveNotes} />}
         {tab === 'resources' && <ResourcePanel key={props.detail.id} projectId={props.detail.id} showUndo={props.showUndo} />}
+        {tab === 'runbooks' && <RunbooksPanel key={props.detail.id} projectId={props.detail.id} />}
         {tab === 'notifications' && <NotificationsPanel projectId={props.detail.id} onDelegate={props.onDelegate} />}
       </div>
     </div>

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -436,6 +436,30 @@ export interface ProjectCard {
 
 export type ProjectCardPatch = Partial<Pick<ProjectCard, 'purpose' | 'repos' | 'services' | 'activeGoal' | 'glossary'>>
 
+// ── Service knowledge / runbooks (#100) ───────────────────────────────────────
+
+/**
+ * A per-service markdown runbook as surfaced in the project view. One is produced
+ * for each service on the project card (deduped by normalized key). `status`
+ * distinguishes a present runbook from one that hasn't been written yet, a card
+ * service whose name isn't a valid runbook key, an oversized file, or a path the
+ * store refused (symlink/containment).
+ */
+export interface ServiceRunbook {
+  /** The service name as listed on the project card (display form). */
+  service: string
+  /** Normalized filename key when the name is a valid runbook slug, else null. */
+  key: string | null
+  status: 'ok' | 'missing' | 'invalid' | 'too_large' | 'blocked'
+  /** Human-readable reason for `invalid` / `blocked` / `too_large`; null otherwise. */
+  reason: string | null
+  /** Full file markdown when `status === 'ok'`, else null. */
+  markdown: string | null
+  env: string | null
+  updatedAt: string | null
+  source: string | null
+}
+
 /** A proposed typed record produced from a pasted/dropped URL, for one-tap accept. */
 export interface CaptureProposal {
   title: string
@@ -1043,6 +1067,20 @@ export type IpcChannels = {
     args: [projectId: number, patch: ProjectCardPatch]
     result: ProjectCard
   }
+
+  // ── Service knowledge / runbooks (#100) ──────────────────────────────────────
+
+  /** Returns a runbook entry for each service on the project card (deduped by key). */
+  'knowledge:list-for-project': {
+    args: [projectId: number]
+    result: ServiceRunbook[]
+  }
+
+  /** Reveals a service's runbook file in Finder. No-op when the file doesn't exist. */
+  'knowledge:reveal': {
+    args: [service: string]
+    result: void
+  }
 }
 
 export type IpcChannelName = keyof IpcChannels
@@ -1085,6 +1123,12 @@ export interface ElectronApi {
    * live. Returns an unsubscribe fn.
    */
   onTodosUpdated: (callback: () => void) => () => void
+  /**
+   * Registers a callback that fires when service knowledge changes out-of-band — specifically
+   * when the `write_service_knowledge` MCP tool writes a runbook. The project Runbooks surface
+   * reloads on this so an agent-written runbook appears live. Returns an unsubscribe fn.
+   */
+  onKnowledgeUpdated: (callback: () => void) => () => void
 }
 
 declare global {

--- a/src/shared/service-name.test.ts
+++ b/src/shared/service-name.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest'
+import { normalizeServiceName, validateServiceName, isValidServiceName } from './service-name'
+
+describe('normalizeServiceName', () => {
+  it('trims and lowercases only (no substitution)', () => {
+    expect(normalizeServiceName('  Payments-API  ')).toBe('payments-api')
+    expect(normalizeServiceName('WEB')).toBe('web')
+  })
+})
+
+describe('validateServiceName - accepts safe slugs', () => {
+  it.each([
+    'web',
+    'payments-api',
+    'web_store',
+    'a',
+    'a1',
+    'service.v2',
+    'foo-bar_baz.qux',
+    '  Payments-API  ', // normalized to payments-api
+  ])('accepts %j', (raw) => {
+    const res = validateServiceName(raw)
+    expect(res.ok).toBe(true)
+    if (res.ok) {
+      expect(res.key).toMatch(/^[a-z0-9]/)
+      expect(isValidServiceName(raw)).toBe(true)
+    }
+  })
+
+  it('folds case to a single key', () => {
+    const a = validateServiceName('API')
+    const b = validateServiceName('api')
+    expect(a.ok && b.ok && a.key === b.key).toBe(true)
+  })
+})
+
+describe('validateServiceName - rejects traversal / unsafe input (SECURITY)', () => {
+  it.each([
+    '',
+    '   ',
+    '.',
+    '..',
+    '../foo',
+    '../../etc/passwd',
+    '..\\windows',
+    'foo/bar',
+    'foo\\bar',
+    '/etc/passwd',
+    '/absolute',
+    'a/../b',
+    '.hidden', // leading dot
+    'foo.', // trailing dot
+    '-foo', // leading separator
+    'foo-', // trailing separator
+    '_foo',
+    'foo/',
+    'foo..bar', // contains ..
+    'a\u0000b', // NUL byte
+    'a\tb', // control char
+    'a\nb',
+    'café', // non-ASCII
+    'Ω',
+    'has space',
+    'UPPER/lower', // slash survives lowercasing
+  ])('rejects %j', (raw) => {
+    expect(validateServiceName(raw).ok).toBe(false)
+    expect(isValidServiceName(raw)).toBe(false)
+  })
+
+  it('rejects an over-length name', () => {
+    expect(validateServiceName('a'.repeat(65)).ok).toBe(false)
+    expect(validateServiceName('a'.repeat(64)).ok).toBe(true)
+  })
+
+  it('gives an actionable reason on rejection', () => {
+    const res = validateServiceName('../evil')
+    expect(res.ok).toBe(false)
+    if (!res.ok) expect(res.reason.length).toBeGreaterThan(0)
+  })
+})

--- a/src/shared/service-name.ts
+++ b/src/shared/service-name.ts
@@ -1,0 +1,88 @@
+/**
+ * Service-name -> knowledge-file KEY normalization + validation. Shared by the
+ * main process (the MCP tools + the on-disk knowledge store) and the renderer
+ * (the Runbooks surface), so the UI can never disagree with the write path about
+ * which service names are addressable as runbooks.
+ *
+ * SECURITY: a service value becomes a filename (`<key>.md`) under
+ * `~/.gh-projects/knowledge/`. This module is the FIRST gate that keeps a write
+ * from escaping that directory. It is deliberately REJECT-based (never
+ * substitute/slugify): the accepted key maps 1:1 to a filename, and anything
+ * that isn't a safe slug is refused with an actionable message rather than
+ * silently rewritten into a different (possibly colliding) file. The store layer
+ * adds a second, independent containment check as defense-in-depth.
+ */
+
+/** Max length of a normalized service key (keeps filenames sane). */
+export const MAX_SERVICE_KEY_LENGTH = 64
+
+/**
+ * Normalize a raw service name to its canonical key: trim surrounding
+ * whitespace and lowercase. NO character substitution — normalization only folds
+ * case and trims, so the mapping from an accepted name to a filename is
+ * predictable and reversible-by-eye. (Case folding means `API` and `api` share
+ * one runbook, by design.)
+ */
+export function normalizeServiceName(raw: string): string {
+  return raw.trim().toLowerCase()
+}
+
+/** Outcome of validating a normalized service key. */
+export type ServiceNameValidation =
+  | { ok: true; key: string }
+  | { ok: false; reason: string }
+
+// A safe slug: starts and ends alphanumeric, inner chars limited to
+// [a-z0-9._-]. Single-char alphanumeric names are allowed. The start/end anchors
+// forbid leading/trailing separators (so no leading `.` hidden files, no
+// trailing dot). `..` is rejected separately below because the charset alone
+// would otherwise permit it in the middle.
+const SAFE_KEY = /^[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?$/
+
+/**
+ * Validate + normalize a raw service name into a safe file key. Rejects (never
+ * rewrites) anything unsafe: empty/whitespace, path separators, `..`, leading
+ * dots, control chars, non-ASCII, or anything outside the `[a-z0-9._-]` slug
+ * charset. Case is folded first, so validation always runs on the same key the
+ * store will use.
+ */
+export function validateServiceName(raw: string): ServiceNameValidation {
+  if (typeof raw !== 'string') {
+    return { ok: false, reason: 'Service must be a string.' }
+  }
+  const key = normalizeServiceName(raw)
+  if (key.length === 0) {
+    return { ok: false, reason: 'Service must not be empty.' }
+  }
+  if (key.length > MAX_SERVICE_KEY_LENGTH) {
+    return { ok: false, reason: `Service must be at most ${MAX_SERVICE_KEY_LENGTH} characters.` }
+  }
+  // Explicit traversal / separator rejects with clear messages (these would also
+  // fail SAFE_KEY, but a targeted message is more useful to the caller).
+  if (key.includes('/') || key.includes('\\')) {
+    return { ok: false, reason: 'Service must not contain path separators.' }
+  }
+  if (key.includes('..')) {
+    return { ok: false, reason: 'Service must not contain "..".' }
+  }
+  // Reject any control char or NUL explicitly (belt-and-suspenders vs SAFE_KEY).
+  for (let i = 0; i < key.length; i++) {
+    const code = key.charCodeAt(i)
+    if (code < 0x20 || code === 0x7f) {
+      return { ok: false, reason: 'Service must not contain control characters.' }
+    }
+  }
+  if (!SAFE_KEY.test(key)) {
+    return {
+      ok: false,
+      reason:
+        'Service must be a slug of lowercase letters, digits, ".", "-", "_" that starts and ends with a letter or digit (e.g. "payments-api").',
+    }
+  }
+  return { ok: true, key }
+}
+
+/** Convenience boolean form of {@link validateServiceName}. */
+export function isValidServiceName(raw: string): boolean {
+  return validateServiceName(raw).ok
+}

--- a/src/shared/service-name.ts
+++ b/src/shared/service-name.ts
@@ -44,9 +44,9 @@ const SAFE_KEY = /^[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?$/
  * rewrites) anything unsafe: empty/whitespace, path separators, `..`, leading
  * dots, control chars, non-ASCII, or anything outside the `[a-z0-9._-]` slug
  * charset. Case is folded first, so validation always runs on the same key the
- * store will use.
+ * store will use. Accepts `unknown` because it gates untrusted MCP/IPC input.
  */
-export function validateServiceName(raw: string): ServiceNameValidation {
+export function validateServiceName(raw: unknown): ServiceNameValidation {
   if (typeof raw !== 'string') {
     return { ok: false, reason: 'Service must be a string.' }
   }
@@ -83,6 +83,6 @@ export function validateServiceName(raw: string): ServiceNameValidation {
 }
 
 /** Convenience boolean form of {@link validateServiceName}. */
-export function isValidServiceName(raw: string): boolean {
+export function isValidServiceName(raw: unknown): boolean {
   return validateServiceName(raw).ok
 }


### PR DESCRIPTION
Closes #100. Part of the epic #98.

## What this does

Copilot can now read and write **per-service knowledge** as human-editable markdown - "how to check health", monitor links, oncall notes - keyed per service and surfaced in the project view. Two new inbound MCP tools plus on-disk storage.

- **Storage:** one `<service>.md` per service under `~/.gh-projects/knowledge/` with light frontmatter (`service`, `env?`, `updated_at`, `source`). Prose can reference registry resources by name/alias rather than pasting URLs that rot - the link truth stays in the resource, the procedure in the markdown.
- **Tools:**
  - `read_service_knowledge({ service, includeResources?, project? })` - reads the file fresh from disk (so hand edits are always reflected). Optionally lists registry resources whose service matches, each annotated with its owning project so nothing is conflated across projects.
  - `write_service_knowledge({ service, markdown })` - writes **straight through, ungated** (owner's decision, no propose/accept step). Stamps `updated_at` + `source: copilot`, preserves a human-set `env`. Never clobbers silently: the prior version is backed up before every overwrite.
- **Project link:** reuses the existing `ProjectCard.services` list. A new **Runbooks** tab in the project view lists the card's services and renders each runbook (with a "Reveal file" affordance), live-reloading on a `knowledge:updated` broadcast.

## Security (the `service` value becomes a filename)

- Service names are validated to a safe slug by a **shared** validator (main + renderer agree): reject-based (`normalize` = trim+lowercase; strict `[a-z0-9._-]` charset, must start/end alphanumeric; rejects `/`, `\`, `..`, leading dots, control chars, non-ASCII, empty, >64 chars). Plus a second path-containment check in the store.
- Reads and overwrites **refuse to follow a symlinked runbook or history dir**; the atomic temp+rename never writes through a symlink.
- Oversized files (hand-edited beyond the 256 KiB cap) report `too_large` rather than being silently truncated; writes re-check the *final* stamped size before touching disk.
- Writes are **serialized per service** and **atomic** (exclusive temp file + rename); backups are uniquely named and created exclusively, and a write is aborted if its backup fails.

## How I verified it

`bun run test` (typecheck + eslint + vitest, **647 tests**) is green. Specifically:

- **Service-name validation** (`src/shared/service-name.test.ts`): accepts safe slugs, folds case; rejects `../foo`, `/etc/passwd`, `..\`, `a/b`, `.hidden`, control chars, non-ASCII, spaces, over-length, empty.
- **Frontmatter** (`frontmatter.test.ts`): parse/emit, round-trip, quoted values, BOM, CRLF; does NOT mistake a body that opens with a `---` horizontal rule (or a block with only unknown keys) for frontmatter; unclosed fence -> whole file is body.
- **Store** (`store.test.ts`): write/read round-trip + stamping; sees an out-of-band hand edit on the next read; env preservation + override; version history is created and pruned to 20; oversize write rejected (incl. the final-size edge); traversal names never write outside the dir; **symlink refusal** on read/overwrite/history; concurrent writes serialize and keep unique recoverable history; a service literally named `history` doesn't collide with `.history`.
- **Integration over the REAL loopback MCP server** via an in-process `@modelcontextprotocol/sdk` client (`knowledge.integration.test.ts`): both tools advertised; write a runbook then **mutate the file on disk out-of-band and read it back to assert the edit is seen** (the issue's acceptance test); friendly "no runbook yet" for a missing file; traversal service rejected on read + write; `includeResources` shows project context; soft-deleted and unknown-explicit projects don't leak resources.
- **Renderer** (`RunbooksPanel.test.tsx`): empty state, rendered runbook + metadata, missing/invalid states, reveal action, live-reload subscription.

The plan and the implementation were each reviewed by an independent model (GPT-5.5) and iterated until sound / ready-for-merge; the layering concern about the central output sanitizer (a 2000-char cap that would clip a runbook read) is handled by a per-tool output cap so only `read_service_knowledge` opts into a larger bound while every other tool keeps the small default.

## Honest gap

I could not drive the **real Copilot desktop app** calling these tools end-to-end from this environment. The tools are verified against the real loopback server with a real MCP SDK client (same protocol path the app uses), and `tools/list` advertises them via the shared manifest, but a human should confirm the installed app can invoke them once.

## Notes

- No DB migration (file-based storage + the existing `ProjectCard.services`), so nothing conflicts with migration numbering.