### PR TITLE
Fix gh-projects skill frontmatter so the Copilot app loads it

### DIFF
--- a/.github/skills/gh-projects/SKILL.md
+++ b/.github/skills/gh-projects/SKILL.md
@@ -1,14 +1,6 @@
 ---
 name: gh-projects
-description: >-
-  Use when working inside the GH Projects app's world - re-entering a project,
-  triaging GitHub notifications, reviewing a PR you were asked to follow up on,
-  or planning/recording a service rollout - and the GH Projects MCP tools
-  (ping, add_todo, list_projects, get_project_context, get_reentry_digest,
-  read_service_knowledge, write_service_knowledge) are available. Teaches when to
-  orient with the read tools before acting, how to propose human-gated follow-up
-  work with add_todo instead of writing to GitHub, and how to read/record service
-  runbooks. Do NOT trigger this for unrelated coding sessions.
+description: Use when working inside the GH Projects app's world - re-entering a project, triaging GitHub notifications, reviewing a PR you were asked to follow up on, or planning/recording a service rollout - and the GH Projects MCP tools (ping, add_todo, list_projects, get_project_context, get_reentry_digest, read_service_knowledge, write_service_knowledge) are available. Teaches when to orient with the read tools before acting, how to propose human-gated follow-up work with add_todo instead of writing to GitHub, and how to read/record service runbooks. Do NOT trigger this for unrelated coding sessions.
 ---
 
 # GH Projects MCP tools

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -114,15 +114,22 @@ Copilot discovers skills two ways:
 - **Repo-local** - when you run Copilot in a checkout of this repo, the
   `.github/skills/gh-projects/` skill is discovered automatically.
 - **User-global** - to make the skill available in *any* session (not just this repo),
-  copy the skill folder into your personal skills directory:
+  copy the skill into your personal skills directory. This form is safe to re-run to
+  update in place (it won't create a nested `gh-projects/gh-projects/`):
 
   ```bash
-  mkdir -p ~/.copilot/skills
-  cp -R .github/skills/gh-projects ~/.copilot/skills/gh-projects
+  mkdir -p ~/.copilot/skills/gh-projects
+  cp -R .github/skills/gh-projects/. ~/.copilot/skills/gh-projects/
   ```
 
+Note: keep the skill's frontmatter `description:` on a single line. Every skill the
+Copilot CLI loads here uses a single-line description, and multi-line YAML block scalars
+(`>-`) may be ignored - so a single line is the safe, compatible shape.
+
 After installing (or updating) the skill, **start a fresh Copilot session** so it picks
-up the change.
+up the change. Skill discovery happens in the Copilot CLI (it scans the skills directory
+when a session's CLI process starts and caches the result) - this is separate from the
+GH Projects app, which owns the MCP server described above.
 
 ---
 


### PR DESCRIPTION
Follow-up to #112 (issue #105).

## Problem
The `gh-projects` skill wasn't being registered by the Copilot app when installed into `~/.copilot/skills/`. The `description` in the SKILL.md frontmatter used a YAML block scalar (`description: >-` spanning multiple indented lines). Every skill the app actually loads uses a plain **single-line** `description:` string - the multi-line block scalar was the one structural difference from the working skills.

## Fix
Convert the `description` to a single line. Same text, no content change - just the frontmatter format.

## How I verified
- Enumerated the user's installed skills in `~/.copilot/skills/` (a symlink to their dotfiles). The skills the app loads (`web-artifacts-builder`, `manage-pr`, `docx`, etc.) all use a single-line `description:`; the `gh-projects` skill was the only one using a `>-` block scalar.
- Confirmed `gh-projects` is present in the skills dir and is NOT in `settings.json` `disabledSkills`, so disablement wasn't the cause.
- After the fix, re-validated the frontmatter parses as clean YAML (`name` + single-line `description`).

## Honest gap
No parse-error was surfaced in the app logs to pinpoint the block scalar as the definitive failure, and the app caches the skill list in a warm CLI process pool (so a fresh session / app restart is needed to re-scan regardless). But single-line matches every working skill and removes the one structural deviation, so it's the right fix either way.