### PR TITLE
Add gh-projects Copilot skill + MCP onboarding docs

### DIFF
--- a/.github/skills/gh-projects/SKILL.md
+++ b/.github/skills/gh-projects/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: gh-projects
+description: >-
+  Use when working inside the GH Projects app's world - re-entering a project,
+  triaging GitHub notifications, reviewing a PR you were asked to follow up on,
+  or planning/recording a service rollout - and the GH Projects MCP tools
+  (ping, add_todo, list_projects, get_project_context, get_reentry_digest,
+  read_service_knowledge, write_service_knowledge) are available. Teaches when to
+  orient with the read tools before acting, how to propose human-gated follow-up
+  work with add_todo instead of writing to GitHub, and how to read/record service
+  runbooks. Do NOT trigger this for unrelated coding sessions.
+---
+
+# GH Projects MCP tools
+
+GH Projects is a personal, macOS project-management app. It exposes an **inbound MCP
+server** so you (Copilot) can read the app's own situational state and file
+human-gated follow-up work. These tools let you act *with the project's context*
+instead of guessing.
+
+## The one rule that matters most
+
+**These tools never write to GitHub.** The only way you affect the outside world is
+by proposing work the human approves later. When you finish reviewing a PR or spot
+something worth doing, call `add_todo` to file a proposal in GH Projects - do **not**
+post a comment, request changes, or push anything to GitHub through these tools.
+
+Exception: if the user explicitly asked you to leave a real PR review comment using
+some *other* tool, honor that. `add_todo` is for follow-up work inside GH Projects,
+not a replacement for a review comment the user directly requested.
+
+## When to reach for these tools
+
+Trigger on GH-Projects-shaped work, not every session:
+
+- **Re-entering / orienting** - "what was I doing", "what changed", "what should I
+  pick up". Start with `get_reentry_digest` (and `list_projects` for the roster).
+- **Before proposing a fix or a rollout plan** - pull `get_project_context` for the
+  project, and `read_service_knowledge` for any service you'll touch, *first*. Don't
+  propose against a blank slate.
+- **After reviewing a PR** - file the follow-up as a todo with `add_todo`.
+- **After learning something durable about a service** (health check, monitor, a
+  gotcha) - record it with `write_service_knowledge`.
+
+Do not call these during unrelated coding work. `get_reentry_digest` / `list_projects`
+are for GH-Projects orientation, not a generic "what's going on" probe.
+
+## Core workflows
+
+### 1. Orient at the start of a GH Projects session
+```
+get_reentry_digest            # {projects:[...]} - what changed / what to pick up
+list_projects                 # the roster: id, name, status, next action, open-todo count
+```
+`get_reentry_digest` with no `project` returns every project with new activity or
+drift. Pass a `project` to focus on one.
+
+### 2. Get context before you propose anything
+```
+get_project_context { "project": "Payments revamp" }
+```
+Returns the project card (purpose, repos, **services**, active goal, glossary), open
+todos, links, and saved resources. Use the `services` list to learn the exact service
+slugs, then:
+```
+read_service_knowledge { "service": "payments-api", "includeResources": true }
+```
+Now propose your fix/rollout grounded in the runbook and the real linked resources.
+
+### 3. After reviewing a PR, propose - don't comment
+```
+add_todo {
+  "repo": "acme/payments-api",
+  "title": "Address review feedback on PR #482",
+  "body": "Nullable receipt id needs a guard; suggest adding a test for the empty-cart path.",
+  "sourceUrl": "https://github.com/acme/payments-api/pull/482",
+  "suggestedAction": {
+    "kind": "pr_comment",
+    "url": "https://github.com/acme/payments-api/pull/482",
+    "comment": "Consider guarding the nullable receipt id before dereferencing."
+  }
+}
+```
+The `suggestedAction` is advisory - the app renders a one-tap affordance but never
+performs the GitHub write for you. The human decides.
+
+### 4. Record what you learned about a service
+```
+read_service_knowledge { "service": "payments-api" }    # read current runbook first
+write_service_knowledge {
+  "service": "payments-api",
+  "markdown": "# payments-api\n\n## Health\nHit the **Payments health dashboard** ...\n\n## Gotchas\n..."
+}
+```
+Read before you write. Only record durable, operational, user-relevant knowledge -
+health checks, monitor links, on-call notes, gotchas. **Never write secrets.** Prefer
+referencing a saved resource by its **name/alias** (from `get_project_context` or
+`read_service_knowledge` with `includeResources: true`) rather than pasting a raw URL
+that will rot. The write is **immediate and ungated** (no approval step), but the
+prior version is backed up before every overwrite, so it's recoverable.
+
+## Idempotency: don't create duplicates
+
+`add_todo` de-duplicates on a key derived from the **normalized `sourceUrl` plus the
+full `suggestedAction`**:
+
+- Same `sourceUrl` **and** same `suggestedAction` → **updates** the existing todo in place.
+- Same `sourceUrl` but a **different** `suggestedAction` → a **distinct** new todo.
+- **No `sourceUrl`** → always inserts a new todo (nothing stable to dedup on).
+
+So when you re-review the same PR, pass the same `sourceUrl` (and keep the action
+stable) to update rather than pile up duplicates. Always include a `sourceUrl` when
+one exists.
+
+## Placement: where a todo lands
+
+`add_todo` resolves placement in this order:
+
+1. Explicit `project` (exact project **name**) wins.
+2. Else `repo` (`"owner/name"`) is routed to a project via the same rules notifications use.
+3. Else it lands in the **Inbox**.
+
+## Project argument cheat sheet (easy to get wrong)
+
+| Tool | `project` accepts |
+|---|---|
+| `add_todo` | exact project **name string only** (never an id) |
+| `get_project_context` | name **string** OR integer **id** (required) |
+| `get_reentry_digest` | name **string** OR integer **id** (optional) |
+| `read_service_knowledge` | exact project **name string only** (optional; scopes linked resources) |
+
+Get names/ids from `list_projects`. Don't pass a numeric id to `add_todo.project` or
+`read_service_knowledge.project` - those are name-only.
+
+## Tool reference
+
+| Tool | Required | Optional | What it does |
+|---|---|---|---|
+| `ping` | - | - | Liveness check. Returns `pong`. Use to confirm the server is reachable. |
+| `add_todo` | `title` | `project`, `repo`, `body`, `sourceUrl`, `suggestedAction` | Files a human-gated todo (a proposal). Never writes to GitHub. |
+| `list_projects` | - | - | Read-only roster: `id`, `name`, `status` (active/snoozed), `nextAction`, `activeTodoCount`. |
+| `get_project_context` | `project` | - | Read-only brief: card, open todos, links, resources, service names. |
+| `get_reentry_digest` | - | `project` | Read-only "what changed while I was away" digest. Always `{ projects: [...] }`. |
+| `read_service_knowledge` | `service` | `includeResources`, `project` | Reads a service's markdown runbook fresh from disk. Friendly note (not an error) when none exists. |
+| `write_service_knowledge` | `service`, `markdown` | - | Creates/overwrites a service runbook (ungated, backed up). |
+
+`suggestedAction` (all optional, advisory only) is one of:
+
+- `{ "kind": "pr_comment", "url": "...", "comment": "..." }`
+- `{ "kind": "delegate", "prompt": "..." }`
+- `{ "kind": "open_url", "url": "..." }`
+
+A `service` is a slug like `payments-api` (lowercase letters/digits with `-`, `_`, `.`).
+`sourceUrl` and any action `url` must be `http`/`https`.
+
+## When the app isn't running
+
+If GH Projects isn't running, every tool **call** - `add_todo`, the read tools, and
+even `ping` - returns a clean **"The GH Projects app isn't running..."** error (they
+never hang). Only the tool **list** stays available (the shim serves it statically), so
+you'll still see the tools advertised even when the app is down; calling any of them
+just reports the app isn't running. If you hit that error, tell the user to start GH
+Projects and retry - don't fall back to writing on GitHub directly.

