### PR TITLE
Add electron to trustedDependencies so `bun install` fetches the binary

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -45,6 +45,7 @@
     },
   },
   "trustedDependencies": [
+    "electron",
     "onnxruntime-node",
     "protobufjs",
   ],

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "author": "robert-crandall",
   "license": "MIT",
   "trustedDependencies": [
+    "electron",
     "onnxruntime-node",
     "protobufjs"
   ],


### PR DESCRIPTION
## What & why

`electron` was missing from `trustedDependencies`. Bun ships a built-in default allowlist of trusted dependencies (electron is normally on it), but the moment a project declares its own `trustedDependencies` array, that array *replaces* the default allowlist instead of extending it. This project declared only `onnxruntime-node` and `protobufjs`, which silently dropped electron from the trusted set. So on a fresh `bun install`, electron's postinstall was skipped and the Electron binary was never downloaded.

The result: three electron-importing Vitest suites failed with `Electron failed to install correctly` until someone knew to run `bun run setup`, making a clean checkout look broken.

This fixes it at the right layer - the dependency-install trust metadata - by adding `electron` to `trustedDependencies` in both `package.json` and `bun.lock` (kept alphabetized). `bun.lock` carries its own copy of the list, so both files need the entry or `bun install --frozen-lockfile` (used by `prepackage` / CI) would see an out-of-sync lockfile.

Fixes #114

## How I verified it

All run locally on macOS with bun 1.3.13:

1. **Before (bug reproduced):** fresh `bun install` with the old config left `node_modules/electron/dist` and `node_modules/electron/path.txt` absent.
2. **After (`bun install`):** lockfile saved; `node_modules/electron/dist/Electron.app` present; `path.txt` = `Electron.app/Contents/MacOS/Electron`; `bun.lock` trustedDependencies now includes electron.
3. **Three previously-failing suites pass** without a separate `bun run setup`:
   - `src/main/copilot/github-source.test.ts`
   - `src/main/context/resolve-deps.test.ts`
   - `src/main/mcp-server/shim/entry.e2e.test.ts`
   
   Result: `Test Files 3 passed (3)`, `Tests 10 passed (10)`.
4. **Frozen-lockfile path** (what CI / `prepackage` use): removed `node_modules/electron`, ran `bun install --frozen-lockfile` -> exit 0 (lockfile accepted, no out-of-sync error), binary fetched again.

## Scope note

This makes the Electron binary available after `bun install`. It does **not** make plain `bun install` a full replacement for `bun run setup` - `better-sqlite3` still needs its Electron-ABI rebuild (`bun run rebuild`) and model provisioning is still separate. The three target suites don't import `better-sqlite3` directly, so the rebuild flow is out of scope here.