### PR TITLE
Add a UI to CRUD card.services on a project (#116)

### DIFF
--- a/src/renderer/src/components/RunbooksPanel.test.tsx
+++ b/src/renderer/src/components/RunbooksPanel.test.tsx
@@ -134,15 +134,19 @@ describe('RunbooksPanel', () => {
     expect(screen.queryByText(/No services on this project yet/i)).toBeNull()
   })
 
-  it('shows a card error when the card fails to load', async () => {
+  it('shows a card error inline but still renders runbooks when only the card fails', async () => {
     invoke.mockImplementation((channel: string) => {
       if (channel === 'resources:card-get') return Promise.reject(new Error('nope'))
-      if (channel === 'knowledge:list-for-project') return Promise.resolve([])
+      if (channel === 'knowledge:list-for-project') {
+        return Promise.resolve([rb({ service: 'web', status: 'ok', markdown: 'Hit /health.' })])
+      }
       return Promise.resolve(undefined)
     })
     render(<RunbooksPanel projectId={1} />)
     expect(await screen.findByText(/Couldn’t load this project’s card/i)).toBeTruthy()
+    // Editor is hidden (no card), but the runbooks that loaded fine still render.
     expect(screen.queryByLabelText('Add a service')).toBeNull()
+    expect(screen.getByText('Hit /health.', { exact: false })).toBeTruthy()
   })
 
   it('hides stale runbook cards when a later refresh fails', async () => {

--- a/src/renderer/src/components/RunbooksPanel.test.tsx
+++ b/src/renderer/src/components/RunbooksPanel.test.tsx
@@ -1,23 +1,67 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor, fireEvent } from '@testing-library/react'
-import type { ServiceRunbook } from '@shared/ipc-channels'
+import type { ProjectCard, ServiceRunbook } from '@shared/ipc-channels'
+import { normalizeServiceName } from '@shared/service-name'
 import { RunbooksPanel } from './RunbooksPanel'
 
 const invoke = vi.fn()
 const onKnowledgeUpdated = vi.fn(() => () => {})
 
+// Stateful mock: the card's services array is the source of truth. `knowledge:list-for-project`
+// either returns an explicit list or derives one runbook per (deduped) service so tests can
+// prove the upsert-then-reload path end to end.
+let cardServices: string[] = []
+let runbookList: ServiceRunbook[] | 'derive' = []
+let failRunbooks = false
+
+function makeCard(services: string[]): ProjectCard {
+  return { projectId: 1, purpose: '', repos: [], services, activeGoal: '', glossary: {}, updatedAt: '2026-07-10T00:00:00.000Z' }
+}
+
+function deriveRunbooks(services: string[]): ServiceRunbook[] {
+  const seen = new Set<string>()
+  const out: ServiceRunbook[] = []
+  for (const raw of services) {
+    const key = normalizeServiceName(raw)
+    if (key.length === 0 || seen.has(key)) continue
+    seen.add(key)
+    out.push({ service: raw, key, status: 'missing', reason: null, markdown: null, env: null, updatedAt: null, source: null })
+  }
+  return out
+}
+
 function setRunbooks(list: ServiceRunbook[]): void {
-  invoke.mockImplementation((channel: string) => {
-    if (channel === 'knowledge:list-for-project') return Promise.resolve(list)
-    return Promise.resolve(undefined)
-  })
+  runbookList = list
+}
+
+function setCardServices(services: string[]): void {
+  cardServices = services
+}
+
+function deriveMode(): void {
+  runbookList = 'derive'
 }
 
 beforeEach(() => {
   invoke.mockReset()
   onKnowledgeUpdated.mockClear()
-  setRunbooks([])
+  cardServices = []
+  runbookList = []
+  failRunbooks = false
+  invoke.mockImplementation((channel: string, ...args: unknown[]) => {
+    if (channel === 'resources:card-get') return Promise.resolve(makeCard(cardServices))
+    if (channel === 'resources:card-upsert') {
+      const patch = args[1] as { services?: string[] }
+      if (patch.services) cardServices = patch.services
+      return Promise.resolve(makeCard(cardServices))
+    }
+    if (channel === 'knowledge:list-for-project') {
+      if (failRunbooks) return Promise.reject(new Error('boom'))
+      return Promise.resolve(runbookList === 'derive' ? deriveRunbooks(cardServices) : runbookList)
+    }
+    return Promise.resolve(undefined)
+  })
   ;(globalThis as unknown as { window: Window }).window.electron = {
     ipc: { invoke },
     openExternal: vi.fn(() => Promise.resolve()),
@@ -39,35 +83,38 @@ function rb(partial: Partial<ServiceRunbook> & Pick<ServiceRunbook, 'service' | 
 }
 
 describe('RunbooksPanel', () => {
-  it('renders an empty state when the project has no services', async () => {
-    setRunbooks([])
+  it('shows the services editor and an empty hint when the project has no services', async () => {
     render(<RunbooksPanel projectId={1} />)
-    expect(await screen.findByText(/lists no services yet/i)).toBeTruthy()
+    expect(await screen.findByLabelText('Add a service')).toBeTruthy()
+    expect(screen.getByText(/No services on this project yet/i)).toBeTruthy()
   })
 
   it('renders a written runbook body and its metadata', async () => {
+    setCardServices(['web'])
     setRunbooks([
       rb({ service: 'web', status: 'ok', markdown: '# Health\n\nHit /health.', env: 'prod', source: 'copilot', updatedAt: '2026-07-09T00:00:00.000Z' }),
     ])
     render(<RunbooksPanel projectId={1} />)
-    expect(await screen.findByText('web')).toBeTruthy()
-    expect(screen.getByText(/Hit \/health\./)).toBeTruthy()
+    expect(await screen.findByText('Hit /health.', { exact: false })).toBeTruthy()
     expect(screen.getByText(/source: copilot/)).toBeTruthy()
   })
 
   it('shows a friendly note for a service with no runbook yet', async () => {
+    setCardServices(['payments-api'])
     setRunbooks([rb({ service: 'payments-api', status: 'missing' })])
     render(<RunbooksPanel projectId={1} />)
     expect(await screen.findByText(/No runbook yet/i)).toBeTruthy()
   })
 
   it('surfaces an invalid service name honestly', async () => {
+    setCardServices(['Bad Name'])
     setRunbooks([rb({ service: 'Bad Name', key: null, status: 'invalid', reason: 'Service must be a slug.' })])
     render(<RunbooksPanel projectId={1} />)
     expect(await screen.findByText(/Service must be a slug\./)).toBeTruthy()
   })
 
   it('reveals a runbook file on the reveal button', async () => {
+    setCardServices(['web'])
     setRunbooks([rb({ service: 'web', status: 'ok', markdown: 'body' })])
     render(<RunbooksPanel projectId={1} />)
     const revealBtn = await screen.findByTitle('Reveal file in Finder')
@@ -76,18 +123,54 @@ describe('RunbooksPanel', () => {
   })
 
   it('subscribes to knowledge updates', async () => {
-    setRunbooks([])
     render(<RunbooksPanel projectId={1} />)
     await waitFor(() => expect(onKnowledgeUpdated).toHaveBeenCalled())
   })
 
-  it('shows an error message (not the empty state) when the load fails', async () => {
+  it('shows a runbook error (not the empty hint) when the runbook list fails to load', async () => {
+    failRunbooks = true
+    render(<RunbooksPanel projectId={1} />)
+    expect(await screen.findByText(/Couldn’t load runbooks/i)).toBeTruthy()
+    expect(screen.queryByText(/No services on this project yet/i)).toBeNull()
+  })
+
+  it('shows a card error when the card fails to load', async () => {
     invoke.mockImplementation((channel: string) => {
-      if (channel === 'knowledge:list-for-project') return Promise.reject(new Error('boom'))
+      if (channel === 'resources:card-get') return Promise.reject(new Error('nope'))
+      if (channel === 'knowledge:list-for-project') return Promise.resolve([])
       return Promise.resolve(undefined)
     })
     render(<RunbooksPanel projectId={1} />)
-    expect(await screen.findByText(/Couldn’t load runbooks/i)).toBeTruthy()
-    expect(screen.queryByText(/lists no services yet/i)).toBeNull()
+    expect(await screen.findByText(/Couldn’t load this project’s card/i)).toBeTruthy()
+    expect(screen.queryByLabelText('Add a service')).toBeNull()
+  })
+
+  it('adds a service: upserts the card then reloads so the runbook appears', async () => {
+    deriveMode()
+    render(<RunbooksPanel projectId={1} />)
+    const input = await screen.findByLabelText('Add a service')
+    fireEvent.change(input, { target: { value: 'usersd' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }))
+
+    await waitFor(() => expect(invoke).toHaveBeenCalledWith('resources:card-upsert', 1, { services: ['usersd'] }))
+    // The reloaded runbook list now has an entry for the new service (unique "No runbook yet" copy).
+    expect(await screen.findByText(/No runbook yet/i)).toBeTruthy()
+  })
+
+  it('removes a service: upserts without it and drops the row, with no destructive file IPC', async () => {
+    setCardServices(['usersd'])
+    deriveMode()
+    render(<RunbooksPanel projectId={1} />)
+    expect(await screen.findByText(/No runbook yet/i)).toBeTruthy()
+
+    fireEvent.click(screen.getByLabelText('Remove usersd'))
+
+    await waitFor(() => expect(invoke).toHaveBeenCalledWith('resources:card-upsert', 1, { services: [] }))
+    await waitFor(() => expect(screen.queryByText(/No runbook yet/i)).toBeNull())
+
+    // Removal only edits the card list: no reveal/delete-style IPC was ever called.
+    const channels = invoke.mock.calls.map((c) => c[0])
+    expect(channels).not.toContain('knowledge:reveal')
+    expect(new Set(channels)).toEqual(new Set(['resources:card-get', 'knowledge:list-for-project', 'resources:card-upsert']))
   })
 })

--- a/src/renderer/src/components/RunbooksPanel.test.tsx
+++ b/src/renderer/src/components/RunbooksPanel.test.tsx
@@ -6,7 +6,7 @@ import { normalizeServiceName } from '@shared/service-name'
 import { RunbooksPanel } from './RunbooksPanel'
 
 const invoke = vi.fn()
-const onKnowledgeUpdated = vi.fn(() => () => {})
+const onKnowledgeUpdated = vi.fn((_callback: () => void) => () => {})
 
 // Stateful mock: the card's services array is the source of truth. `knowledge:list-for-project`
 // either returns an explicit list or derives one runbook per (deduped) service so tests can
@@ -143,6 +143,21 @@ describe('RunbooksPanel', () => {
     render(<RunbooksPanel projectId={1} />)
     expect(await screen.findByText(/Couldn’t load this project’s card/i)).toBeTruthy()
     expect(screen.queryByLabelText('Add a service')).toBeNull()
+  })
+
+  it('hides stale runbook cards when a later refresh fails', async () => {
+    setCardServices(['web'])
+    setRunbooks([rb({ service: 'web', status: 'ok', markdown: 'Hit /health.' })])
+    render(<RunbooksPanel projectId={1} />)
+    expect(await screen.findByText('Hit /health.', { exact: false })).toBeTruthy()
+
+    // A later out-of-band refresh fails: show the error, not the now-stale cards.
+    failRunbooks = true
+    const refresh = onKnowledgeUpdated.mock.calls[0]?.[0]
+    refresh?.()
+
+    expect(await screen.findByText(/Couldn’t load runbooks/i)).toBeTruthy()
+    await waitFor(() => expect(screen.queryByText('Hit /health.', { exact: false })).toBeNull())
   })
 
   it('adds a service: upserts the card then reloads so the runbook appears', async () => {

--- a/src/renderer/src/components/RunbooksPanel.tsx
+++ b/src/renderer/src/components/RunbooksPanel.tsx
@@ -183,7 +183,7 @@ export function RunbooksPanel({ projectId }: RunbooksPanelProps): JSX.Element {
         </div>
       )}
 
-      {runbooks.map((rb) => (
+      {loaded && !runbooksError && runbooks.map((rb) => (
         <RunbookCard key={rb.key ?? `invalid:${rb.service}`} rb={rb} />
       ))}
     </div>

--- a/src/renderer/src/components/RunbooksPanel.tsx
+++ b/src/renderer/src/components/RunbooksPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { BookOpen, FolderOpen, AlertTriangle } from 'lucide-react'
 import type { ProjectCard, ServiceRunbook } from '@shared/ipc-channels'
 import { normalizeServiceName } from '@shared/service-name'
@@ -67,6 +67,19 @@ export function RunbooksPanel({ projectId }: RunbooksPanelProps): JSX.Element {
   const [cardError, setCardError] = useState(false)
   const [runbooksError, setRunbooksError] = useState(false)
   const [saving, setSaving] = useState(false)
+  // Synchronous in-flight mutex: `saving` state drives the disabled UI but only updates on
+  // re-render, so it can't reliably reject a second call fired in the same tick. The ref does.
+  const savingRef = useRef(false)
+  // Guards against setState after the component unmounts (e.g. a fast project switch mid-load,
+  // since the parent remounts this component per project).
+  const mountedRef = useRef(true)
+
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+    }
+  }, [])
 
   // Load the card and the runbook list independently: a transient runbook read failure must
   // not hide the services editor when the card loaded fine (and vice versa).
@@ -75,6 +88,7 @@ export function RunbooksPanel({ projectId }: RunbooksPanelProps): JSX.Element {
       window.electron.ipc.invoke('resources:card-get', projectId),
       window.electron.ipc.invoke('knowledge:list-for-project', projectId),
     ])
+    if (!mountedRef.current) return
     if (cardResult.status === 'fulfilled') {
       setCard(cardResult.value ?? null)
       setCardError(false)
@@ -107,23 +121,26 @@ export function RunbooksPanel({ projectId }: RunbooksPanelProps): JSX.Element {
     }
   }, [load])
 
-  // Persist a new services array, then reload so runbooks appear/disappear live. The `saving`
-  // guard drops overlapping mutations so a stale services array can't clobber a newer one.
+  // Persist a new services array, then reload so runbooks appear/disappear live. The synchronous
+  // `savingRef` mutex drops overlapping mutations so a stale services array can't clobber a newer
+  // one even if two calls fire before a re-render disables the controls.
   const persistServices = useCallback(
     async (services: string[]): Promise<void> => {
-      if (saving) return
+      if (savingRef.current) return
+      savingRef.current = true
       setSaving(true)
       try {
         const updated = await window.electron.ipc.invoke('resources:card-upsert', projectId, { services })
-        setCard(updated ?? null)
+        if (mountedRef.current) setCard(updated ?? null)
         await load()
       } catch (err) {
         console.error('[Runbooks] card-upsert failed:', err)
       } finally {
-        setSaving(false)
+        savingRef.current = false
+        if (mountedRef.current) setSaving(false)
       }
     },
-    [projectId, saving, load]
+    [projectId, load]
   )
 
   const addService = useCallback(

--- a/src/renderer/src/components/RunbooksPanel.tsx
+++ b/src/renderer/src/components/RunbooksPanel.tsx
@@ -1,8 +1,10 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { BookOpen, FolderOpen, AlertTriangle } from 'lucide-react'
-import type { ServiceRunbook } from '@shared/ipc-channels'
+import type { ProjectCard, ServiceRunbook } from '@shared/ipc-channels'
+import { normalizeServiceName } from '@shared/service-name'
 import { Icon } from './Icon'
 import { LinkifiedText } from './LinkifiedText'
+import { ServicesEditor } from './ServicesEditor'
 import { fire } from '../ipc'
 import styles from './RunbooksPanel.module.css'
 
@@ -59,51 +61,111 @@ function RunbookCard({ rb }: { rb: ServiceRunbook }): JSX.Element {
 }
 
 export function RunbooksPanel({ projectId }: RunbooksPanelProps): JSX.Element {
+  const [card, setCard] = useState<ProjectCard | null>(null)
   const [runbooks, setRunbooks] = useState<ServiceRunbook[]>([])
   const [loaded, setLoaded] = useState(false)
-  const [error, setError] = useState(false)
+  const [cardError, setCardError] = useState(false)
+  const [runbooksError, setRunbooksError] = useState(false)
+  const [saving, setSaving] = useState(false)
+
+  // Load the card and the runbook list independently: a transient runbook read failure must
+  // not hide the services editor when the card loaded fine (and vice versa).
+  const load = useCallback(async (): Promise<void> => {
+    const [cardResult, runbooksResult] = await Promise.allSettled([
+      window.electron.ipc.invoke('resources:card-get', projectId),
+      window.electron.ipc.invoke('knowledge:list-for-project', projectId),
+    ])
+    if (cardResult.status === 'fulfilled') {
+      setCard(cardResult.value ?? null)
+      setCardError(false)
+    } else {
+      console.error('[Runbooks] card load failed:', cardResult.reason)
+      setCardError(true)
+    }
+    if (runbooksResult.status === 'fulfilled') {
+      setRunbooks(runbooksResult.value)
+      setRunbooksError(false)
+    } else {
+      console.error('[Runbooks] runbook load failed:', runbooksResult.reason)
+      setRunbooksError(true)
+    }
+  }, [projectId])
 
   useEffect(() => {
     let active = true
-    const load = async (): Promise<void> => {
-      try {
-        const list = await window.electron.ipc.invoke('knowledge:list-for-project', projectId)
-        if (active) {
-          setRunbooks(list)
-          setError(false)
-          setLoaded(true)
-        }
-      } catch (err) {
-        console.error('[Runbooks] load failed:', err)
-        if (active) {
-          setError(true)
-          setLoaded(true)
-        }
-      }
+    const run = async (): Promise<void> => {
+      await load()
+      if (active) setLoaded(true)
     }
-    void load()
+    void run()
+    // card-upsert fires no event, so this only reloads on out-of-band MCP knowledge writes;
+    // in-app card edits reload directly via the add/remove handlers below.
     const unsub = window.electron.onKnowledgeUpdated(() => { void load() })
     return () => {
       active = false
       unsub()
     }
-  }, [projectId])
+  }, [load])
 
-  if (loaded && error) {
-    return <div className={styles.empty}>Couldn’t load runbooks for this project. Try again in a moment.</div>
-  }
+  // Persist a new services array, then reload so runbooks appear/disappear live. The `saving`
+  // guard drops overlapping mutations so a stale services array can't clobber a newer one.
+  const persistServices = useCallback(
+    async (services: string[]): Promise<void> => {
+      if (saving) return
+      setSaving(true)
+      try {
+        const updated = await window.electron.ipc.invoke('resources:card-upsert', projectId, { services })
+        setCard(updated ?? null)
+        await load()
+      } catch (err) {
+        console.error('[Runbooks] card-upsert failed:', err)
+      } finally {
+        setSaving(false)
+      }
+    },
+    [projectId, saving, load]
+  )
 
-  if (loaded && runbooks.length === 0) {
-    return (
-      <div className={styles.empty}>
-        This project lists no services yet. Add services to the project card, then Copilot can keep a per-service
-        runbook (how to check health, monitor links, oncall notes).
-      </div>
-    )
+  const addService = useCallback(
+    (key: string): void => {
+      if (card === null) return
+      if (card.services.some((s) => normalizeServiceName(s) === key)) return
+      fire(persistServices([...card.services, key]), 'resources:card-upsert')
+    },
+    [card, persistServices]
+  )
+
+  const removeService = useCallback(
+    (key: string): void => {
+      if (card === null) return
+      const next = card.services.filter((s) => normalizeServiceName(s) !== key)
+      if (next.length === card.services.length) return
+      fire(persistServices(next), 'resources:card-upsert')
+    },
+    [card, persistServices]
+  )
+
+  if (loaded && cardError) {
+    return <div className={styles.empty}>Couldn’t load this project’s card. Try again in a moment.</div>
   }
 
   return (
     <div className={styles.panel}>
+      {card !== null && (
+        <ServicesEditor services={card.services} onAdd={addService} onRemove={removeService} busy={saving} />
+      )}
+
+      {loaded && runbooksError && (
+        <div className={styles.empty}>Couldn’t load runbooks for this project. Try again in a moment.</div>
+      )}
+
+      {loaded && !runbooksError && runbooks.length === 0 && (
+        <div className={styles.empty}>
+          No services on this project yet. Add one above and Copilot can keep a per-service runbook (how to check
+          health, monitor links, oncall notes).
+        </div>
+      )}
+
       {runbooks.map((rb) => (
         <RunbookCard key={rb.key ?? `invalid:${rb.service}`} rb={rb} />
       ))}

--- a/src/renderer/src/components/RunbooksPanel.tsx
+++ b/src/renderer/src/components/RunbooksPanel.tsx
@@ -162,21 +162,21 @@ export function RunbooksPanel({ projectId }: RunbooksPanelProps): JSX.Element {
     [card, persistServices]
   )
 
-  if (loaded && cardError) {
-    return <div className={styles.empty}>Couldn’t load this project’s card. Try again in a moment.</div>
-  }
-
   return (
     <div className={styles.panel}>
       {card !== null && (
         <ServicesEditor services={card.services} onAdd={addService} onRemove={removeService} busy={saving} />
       )}
 
+      {loaded && cardError && (
+        <div className={styles.empty}>Couldn’t load this project’s card. Try again in a moment.</div>
+      )}
+
       {loaded && runbooksError && (
         <div className={styles.empty}>Couldn’t load runbooks for this project. Try again in a moment.</div>
       )}
 
-      {loaded && !runbooksError && runbooks.length === 0 && (
+      {loaded && !cardError && !runbooksError && runbooks.length === 0 && (
         <div className={styles.empty}>
           No services on this project yet. Add one above and Copilot can keep a per-service runbook (how to check
           health, monitor links, oncall notes).

--- a/src/renderer/src/components/ServicesEditor.module.css
+++ b/src/renderer/src/components/ServicesEditor.module.css
@@ -1,0 +1,146 @@
+.editor {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px;
+  background: var(--bg-inset);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+}
+
+.addRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.addIcon {
+  color: var(--text-3);
+  flex: none;
+}
+
+.addInput {
+  flex: 1;
+  min-width: 0;
+  background: var(--bg-window);
+  border: 1px solid var(--border-muted);
+  border-radius: var(--radius);
+  outline: none;
+  padding: 5px 8px;
+  color: var(--text);
+  font-size: 13px;
+}
+
+.addInput:focus {
+  border-color: var(--text-3);
+}
+
+.addInput::placeholder {
+  color: var(--text-3);
+}
+
+.addInput:disabled {
+  opacity: 0.6;
+}
+
+.addButton {
+  flex: none;
+  padding: 5px 12px;
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--text);
+  background: var(--bg-window);
+  border: 1px solid var(--border-muted);
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: background 150ms, border-color 150ms;
+}
+
+.addButton:hover:not(:disabled) {
+  border-color: var(--text-3);
+}
+
+.addButton:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.preview {
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.preview code {
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: 11.5px;
+  color: var(--text);
+}
+
+.ok {
+  color: var(--text-3);
+}
+
+.dupe {
+  color: var(--text-2);
+}
+
+.error {
+  color: var(--danger, #cf222e);
+}
+
+.list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin: 2px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 4px 3px 10px;
+  font-size: 12.5px;
+  color: var(--text);
+  background: var(--bg-window);
+  border: 1px solid var(--border-muted);
+  border-radius: 999px;
+}
+
+.chipName {
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: 12px;
+}
+
+.removeBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  padding: 0;
+  color: var(--text-3);
+  background: none;
+  border: none;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background 150ms, color 150ms;
+}
+
+.removeBtn:hover:not(:disabled) {
+  color: var(--text);
+  background: var(--bg-inset);
+}
+
+.removeBtn:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.note {
+  margin: 2px 0 0;
+  font-size: 11.5px;
+  color: var(--text-3);
+}

--- a/src/renderer/src/components/ServicesEditor.test.tsx
+++ b/src/renderer/src/components/ServicesEditor.test.tsx
@@ -52,6 +52,15 @@ describe('ServicesEditor', () => {
     expect(onAdd).not.toHaveBeenCalled()
   })
 
+  it('surfaces "must not be empty" for whitespace-only input and blocks the add', () => {
+    const { onAdd } = renderEditor([])
+    typeService('   ')
+    expect(screen.getByText(/must not be empty/i)).toBeTruthy()
+    expect((screen.getByRole('button', { name: 'Add' }) as HTMLButtonElement).disabled).toBe(true)
+    fireEvent.keyDown(screen.getByLabelText('Add a service'), { key: 'Enter' })
+    expect(onAdd).not.toHaveBeenCalled()
+  })
+
   it('removes a service by its normalized key', () => {
     const { onRemove } = renderEditor(['payments-api'])
     fireEvent.click(screen.getByLabelText('Remove payments-api'))

--- a/src/renderer/src/components/ServicesEditor.test.tsx
+++ b/src/renderer/src/components/ServicesEditor.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { ServicesEditor } from './ServicesEditor'
+
+function renderEditor(services: string[], busy = false): { onAdd: ReturnType<typeof vi.fn>; onRemove: ReturnType<typeof vi.fn> } {
+  const onAdd = vi.fn()
+  const onRemove = vi.fn()
+  render(<ServicesEditor services={services} onAdd={onAdd} onRemove={onRemove} busy={busy} />)
+  return { onAdd, onRemove }
+}
+
+function typeService(value: string): HTMLInputElement {
+  const input = screen.getByLabelText('Add a service') as HTMLInputElement
+  fireEvent.change(input, { target: { value } })
+  return input
+}
+
+describe('ServicesEditor', () => {
+  it('adds a valid service with its normalized key and clears the input', () => {
+    const { onAdd } = renderEditor([])
+    const input = typeService('usersd')
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }))
+    expect(onAdd).toHaveBeenCalledTimes(1)
+    expect(onAdd).toHaveBeenCalledWith('usersd')
+    expect(input.value).toBe('')
+  })
+
+  it('normalizes case/whitespace: previews and adds the normalized key', () => {
+    const { onAdd } = renderEditor([])
+    typeService('  UsersD  ')
+    expect(screen.getByText('usersd')).toBeTruthy()
+    fireEvent.keyDown(screen.getByLabelText('Add a service'), { key: 'Enter' })
+    expect(onAdd).toHaveBeenCalledWith('usersd')
+  })
+
+  it('rejects an unsafe name with the returned reason and does not add', () => {
+    const { onAdd } = renderEditor([])
+    typeService('../etc')
+    expect(screen.getByText(/must not contain path separators/i)).toBeTruthy()
+    expect((screen.getByRole('button', { name: 'Add' }) as HTMLButtonElement).disabled).toBe(true)
+    fireEvent.keyDown(screen.getByLabelText('Add a service'), { key: 'Enter' })
+    expect(onAdd).not.toHaveBeenCalled()
+  })
+
+  it('dedupes by normalized key: an existing service (any case) blocks the add', () => {
+    const { onAdd } = renderEditor(['api'])
+    typeService('API')
+    expect(screen.getByText(/already on this project/i)).toBeTruthy()
+    expect((screen.getByRole('button', { name: 'Add' }) as HTMLButtonElement).disabled).toBe(true)
+    fireEvent.keyDown(screen.getByLabelText('Add a service'), { key: 'Enter' })
+    expect(onAdd).not.toHaveBeenCalled()
+  })
+
+  it('removes a service by its normalized key', () => {
+    const { onRemove } = renderEditor(['payments-api'])
+    fireEvent.click(screen.getByLabelText('Remove payments-api'))
+    expect(onRemove).toHaveBeenCalledWith('payments-api')
+  })
+
+  it('collapses duplicate raw entries to one row (deduped by normalized key)', () => {
+    renderEditor(['API', 'api'])
+    expect(screen.getAllByRole('listitem')).toHaveLength(1)
+  })
+
+  it('states that removing keeps the runbook file on disk', () => {
+    renderEditor(['api'])
+    expect(screen.getByText(/runbook file on disk is kept/i)).toBeTruthy()
+  })
+
+  it('disables the controls while a mutation is in flight', () => {
+    renderEditor(['api'], true)
+    expect((screen.getByLabelText('Add a service') as HTMLInputElement).disabled).toBe(true)
+    expect((screen.getByLabelText('Remove api') as HTMLButtonElement).disabled).toBe(true)
+  })
+})

--- a/src/renderer/src/components/ServicesEditor.test.tsx
+++ b/src/renderer/src/components/ServicesEditor.test.tsx
@@ -72,6 +72,15 @@ describe('ServicesEditor', () => {
     expect(screen.getAllByRole('listitem')).toHaveLength(1)
   })
 
+  it('keeps a legacy empty/whitespace entry detachable as a single "(empty)" row', () => {
+    const { onRemove } = renderEditor(['', '   '])
+    const rows = screen.getAllByRole('listitem')
+    expect(rows).toHaveLength(1)
+    expect(screen.getByText('(empty)')).toBeTruthy()
+    fireEvent.click(screen.getByLabelText('Remove (empty)'))
+    expect(onRemove).toHaveBeenCalledWith('')
+  })
+
   it('states that removing keeps the runbook file on disk', () => {
     renderEditor(['api'])
     expect(screen.getByText(/runbook file on disk is kept/i)).toBeTruthy()

--- a/src/renderer/src/components/ServicesEditor.tsx
+++ b/src/renderer/src/components/ServicesEditor.tsx
@@ -24,16 +24,19 @@ interface EditorRow {
 /**
  * Dedupe the card's services by normalized key (first occurrence wins), matching how
  * the runbook list collapses them. Keeps legacy/mixed-case/invalid entries visible so
- * they can be detached rather than silently hidden.
+ * they can be detached rather than silently hidden - including empty / whitespace-only
+ * entries (hand-edited into the DB), which collapse to a single "(empty)" row so the user
+ * can still clean them up.
  */
 function dedupeByKey(services: string[]): EditorRow[] {
   const seen = new Set<string>()
   const rows: EditorRow[] = []
   for (const raw of services) {
     const key = normalizeServiceName(raw)
-    if (key.length === 0 || seen.has(key)) continue
+    if (seen.has(key)) continue
     seen.add(key)
-    rows.push({ display: raw.trim(), key })
+    const display = raw.trim()
+    rows.push({ display: display.length > 0 ? display : '(empty)', key })
   }
   return rows
 }

--- a/src/renderer/src/components/ServicesEditor.tsx
+++ b/src/renderer/src/components/ServicesEditor.tsx
@@ -1,0 +1,124 @@
+import { useMemo, useState } from 'react'
+import { Plus, X } from 'lucide-react'
+import { normalizeServiceName, validateServiceName } from '@shared/service-name'
+import { Icon } from './Icon'
+import styles from './ServicesEditor.module.css'
+
+interface ServicesEditorProps {
+  /** The raw services on the project card (may hold legacy mixed-case / invalid values). */
+  services: string[]
+  /** Attach a validated, normalized service key to the card. */
+  onAdd: (key: string) => void
+  /** Detach a service (by normalized key) from the card. Does NOT delete its runbook file. */
+  onRemove: (key: string) => void
+  /** True while a card mutation is in flight; disables the controls. */
+  busy?: boolean
+}
+
+/** A service as shown in the editor list: its display form plus the key used to detach it. */
+interface EditorRow {
+  display: string
+  key: string
+}
+
+/**
+ * Dedupe the card's services by normalized key (first occurrence wins), matching how
+ * the runbook list collapses them. Keeps legacy/mixed-case/invalid entries visible so
+ * they can be detached rather than silently hidden.
+ */
+function dedupeByKey(services: string[]): EditorRow[] {
+  const seen = new Set<string>()
+  const rows: EditorRow[] = []
+  for (const raw of services) {
+    const key = normalizeServiceName(raw)
+    if (key.length === 0 || seen.has(key)) continue
+    seen.add(key)
+    rows.push({ display: raw.trim(), key })
+  }
+  return rows
+}
+
+/**
+ * The services editor for a project's Runbooks tab (#116). Presentational: owns only the
+ * add-input text and its live validation preview; all persistence happens in the parent via
+ * the `onAdd` / `onRemove` callbacks. Add uses the same `validateServiceName` gate as the
+ * write path, previews the normalized key, rejects unsafe names with the returned reason, and
+ * dedupes by normalized key. Remove detaches the service from the card only.
+ */
+export function ServicesEditor({ services, onAdd, onRemove, busy = false }: ServicesEditorProps): JSX.Element {
+  const [text, setText] = useState('')
+
+  const rows = useMemo(() => dedupeByKey(services), [services])
+  const existingKeys = useMemo(() => new Set(rows.map((r) => r.key)), [rows])
+
+  const trimmed = text.trim()
+  const validation = trimmed.length > 0 ? validateServiceName(text) : null
+  const isDuplicate = validation?.ok === true && existingKeys.has(validation.key)
+  const canAdd = !busy && validation?.ok === true && !isDuplicate
+
+  const submit = (): void => {
+    if (!canAdd || validation?.ok !== true) return
+    onAdd(validation.key)
+    setText('')
+  }
+
+  return (
+    <div className={styles.editor}>
+      <div className={styles.addRow}>
+        <Icon icon={Plus} size={15} className={styles.addIcon} />
+        <input
+          className={styles.addInput}
+          value={text}
+          placeholder="Add a service (e.g. payments-api)…"
+          aria-label="Add a service"
+          disabled={busy}
+          onChange={(e) => setText(e.target.value)}
+          onKeyDown={(e) => e.key === 'Enter' && submit()}
+        />
+        <button type="button" className={styles.addButton} onClick={submit} disabled={!canAdd}>
+          Add
+        </button>
+      </div>
+
+      {validation !== null && (
+        <div className={styles.preview}>
+          {validation.ok ? (
+            isDuplicate ? (
+              <span className={styles.dupe}>
+                <code>{validation.key}</code> is already on this project.
+              </span>
+            ) : (
+              <span className={styles.ok}>
+                Saved as <code>{validation.key}</code>
+              </span>
+            )
+          ) : (
+            <span className={styles.error}>{validation.reason}</span>
+          )}
+        </div>
+      )}
+
+      {rows.length > 0 && (
+        <ul className={styles.list}>
+          {rows.map((row) => (
+            <li key={row.key} className={styles.chip}>
+              <span className={styles.chipName}>{row.display}</span>
+              <button
+                type="button"
+                className={styles.removeBtn}
+                onClick={() => onRemove(row.key)}
+                disabled={busy}
+                aria-label={`Remove ${row.display}`}
+                title="Detach from this project (keeps the runbook file)"
+              >
+                <Icon icon={X} size={12} />
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <p className={styles.note}>Removing a service detaches it from this project. Its runbook file on disk is kept.</p>
+    </div>
+  )
+}

--- a/src/renderer/src/components/ServicesEditor.tsx
+++ b/src/renderer/src/components/ServicesEditor.tsx
@@ -51,8 +51,7 @@ export function ServicesEditor({ services, onAdd, onRemove, busy = false }: Serv
   const rows = useMemo(() => dedupeByKey(services), [services])
   const existingKeys = useMemo(() => new Set(rows.map((r) => r.key)), [rows])
 
-  const trimmed = text.trim()
-  const validation = trimmed.length > 0 ? validateServiceName(text) : null
+  const validation = text.length > 0 ? validateServiceName(text) : null
   const isDuplicate = validation?.ok === true && existingKeys.has(validation.key)
   const canAdd = !busy && validation?.ok === true && !isDuplicate
 


### PR DESCRIPTION
Closes #116

## What this does

Adds a renderer-only CRUD UI for a project card's `services` list on the **Runbooks tab**. Until now the renderer never called `resources:card-get` / `resources:card-upsert` (grep: zero refs), so `card.services` stayed `[]` and #100's per-service runbooks had nowhere to surface - you had to hand-edit SQLite to attach a service. This wires the existing typed IPC to a small editor.

- **Add**: text input validated + normalized through the shared `validateServiceName` / `normalizeServiceName` in `src/shared/service-name.ts` - the exact gate the write path uses. Shows the normalized key as a "saved as" preview, rejects unsafe names (path separators, `..`, leading dot, empty, non-slug) with the returned reason, and dedupes by normalized key.
- **Remove**: detaches the service from the card list. It does **not** delete the on-disk runbook file - the UI copy says so explicitly ("Its runbook file on disk is kept.") so it isn't mistaken for a destructive delete.
- **Rename**: is just remove + add (a rename that changes the normalized key points at a different runbook file, which is expected).
- **Persist**: via `resources:card-upsert(projectId, { services })`, then reload `knowledge:list-for-project` so runbooks appear/disappear live. `card-upsert` broadcasts no event, so the renderer reloads itself after the upsert.

### Design notes

- `RunbooksPanel` owns the card + runbook state and all IPC; a new presentational `ServicesEditor` owns only the input text and its live validation, calling `onAdd(normalizedKey)` / `onRemove(normalizedKey)`. No IPC in the child.
- The stored service value is the **normalized key** (validate returns it), so `service === key` and there's no display-vs-file drift (the runbook file is already the lowercased key).
- A `saving` guard + disabled controls stop overlapping mutations from sending a stale services array.
- Card and runbook list load with `Promise.allSettled` and independent error state, so a transient runbook-list read failure doesn't hide the editor when the card loaded fine.
- Legacy/mixed-case/invalid services written directly to SQLite stay visible and detachable (list deduped by normalized key; removal filters by normalized-key equality so all collapsed duplicates go).

### Out of scope

The card's `purpose` / `repos` / `activeGoal` / `glossary` have the same "backend exists, no UI" gap. Per #116 this PR is just `services` to unblock the runbook surface; a general card editor can follow the same pattern later.

## How I verified

- `bun run test` (typecheck + eslint + Vitest) - **green: 71 files, 695 tests**.
- New `ServicesEditor.test.tsx` (unit, RTL): valid add calls `onAdd` with the normalized key and clears the input; case/whitespace is normalized in the preview and the added key; an unsafe name (`../etc`) is rejected with the reason and never calls `onAdd`; dedup by normalized key (`API` when `api` is present) blocks the add; remove calls `onRemove` with the key; duplicate raw entries collapse to one row; the "runbook file on disk is kept" copy is present; `busy` disables the controls.
- Extended `RunbooksPanel.test.tsx` (integration, RTL with a stateful mocked IPC where the card's services array is the source of truth and the runbook list is derived from it):
  - **Add path**: typing a service and clicking Add calls `resources:card-upsert` with `{ services: ['usersd'] }`, and after the reload the new runbook row appears - it only appears if the post-upsert reload actually happened, so this proves the upsert-then-reload behavior rather than being tautological.
  - **Remove path**: detaching calls `card-upsert` with the key filtered out, the row drops, and the only IPC channels touched are `resources:card-get` / `resources:card-upsert` / `knowledge:list-for-project` - no `knowledge:reveal` or any delete-style call - which is the strongest renderer-level evidence for "removing does not delete the runbook file" (there is no file-delete IPC path at all).
  - Independent error states: a runbook-list load failure shows the runbook error (not the empty hint) while the editor still renders; a card-get failure shows a card error and hides the editor.
- Plan and implementation both reviewed by an independent model (GPT-5.5) to completion: plan verdict "sound"; implementation verdict "ready to merge" (it independently re-ran typecheck, lint, and the full suite).

### Honest gap

A full click-through in the packaged Electron app isn't automated - I didn't launch the built `.dmg` and drive it by hand. The behavior is covered by the component + integration tests above, which exercise the real validation module and the real upsert-then-reload control flow through a mocked IPC boundary.