--- a/README.md
+++ b/README.md
@@ -85,6 +85,15 @@ bun run typecheck
 
 ---
 
+## Copilot MCP integration
+
+GH Projects runs an inbound MCP server so the GitHub Copilot CLI can read project context and file human-gated todos (it never writes back to GitHub). The app registers itself in `~/.mcp.json` automatically, and a version-controlled skill teaches Copilot when and how to use the tools.
+
+- Skill: [`.github/skills/gh-projects/SKILL.md`](.github/skills/gh-projects/SKILL.md)
+- Wiring, enable/disable, and how to confirm it's up: [`docs/mcp-server.md`](docs/mcp-server.md)
+
+---
+
 ## Resetting the notification sync cursor
 
 If notifications go missing (e.g., after debugging or a sync race), clear the stored `since` timestamp so the next sync does a full re-fetch:
@@ -122,5 +131,8 @@ src/
   shared/        # Types and constants shared between main and renderer
 db/
   migrations/    # SQL migration files, applied in filename order on startup
+docs/            # Operator/developer docs (e.g. the Copilot MCP integration)
 requirements/    # PRD and milestone docs (not shipped)
+.github/
+  skills/        # Version-controlled Copilot skills (e.g. gh-projects)
 ```

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -1,0 +1,181 @@
+# Copilot MCP integration
+
+GH Projects exposes an **inbound MCP server** so the GitHub Copilot CLI can call the
+app's own tools - reading project context and filing human-gated todos - without the
+app ever writing back to GitHub. This doc covers two separate things:
+
+- **A. MCP tool registration** - how the app wires its server into `~/.mcp.json` so
+  Copilot can discover and spawn it.
+- **B. Skill install / discovery** - how the `gh-projects` skill teaches Copilot
+  *when and how* to use those tools.
+
+They are independent: registering the server makes the tools *available*; installing
+the skill makes Copilot *use them well*. You generally want both.
+
+The tool surface itself is documented for the model in
+[`.github/skills/gh-projects/SKILL.md`](../.github/skills/gh-projects/SKILL.md).
+
+---
+
+## What it is
+
+- A **loopback MCP server** runs inside the Electron main process, bound to
+  `127.0.0.1:<ephemeral>`, speaking MCP over Streamable HTTP
+  (`src/main/mcp-server/server.ts`).
+- A small, self-contained **stdio shim** (`build/mcp-shim.cjs`, built from
+  `src/main/mcp-server/shim/entry.ts`) is what the Copilot app actually spawns. It
+  bridges Copilot's stdio channel to the loopback server:
+
+  ```
+  Copilot CLI  <--stdio-->  [mcp-shim.cjs]  <--Streamable HTTP-->  loopback server (in the app)
+  ```
+
+The shim is bundled into the app so the two ends ship together and can't drift.
+
+---
+
+## A. MCP tool registration (`~/.mcp.json`)
+
+The app manages a single entry keyed **`gh-projects`** in your global `~/.mcp.json`
+(`src/main/mcp-server/mcp-json.ts`). The written entry looks like:
+
+```jsonc
+{
+  "mcpServers": {
+    "gh-projects": {
+      "command": "/path/to/GH Projects.app/Contents/MacOS/GH Projects", // process.execPath - the Electron binary
+      "args": ["/path/to/mcp-shim.cjs"],
+      "env": {
+        "ELECTRON_RUN_AS_NODE": "1",       // run the Electron binary as plain Node
+        "GH_PROJECTS_MCP_MANAGED": "1"      // ownership marker - see below
+      }
+    }
+  }
+}
+```
+
+Why this shape (`src/main/mcp-server/lifecycle.ts`, `buildShimCommand`):
+
+- The **command is the app's own Electron binary run as Node**
+  (`ELECTRON_RUN_AS_NODE=1`) against the unpacked `mcp-shim.cjs`. That means there's
+  no dependency on a system `node` or `bun` being installed, and no script-in-asar
+  execution.
+- The `GH_PROJECTS_MCP_MANAGED=1` env var is an **ownership marker**. The app only
+  ever adds, updates, or removes a `gh-projects` entry that carries this marker (or is
+  absent). If you hand-authored your own `gh-projects` entry without the marker, the
+  app **leaves it untouched** - it will never clobber your config.
+- Writes are **atomic** (temp file + same-directory rename), and any unrelated servers
+  or top-level keys in `~/.mcp.json` are preserved. A present-but-unparseable
+  `~/.mcp.json` is treated as a hard error and is never overwritten.
+
+### Enable / disable
+
+- The server is **enabled by default** (`src/main/mcp-server/settings.ts` - an unset
+  setting means enabled).
+- On app launch, if enabled, the app **starts the loopback server and registers the
+  shim** in `~/.mcp.json` (`src/main/index.ts`).
+  - **Dev caveat:** registration only happens when the shim bundle actually exists at
+    the expected path. In a dev checkout **before `bun run build:shim`** has produced
+    `build/mcp-shim.cjs`, the app **skips registration and logs a warning** rather than
+    pointing Copilot at a missing command. Run `bun run build` (which runs
+    `build:shim`) first.
+- There is an IPC channel `settings:set-mcp-server-enabled` that starts/stops the
+  server and adds/removes the `~/.mcp.json` entry. There is **no renderer UI toggle for
+  this yet** - the behavior is default-on plus that IPC channel.
+
+### Runtime discovery files (`~/.gh-projects/run/`)
+
+While the app is running it publishes two files the shim reads to find and
+authenticate to the loopback server (`src/main/mcp-server/runfiles.ts`):
+
+- `~/.gh-projects/run/token` - a base64url auth token, mode `0600`. **Rotates on every
+  app launch.**
+- `~/.gh-projects/run/port` - the localhost port the loopback server listens on, mode
+  `0600`.
+
+Both are written **only after** the HTTP server's `listen()` succeeds, `token` first
+then `port` last - so a reader never sees a `port` that isn't accepting yet. The shim
+re-reads these on **every** connect attempt, which is how it heals app restarts and
+token rotation. The token is a secret and is never logged.
+
+---
+
+## B. Skill install / discovery
+
+The tools being registered makes them *available* to Copilot; the **skill** is what
+teaches Copilot *when and how* to use them. The skill lives in this repo at:
+
+```
+.github/skills/gh-projects/SKILL.md
+```
+
+Copilot discovers skills two ways:
+
+- **Repo-local** - when you run Copilot in a checkout of this repo, the
+  `.github/skills/gh-projects/` skill is discovered automatically.
+- **User-global** - to make the skill available in *any* session (not just this repo),
+  copy the skill folder into your personal skills directory:
+
+  ```bash
+  mkdir -p ~/.copilot/skills
+  cp -R .github/skills/gh-projects ~/.copilot/skills/gh-projects
+  ```
+
+After installing (or updating) the skill, **start a fresh Copilot session** so it picks
+up the change.
+
+---
+
+## When the app isn't running
+
+The shim degrades gracefully (`src/main/mcp-server/shim/proxy.ts`):
+
+- `tools/list` **always** returns the static, bundled tool manifest - so the advertised
+  surface is stable and never empty, even with the app down.
+- `tools/call` forwards to the loopback server, re-reading the run files and retrying
+  once on a transient failure. If it still can't reach the app, it returns a clean
+  **"The GH Projects app isn't running..."** error result and **never hangs**.
+- On app **quit**, the run files are removed but the `~/.mcp.json` entry is **left in
+  place** (quit is not the same as disable). The next launch republishes the run files;
+  meanwhile the shim just reports "app not running".
+
+---
+
+## Confirming it's up (manual smoke check)
+
+There's no automated end-to-end harness for a live Copilot session, so verify by hand:
+
+1. **Build the shim:** `bun run build` (runs `build:shim`, producing
+   `build/mcp-shim.cjs`).
+2. **Launch GH Projects.**
+3. **Check registration:** `~/.mcp.json` contains a `gh-projects` entry whose `env` has
+   `GH_PROJECTS_MCP_MANAGED=1`.
+
+   ```bash
+   cat ~/.mcp.json
+   ```
+4. **Check the server is listening:** the port file exists while the app runs.
+
+   ```bash
+   cat ~/.gh-projects/run/port    # a port number
+   ```
+5. **Call `ping`** from a Copilot session (with the `gh-projects` MCP server
+   configured). It should return `pong`.
+
+---
+
+## Troubleshooting
+
+- **No `gh-projects` entry appears in `~/.mcp.json`.** Either the server is disabled,
+  or you're in a dev checkout and haven't built the shim yet - run `bun run build` and
+  relaunch. Check the app logs for a "shim bundle missing" warning.
+- **A `gh-projects` entry exists but tools fail with "app isn't running".** The app is
+  closed, or the run files are stale. Launch the app; the shim re-reads
+  `~/.gh-projects/run/{port,token}` on the next call.
+- **The app won't touch my `gh-projects` entry.** If you hand-added a `gh-projects`
+  entry without the `GH_PROJECTS_MCP_MANAGED=1` marker, the app intentionally leaves it
+  alone. Remove your unmarked entry (or add the marker) if you want the app to manage
+  it.
+- **Copilot has the tools but doesn't use them well.** The tools are registered but the
+  skill isn't discovered. Confirm you're in this repo, or copy the skill into
+  `~/.copilot/skills/gh-projects/`, then start a fresh session.

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -23,7 +23,7 @@ The tool surface itself is documented for the model in
   `127.0.0.1:<ephemeral>`, speaking MCP over Streamable HTTP
   (`src/main/mcp-server/server.ts`).
 - A small, self-contained **stdio shim** (`build/mcp-shim.cjs`, built from
-  `src/main/mcp-server/shim/entry.ts`) is what the Copilot app actually spawns. It
+  `src/main/mcp-server/shim/entry.ts`) is what the Copilot CLI actually spawns. It
   bridges Copilot's stdio channel to the loopback server:
 
   ```


### PR DESCRIPTION
Closes #105.

The last build-track piece of epic #98: teach the **Copilot side** when and how to use the inbound MCP tools, plus a short onboarding doc for wiring the server up. Docs only - no server or schema changes.

## What's here

- **`.github/skills/gh-projects/SKILL.md`** - a version-controlled Copilot skill (also installable into `~/.copilot/skills/`) with valid `name` + `description` frontmatter. It shapes behavior, it isn't just a tool list:
  - Orient at the start of a GH-Projects session with `get_reentry_digest` (+ `list_projects`) - and explicitly **not** during unrelated coding.
  - Read `get_project_context` + `read_service_knowledge` **before** proposing a fix or rollout.
  - After reviewing a PR, **propose** work with `add_todo` instead of writing to GitHub (these tools never write back to GitHub).
  - Idempotency: reuse `sourceUrl` (+ a stable `suggestedAction`) so re-runs update in place instead of duplicating.
  - Record durable service knowledge with `write_service_knowledge`, referencing saved resources by name.
  - A project-argument cheat sheet (name-only vs name-or-id differs per tool) and one example call per tool.
- **`docs/mcp-server.md`** - onboarding/wiring doc: the app-managed `~/.mcp.json` entry, the Electron-as-Node shim command, the managed-ownership marker, default-on + auto-register-on-launch (with the dev "shim bundle missing => skip" caveat), the IPC enable/disable toggle, the `~/.gh-projects/run/{token,port}` files, app-not-running degradation, a manual smoke check, and troubleshooting.
- **README** - a short "Copilot MCP integration" section linking both, plus a project-structure update for `docs/` and `.github/skills/`.

## Source of truth

Every tool name, input field, and onboarding step was derived from the merged code in `src/main/mcp-server/`, not from the issue's original proposals. Where the issue and the code differed, I followed the code.

## How I verified

- **Tool surface** cross-checked against `src/main/mcp-server/tool-manifest.ts` (+ `tools.ts`): the 7 registered tools (`ping`, `add_todo`, `list_projects`, `get_project_context`, `get_reentry_digest`, `read_service_knowledge`, `write_service_knowledge`), their required/optional fields, the `suggestedAction` oneOf shapes, and the name-only vs name-or-id `project` argument distinction (`add_todo`/`read_service_knowledge` are name-only via `type: string`; `get_project_context`/`get_reentry_digest` accept name-or-id via `PROJECT_REF_SCHEMA`).
- **Behavior details** cross-checked against handlers: `add_todo` placement precedence + `sha256(sourceUrl + full action)` dedup (`add-todo.ts`); read-only context payloads (`read-context.ts`); read-fresh + friendly-missing note (`read-service-knowledge.ts`); ungated-but-backed-up write that stamps `source: copilot` (`write-service-knowledge.ts`).
- **Wiring/onboarding** cross-checked against `mcp-json.ts` (managed `gh-projects` entry, `GH_PROJECTS_MCP_MANAGED=1` ownership marker, never clobbers a hand-added entry, atomic writes), `lifecycle.ts` (`buildShimCommand` = `process.execPath` + `ELECTRON_RUN_AS_NODE=1`; register only if the shim bundle exists; quit leaves the mcp.json entry), `runfiles.ts` (`~/.gh-projects/run/{token,port}`, 0600, token rotates per launch, token-then-port after `listen()`), `settings.ts` (default-on), `index.ts` (startup + IPC toggle, no renderer UI toggle), and `shim/proxy.ts` (static `tools/list` when down; every `tools/call` incl. `ping` returns the clean "app isn't running" error; never hangs).
- **`bun run test` is fully green**: `typecheck` + `eslint src` + `vitest` - 684 tests across 70 files. (Docs touch no `src` files.)
- **SKILL.md frontmatter** validated as well-formed YAML (`name` + `description` parse).

## Honest gap

I did **not** run a real fresh Copilot session end-to-end with the skill installed (review a PR -> `add_todo`; ask about a service -> read/write knowledge). There's no automated harness for that here, and it needs a running app + a live Copilot session. The docs are verified against the code line-by-line, but the intended agent flow itself wasn't exercised in an automated test. The `docs/mcp-server.md` manual smoke check documents how to confirm it by hand.

## Note (not fixed here, out of scope)

No doc-vs-code bug found - the implementation matched what I documented. One environment nit unrelated to this change: `bun install` alone doesn't fetch the Electron binary (electron isn't in `trustedDependencies`), so 3 electron-importing test suites fail until the binary is present (`bun run setup` / the electron install script handles it). Flagging for awareness only; not touching it in a docs PR.
