### PR TITLE
Observe directly-opened desktop-app sessions (persistent WS observer + on-disk reconcile)

### DIFF
--- a/db/migrations/021_copilot_app_sessions_observed.sql
+++ b/db/migrations/021_copilot_app_sessions_observed.sql
@@ -1,0 +1,22 @@
+-- Migration: 021_copilot_app_sessions_observed.sql
+-- #119: observe sessions opened DIRECTLY in the Copilot desktop app.
+--
+-- Until now every row in copilot_app_sessions was a session GH Projects itself
+-- launched over the WS (origin implicitly "launched"). #119 adds sessions the
+-- user opened directly in the app, reconciled read-only from the app's on-disk
+-- session-state store. Two columns distinguish and sticky-assign them:
+--   - origin: 'launched' (Projects created it) vs 'observed' (we found it). The
+--     reconciler never downgrades a launched row to observed.
+--   - pinned_project_id: sticky manual/auto assignment, mirroring the semantics
+--     copilot_sessions already uses for cloud tasks, so an observed session that
+--     resolves to a project stays put across reconciles and manual assignment
+--     wins. ON DELETE SET NULL is a backstop for hard deletes.
+--
+-- Existing rows are all Projects-launched, so origin defaults to 'launched'.
+
+ALTER TABLE copilot_app_sessions
+  ADD COLUMN origin TEXT NOT NULL DEFAULT 'launched'
+    CHECK (origin IN ('launched', 'observed'));
+
+ALTER TABLE copilot_app_sessions
+  ADD COLUMN pinned_project_id INTEGER REFERENCES projects(id) ON DELETE SET NULL;

--- a/src/main/agent/copilot-app/delegate.test.ts
+++ b/src/main/agent/copilot-app/delegate.test.ts
@@ -23,7 +23,8 @@ const payload: DelegatePayload = {
 
 const appSession: CopilotAppSession = {
   id: 'app-1', projectId: 1, cwd: '/repos/foo', title: 'do the thing',
-  status: 'in_progress', repoOwner: 'me', repoName: 'foo', createdAt: '', updatedAt: '',
+  status: 'in_progress', repoOwner: 'me', repoName: 'foo', origin: 'launched',
+  pinnedProjectId: null, createdAt: '', updatedAt: '',
 }
 const cloudSession: CopilotSession = {
   id: 'cloud-1', projectId: 1, source: 'github', status: 'in_progress', title: 'do the thing',

--- a/src/main/agent/copilot-app/observe.ts
+++ b/src/main/agent/copilot-app/observe.ts
@@ -1,0 +1,57 @@
+/**
+ * Controller for the directly-opened-session observer (#119).
+ *
+ * Owns a single `SessionObserver` for the main process and ties its lifecycle to
+ * the `copilot_app_observe_enabled` setting. index.ts calls `initObserving` once
+ * at startup and `setObserveEnabled` when the Settings toggle changes; everything
+ * else (WS, reconciler, timers) is encapsulated in the observer, so turning the
+ * setting off tears the whole pipeline down.
+ */
+
+import { getAppObserveEnabled, setAppObserveEnabled } from './settings'
+import { SessionObserver, createSessionObserver } from './observer'
+
+let observer: SessionObserver | null = null
+let onChanged: (() => void) | null = null
+
+/**
+ * Wire up observing at startup. `notifyChanged` is invoked whenever a reconcile
+ * actually changes something (the caller broadcasts `copilot:updated`). Starts the
+ * observer only when the setting is enabled (default on).
+ */
+export function initObserving(notifyChanged: () => void): void {
+  onChanged = notifyChanged
+  if (getAppObserveEnabled()) startObserver()
+}
+
+function startObserver(): void {
+  if (observer !== null || onChanged === null) return
+  observer = createSessionObserver(onChanged)
+  observer.start()
+}
+
+function stopObserver(): void {
+  if (observer === null) return
+  observer.stop()
+  observer = null
+}
+
+/**
+ * Persist the observe setting and start/stop the observer to match. Safe to call
+ * before `initObserving` (it persists; the observer starts once wired).
+ */
+export function setObserveEnabled(enabled: boolean): void {
+  setAppObserveEnabled(enabled)
+  if (enabled) startObserver()
+  else stopObserver()
+}
+
+/** Stop the observer (used on app shutdown). */
+export function shutdownObserving(): void {
+  stopObserver()
+}
+
+/** Test/diagnostic hook: is the observer currently running? */
+export function isObserving(): boolean {
+  return observer !== null
+}

--- a/src/main/agent/copilot-app/observer.integration.test.ts
+++ b/src/main/agent/copilot-app/observer.integration.test.ts
@@ -248,6 +248,31 @@ describe('SessionObserver — live WS drives the reconciler', () => {
     expect(reads).toBeGreaterThanOrEqual(3)
   })
 
+  it('a full reconcile does not drop a queued session_event for an old (unlisted) session', async () => {
+    server = await startServer()
+    const b = makeBackend()
+    b.knownRepos.add('me/old')
+    // NOT in listed → the recency-bounded full scan can't cover it; only the
+    // targeted reconcileOne can. A larger debounce lets the session_event land in
+    // the SAME drain window as the server_hello-triggered full reconcile.
+    b.files.set('sOld', () => yaml('sOld', 'me/old'))
+
+    observer = new SessionObserver({
+      discover: () => endpointFor(server as FakeServer),
+      connect: createWsConnector(),
+      reconcile: b.deps,
+      onChanged: vi.fn(),
+      timing: { ...FAST, debounceMs: 60 },
+    })
+    observer.start()
+    await waitFor(() => server?.connectionCount() === 1)
+    // server_hello has set fullPending; queue the old id in the same window.
+    server.broadcast({ type: 'session_event', session_id: 'sOld', event: { type: 'assistant.turn_start' } })
+
+    await waitFor(() => b.store.has('sOld'))
+    expect(b.store.get('sOld')?.repoName).toBe('old')
+  })
+
   it('stop() halts ingestion and reconnection', async () => {
     server = await startServer()
     const b = makeBackend()

--- a/src/main/agent/copilot-app/observer.integration.test.ts
+++ b/src/main/agent/copilot-app/observer.integration.test.ts
@@ -1,0 +1,280 @@
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { WebSocketServer, type WebSocket as WsSocket } from 'ws'
+import type { AddressInfo } from 'node:net'
+import type { CopilotAppSession } from '../../../shared/ipc-channels'
+import { SessionObserver, type ObserverTiming } from './observer'
+import { createWsConnector } from './observer'
+import type { ReconcileDeps, ReconcileFs } from './reconcile'
+import type { WsEndpoint } from './discover'
+import { buildAppSessionDeepLink } from './delegate'
+
+// ── Fake desktop-app WS server ───────────────────────────────────────────────
+
+interface FakeServer {
+  port: number
+  connectionCount: () => number
+  sockets: () => WsSocket[]
+  /** Send a frame to every connected socket. */
+  broadcast: (frame: object) => void
+  /** Drop all current sockets (simulates the app relaunching). */
+  dropAll: () => void
+  close: () => Promise<void>
+}
+
+function startServer(opts: { sendHello?: boolean } = {}): Promise<FakeServer> {
+  const sendHello = opts.sendHello ?? true
+  return new Promise((resolve) => {
+    const wss = new WebSocketServer({ port: 0 })
+    const live = new Set<WsSocket>()
+    let count = 0
+    wss.on('connection', (socket) => {
+      count++
+      live.add(socket)
+      socket.on('close', () => live.delete(socket))
+      if (sendHello) socket.send(JSON.stringify({ type: 'server_hello', instance_id: 'i1' }))
+    })
+    wss.on('listening', () => {
+      const port = (wss.address() as AddressInfo).port
+      resolve({
+        port,
+        connectionCount: () => count,
+        sockets: () => [...live],
+        broadcast: (frame) => {
+          for (const s of live) s.send(JSON.stringify(frame))
+        },
+        dropAll: () => {
+          for (const s of live) s.terminate()
+          live.clear()
+        },
+        close: () =>
+          new Promise<void>((r) => {
+            for (const s of wss.clients) {
+              try {
+                s.terminate()
+              } catch {
+                /* ignore */
+              }
+            }
+            const done = setTimeout(r, 1000)
+            wss.close(() => {
+              clearTimeout(done)
+              r()
+            })
+          }),
+      })
+    })
+  })
+}
+
+// ── In-memory reconcile backend (no SQL — keeps the observer test focused) ────
+
+interface MemBackend {
+  fs: ReconcileFs
+  deps: ReconcileDeps
+  store: Map<string, CopilotAppSession>
+  /** id → workspace.yaml text (or a function returning it, for flush-race tests). */
+  files: Map<string, () => string | null>
+  /** ids surfaced by listSessions (the "recent" set). */
+  listed: Set<string>
+  knownRepos: Set<string>
+}
+
+function makeBackend(): MemBackend {
+  const store = new Map<string, CopilotAppSession>()
+  const files = new Map<string, () => string | null>()
+  const listed = new Set<string>()
+  const knownRepos = new Set<string>()
+
+  const fs: ReconcileFs = {
+    listSessions: () => [...listed].map((id) => ({ id, mtimeMs: 1000 })),
+    readWorkspaceYaml: (id) => files.get(id)?.() ?? null,
+  }
+  const deps: ReconcileDeps = {
+    fs,
+    now: () => 2000,
+    resolveProject: (owner, repo) => (knownRepos.has(`${owner}/${repo}`) ? 1 : null),
+    getExisting: (id) => store.get(id) ?? null,
+    upsertObserved: (input) => {
+      const existing = store.get(input.id)
+      const session: CopilotAppSession = {
+        id: input.id,
+        projectId: input.projectId,
+        cwd: input.cwd,
+        title: input.title,
+        status: 'unknown',
+        repoOwner: input.repoOwner,
+        repoName: input.repoName,
+        origin: existing?.origin ?? 'observed',
+        pinnedProjectId: existing?.pinnedProjectId ?? null,
+        createdAt: existing?.createdAt ?? 'now',
+        updatedAt: 'now',
+      }
+      store.set(input.id, session)
+      return session
+    },
+  }
+  return { fs, deps, store, files, listed, knownRepos }
+}
+
+function yaml(id: string, repository: string): string {
+  return `id: ${id}\ncwd: /repos/${id}\nrepository: ${repository}`
+}
+
+const FAST: ObserverTiming = {
+  debounceMs: 5,
+  reconnectBaseMs: 10,
+  reconnectMaxMs: 40,
+  periodicMs: 100_000, // effectively off during a test
+  missRetryMs: [5, 10, 20],
+}
+
+async function waitFor(pred: () => boolean, timeoutMs = 2000): Promise<void> {
+  const start = Date.now()
+  while (!pred()) {
+    if (Date.now() - start > timeoutMs) throw new Error('waitFor timed out')
+    await new Promise((r) => setTimeout(r, 5))
+  }
+}
+
+let server: FakeServer | null = null
+let observer: SessionObserver | null = null
+afterEach(async () => {
+  observer?.stop()
+  observer = null
+  if (server) {
+    await server.close()
+    server = null
+  }
+})
+
+function endpointFor(s: FakeServer): WsEndpoint {
+  return { port: s.port, token: 'rotating-token' }
+}
+
+describe('SessionObserver — live WS drives the reconciler', () => {
+  it('ingests known on-disk sessions via the initial full reconcile', async () => {
+    server = await startServer()
+    const b = makeBackend()
+    b.knownRepos.add('me/foo')
+    b.listed.add('s1')
+    b.files.set('s1', () => yaml('s1', 'me/foo'))
+
+    const onChanged = vi.fn()
+    observer = new SessionObserver({
+      discover: () => endpointFor(server as FakeServer),
+      connect: createWsConnector(),
+      reconcile: b.deps,
+      onChanged,
+      timing: FAST,
+    })
+    observer.start()
+
+    await waitFor(() => b.store.has('s1'))
+    expect(b.store.get('s1')?.origin).toBe('observed')
+    expect(onChanged).toHaveBeenCalled()
+    // The captured id yields a valid deep link (link-back works).
+    expect(buildAppSessionDeepLink('s1')).toBe('github-app://sessions/s1')
+  })
+
+  it('ingests a session announced only via a WS session_event (not on the recent list)', async () => {
+    server = await startServer()
+    const b = makeBackend()
+    b.knownRepos.add('me/bar')
+    // NOT in listed → the full scan won't find it; only the session_event can.
+    b.files.set('s2', () => yaml('s2', 'me/bar'))
+
+    observer = new SessionObserver({
+      discover: () => endpointFor(server as FakeServer),
+      connect: createWsConnector(),
+      reconcile: b.deps,
+      onChanged: vi.fn(),
+      timing: FAST,
+    })
+    observer.start()
+    await waitFor(() => server?.connectionCount() === 1)
+    server.broadcast({ type: 'session_event', session_id: 's2', event: { type: 'assistant.turn_start' } })
+
+    await waitFor(() => b.store.has('s2'))
+    expect(b.store.get('s2')?.repoName).toBe('bar')
+  })
+
+  it('reconnects and re-reads the endpoint after the app drops the socket', async () => {
+    server = await startServer()
+    const b = makeBackend()
+    let discoverCalls = 0
+
+    observer = new SessionObserver({
+      discover: () => {
+        discoverCalls++
+        return endpointFor(server as FakeServer)
+      },
+      connect: createWsConnector(),
+      reconcile: b.deps,
+      onChanged: vi.fn(),
+      timing: FAST,
+    })
+    observer.start()
+    await waitFor(() => server?.connectionCount() === 1)
+    const callsAfterFirst = discoverCalls
+
+    // App relaunch: drop the socket. The observer must re-discover (fresh token) + reconnect.
+    server.dropAll()
+    await waitFor(() => (server?.connectionCount() ?? 0) >= 2)
+    expect(discoverCalls).toBeGreaterThan(callsAfterFirst)
+  })
+
+  it('retries a not-yet-flushed workspace.yaml until it appears (flush race)', async () => {
+    server = await startServer()
+    const b = makeBackend()
+    b.knownRepos.add('me/baz')
+    let reads = 0
+    b.files.set('s3', () => {
+      reads++
+      return reads >= 3 ? yaml('s3', 'me/baz') : null // missing on the first two reads
+    })
+
+    observer = new SessionObserver({
+      discover: () => endpointFor(server as FakeServer),
+      connect: createWsConnector(),
+      reconcile: b.deps,
+      onChanged: vi.fn(),
+      timing: FAST,
+    })
+    observer.start()
+    await waitFor(() => server?.connectionCount() === 1)
+    server.broadcast({ type: 'session_event', session_id: 's3', event: { type: 'tool.execution_complete' } })
+
+    await waitFor(() => b.store.has('s3'))
+    expect(reads).toBeGreaterThanOrEqual(3)
+  })
+
+  it('stop() halts ingestion and reconnection', async () => {
+    server = await startServer()
+    const b = makeBackend()
+    b.knownRepos.add('me/foo')
+    b.files.set('s4', () => yaml('s4', 'me/foo'))
+
+    let discoverCalls = 0
+    observer = new SessionObserver({
+      discover: () => {
+        discoverCalls++
+        return endpointFor(server as FakeServer)
+      },
+      connect: createWsConnector(),
+      reconcile: b.deps,
+      onChanged: vi.fn(),
+      timing: FAST,
+    })
+    observer.start()
+    await waitFor(() => server?.connectionCount() === 1)
+    observer.stop()
+    const callsAtStop = discoverCalls
+
+    // A post-stop event must be ignored, and no further reconnect/discover happens.
+    server.broadcast({ type: 'session_event', session_id: 's4', event: { type: 'assistant.turn_start' } })
+    server.dropAll()
+    await new Promise((r) => setTimeout(r, 100))
+    expect(b.store.has('s4')).toBe(false)
+    expect(discoverCalls).toBe(callsAtStop)
+  })
+})

--- a/src/main/agent/copilot-app/observer.ts
+++ b/src/main/agent/copilot-app/observer.ts
@@ -256,10 +256,17 @@ export class SessionObserver {
     if (gen !== this.generation || !this.running) return
     let changed = false
 
-    if (this.fullPending) {
-      // A full reconcile subsumes every queued per-id request.
-      this.fullPending = false
-      this.pendingIds.clear()
+    // Snapshot both queues up front. A pending full reconcile does NOT discard
+    // queued per-id requests: reconcileRecent is recency/cap-bounded, but a
+    // session_event can name an OLD-but-active session that the bounded scan
+    // won't cover, and reconcileOne is the only path that ingests it. Running
+    // both is safe — reconcileOne is idempotent, so any overlap is a cheap no-op.
+    const doFull = this.fullPending
+    this.fullPending = false
+    const ids = [...this.pendingIds]
+    this.pendingIds.clear()
+
+    if (doFull) {
       try {
         const summary = reconcileRecent(this.reconcile)
         this.log(formatReconcileSummary(summary))
@@ -267,13 +274,9 @@ export class SessionObserver {
       } catch (err) {
         this.log(`full reconcile failed: ${err instanceof Error ? err.name : 'error'}`)
       }
-    } else {
-      const ids = [...this.pendingIds]
-      this.pendingIds.clear()
-      for (const id of ids) {
-        const outcome = this.runOne(gen, id)
-        if (outcome === 'changed') changed = true
-      }
+    }
+    for (const id of ids) {
+      if (this.runOne(gen, id) === 'changed') changed = true
     }
 
     if (changed) this.onChanged()

--- a/src/main/agent/copilot-app/observer.ts
+++ b/src/main/agent/copilot-app/observer.ts
@@ -1,0 +1,327 @@
+/**
+ * Persistent WS observer for directly-opened desktop-app sessions (#119).
+ *
+ * DISTINCT from the one-shot delegate client (client.ts): this keeps a single
+ * long-lived listener on the desktop app's local WebSocket. The app emits
+ * `session_event` "for ALL sessions", but the spike proved those frames carry
+ * only a `session_id` — no cwd. So the observer's job is purely LIVENESS: when a
+ * session shows activity, it triggers the on-disk reconciler (reconcile.ts) to map
+ * that id → repo → project. All the mapping/storage lives in the reconciler; the
+ * observer is a trigger plus a durable periodic backstop.
+ *
+ * Lifecycle / safety (per the #119 review):
+ *   - `discoverWsEndpoint()` is re-read on EVERY (re)connect (the token rotates per
+ *     app launch and is never logged or thrown).
+ *   - `server_hello` marks a STABLE connection: backoff resets THERE (not on socket
+ *     open) and a full reconcile is requested.
+ *   - reconnect uses capped exponential backoff; when the app is closed
+ *     (discover → null) it just retries quietly.
+ *   - `stop()` disables the ENTIRE pipeline — socket, reconnect, periodic scan,
+ *     debounce, and miss-retry timers — and bumps a generation token so any
+ *     already-scheduled callback becomes a no-op. Toggling the feature off stops
+ *     both WS-triggered and disk-scan-triggered ingestion.
+ *   - reconcile work is synchronous (better-sqlite3 + sync fs reads), so there's no
+ *     async overlap; a burst of events is debounced into one drain, and a pending
+ *     full reconcile subsumes queued per-id requests.
+ */
+
+import WebSocket from 'ws'
+import { parseFrame } from './protocol'
+import { discoverWsEndpoint, type WsEndpoint } from './discover'
+import {
+  reconcileOne,
+  reconcileRecent,
+  createReconcileDeps,
+  formatReconcileSummary,
+  type ReconcileDeps,
+} from './reconcile'
+
+/** A minimal socket the observer drives (injectable so tests can use a fake server). */
+export interface ObserverSocket {
+  onOpen(cb: () => void): void
+  onMessage(cb: (raw: string) => void): void
+  onClose(cb: () => void): void
+  onError(cb: (err: Error) => void): void
+  close(): void
+}
+
+export type WsConnector = (endpoint: WsEndpoint) => ObserverSocket
+
+export interface ObserverTiming {
+  /** Debounce before draining queued per-id reconciles. Default 200ms. */
+  debounceMs: number
+  /** First reconnect delay; doubles per failure up to reconnectMaxMs. Default 1000ms. */
+  reconnectBaseMs: number
+  /** Cap on the reconnect backoff. Default 30000ms. */
+  reconnectMaxMs: number
+  /** Periodic full-reconcile backstop interval. Default 90000ms. */
+  periodicMs: number
+  /** Retry schedule (ms) for a session whose workspace.yaml isn't flushed yet. */
+  missRetryMs: number[]
+}
+
+export const DEFAULT_TIMING: ObserverTiming = {
+  debounceMs: 200,
+  reconnectBaseMs: 1000,
+  reconnectMaxMs: 30000,
+  periodicMs: 90000,
+  missRetryMs: [250, 1000, 5000],
+}
+
+export interface ObserverDeps {
+  discover: () => WsEndpoint | null
+  connect: WsConnector
+  reconcile: ReconcileDeps
+  /** Called after a reconcile actually changed something (controller broadcasts). */
+  onChanged: () => void
+  timing?: Partial<ObserverTiming>
+  /** Token-safe logger (defaults to console.warn). */
+  log?: (msg: string) => void
+}
+
+/** Build the WS URL. Kept local so the token never lands in a log or error. */
+function buildUrl(endpoint: WsEndpoint): string {
+  return `ws://127.0.0.1:${endpoint.port}/?token=${encodeURIComponent(endpoint.token)}`
+}
+
+/** Production WS connector over the `ws` package (no Origin header — the non-browser gate). */
+export function createWsConnector(): WsConnector {
+  return (endpoint) => {
+    const ws = new WebSocket(buildUrl(endpoint))
+    return {
+      onOpen: (cb) => ws.on('open', cb),
+      onMessage: (cb) => ws.on('message', (data: WebSocket.RawData) => cb(data.toString())),
+      onClose: (cb) => ws.on('close', () => cb()),
+      onError: (cb) => ws.on('error', (err: Error) => cb(err)),
+      close: () => {
+        try {
+          ws.close()
+        } catch {
+          /* already closing */
+        }
+      },
+    }
+  }
+}
+
+export class SessionObserver {
+  private readonly discover: () => WsEndpoint | null
+  private readonly connect: WsConnector
+  private readonly reconcile: ReconcileDeps
+  private readonly onChanged: () => void
+  private readonly timing: ObserverTiming
+  private readonly log: (msg: string) => void
+
+  private running = false
+  /** Bumped on every start()/stop(); scheduled callbacks capture it and bail if it moved. */
+  private generation = 0
+
+  private socket: ObserverSocket | null = null
+  /** Guards against onError + onClose both scheduling a reconnect for one connection. */
+  private connectionSettled = false
+  private backoffMs: number
+
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null
+  private debounceTimer: ReturnType<typeof setTimeout> | null = null
+  private periodicTimer: ReturnType<typeof setInterval> | null = null
+  private readonly retryTimers = new Set<ReturnType<typeof setTimeout>>()
+
+  private readonly pendingIds = new Set<string>()
+  private fullPending = false
+  private readonly missAttempts = new Map<string, number>()
+
+  constructor(deps: ObserverDeps) {
+    this.discover = deps.discover
+    this.connect = deps.connect
+    this.reconcile = deps.reconcile
+    this.onChanged = deps.onChanged
+    this.timing = { ...DEFAULT_TIMING, ...(deps.timing ?? {}) }
+    this.log = deps.log ?? ((msg) => console.warn(`[copilot/observe] ${msg}`))
+    this.backoffMs = this.timing.reconnectBaseMs
+  }
+
+  /** Start observing. Idempotent. Runs an initial reconcile even if the app is closed. */
+  start(): void {
+    if (this.running) return
+    this.running = true
+    const gen = ++this.generation
+    this.backoffMs = this.timing.reconnectBaseMs
+    // Surface recently-opened sessions immediately, independent of the WS.
+    this.requestFullReconcile()
+    this.periodicTimer = setInterval(() => this.requestFullReconcile(), this.timing.periodicMs)
+    this.openConnection(gen)
+  }
+
+  /** Stop observing and tear down every timer/socket. Idempotent. */
+  stop(): void {
+    if (!this.running) return
+    this.running = false
+    this.generation++ // invalidate all in-flight callbacks
+    if (this.reconnectTimer !== null) clearTimeout(this.reconnectTimer)
+    if (this.debounceTimer !== null) clearTimeout(this.debounceTimer)
+    if (this.periodicTimer !== null) clearInterval(this.periodicTimer)
+    for (const t of this.retryTimers) clearTimeout(t)
+    this.retryTimers.clear()
+    this.reconnectTimer = null
+    this.debounceTimer = null
+    this.periodicTimer = null
+    this.pendingIds.clear()
+    this.missAttempts.clear()
+    this.fullPending = false
+    if (this.socket !== null) {
+      this.socket.close()
+      this.socket = null
+    }
+  }
+
+  // ── WS connection ───────────────────────────────────────────────────────────
+
+  private openConnection(gen: number): void {
+    if (gen !== this.generation) return
+    const endpoint = this.discover()
+    if (endpoint === null) {
+      // App not running — retry quietly on the backoff schedule.
+      this.scheduleReconnect(gen)
+      return
+    }
+    this.connectionSettled = false
+    let socket: ObserverSocket
+    try {
+      socket = this.connect(endpoint)
+    } catch {
+      this.scheduleReconnect(gen)
+      return
+    }
+    this.socket = socket
+    socket.onMessage((raw) => this.handleMessage(gen, raw))
+    socket.onClose(() => this.onDisconnect(gen))
+    socket.onError(() => this.onDisconnect(gen))
+  }
+
+  private handleMessage(gen: number, raw: string): void {
+    if (gen !== this.generation) return
+    const frame = parseFrame(raw)
+    if (frame.kind === 'server_hello') {
+      // Stable connection: reset backoff and catch anything opened while we were away.
+      this.backoffMs = this.timing.reconnectBaseMs
+      this.requestFullReconcile()
+      return
+    }
+    if (frame.kind === 'session_event' && frame.sessionId !== null) {
+      this.requestOne(frame.sessionId)
+    }
+  }
+
+  private onDisconnect(gen: number): void {
+    if (gen !== this.generation) return
+    if (this.connectionSettled) return // onError + onClose for the same socket
+    this.connectionSettled = true
+    this.socket = null
+    this.scheduleReconnect(gen)
+  }
+
+  private scheduleReconnect(gen: number): void {
+    if (gen !== this.generation) return
+    if (this.reconnectTimer !== null) clearTimeout(this.reconnectTimer)
+    const delay = this.backoffMs
+    this.backoffMs = Math.min(this.backoffMs * 2, this.timing.reconnectMaxMs)
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null
+      this.openConnection(gen)
+    }, delay)
+  }
+
+  // ── Reconcile coordinator (debounced, single-flight by virtue of sync work) ──
+
+  private requestFullReconcile(): void {
+    this.fullPending = true
+    this.scheduleDrain()
+  }
+
+  private requestOne(id: string): void {
+    this.pendingIds.add(id)
+    this.scheduleDrain()
+  }
+
+  private scheduleDrain(): void {
+    if (this.debounceTimer !== null) return
+    const gen = this.generation
+    this.debounceTimer = setTimeout(() => {
+      this.debounceTimer = null
+      this.drain(gen)
+    }, this.timing.debounceMs)
+  }
+
+  private drain(gen: number): void {
+    if (gen !== this.generation || !this.running) return
+    let changed = false
+
+    if (this.fullPending) {
+      // A full reconcile subsumes every queued per-id request.
+      this.fullPending = false
+      this.pendingIds.clear()
+      try {
+        const summary = reconcileRecent(this.reconcile)
+        this.log(formatReconcileSummary(summary))
+        if (summary.changed > 0) changed = true
+      } catch (err) {
+        this.log(`full reconcile failed: ${err instanceof Error ? err.name : 'error'}`)
+      }
+    } else {
+      const ids = [...this.pendingIds]
+      this.pendingIds.clear()
+      for (const id of ids) {
+        const outcome = this.runOne(gen, id)
+        if (outcome === 'changed') changed = true
+      }
+    }
+
+    if (changed) this.onChanged()
+  }
+
+  /** Reconcile one id, handling the workspace.yaml flush race with bounded retries. */
+  private runOne(gen: number, id: string): 'changed' | 'noop' {
+    let outcome: ReturnType<typeof reconcileOne>
+    try {
+      outcome = reconcileOne(id, this.reconcile)
+    } catch (err) {
+      this.log(`reconcileOne failed: ${err instanceof Error ? err.name : 'error'}`)
+      this.missAttempts.delete(id)
+      return 'noop'
+    }
+    if (outcome.kind === 'missing') {
+      this.scheduleMissRetry(gen, id)
+      return 'noop'
+    }
+    // Resolved one way or another — stop retrying this id.
+    this.missAttempts.delete(id)
+    return outcome.kind === 'upserted' && outcome.changed ? 'changed' : 'noop'
+  }
+
+  private scheduleMissRetry(gen: number, id: string): void {
+    const attempt = this.missAttempts.get(id) ?? 0
+    if (attempt >= this.timing.missRetryMs.length) {
+      // Give up on the targeted retry; the periodic backstop is the final net.
+      this.missAttempts.delete(id)
+      return
+    }
+    this.missAttempts.set(id, attempt + 1)
+    const delay = this.timing.missRetryMs[attempt] ?? this.timing.missRetryMs[this.timing.missRetryMs.length - 1]
+    const timer = setTimeout(() => {
+      this.retryTimers.delete(timer)
+      if (gen !== this.generation || !this.running) return
+      this.requestOne(id)
+    }, delay)
+    this.retryTimers.add(timer)
+  }
+}
+
+/** Production wiring for the observer. */
+export function createSessionObserver(onChanged: () => void): SessionObserver {
+  return new SessionObserver({
+    discover: () => discoverWsEndpoint(),
+    connect: createWsConnector(),
+    reconcile: createReconcileDeps(),
+    onChanged,
+  })
+}

--- a/src/main/agent/copilot-app/reconcile.integration.test.ts
+++ b/src/main/agent/copilot-app/reconcile.integration.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Database as BunDb } from 'bun:sqlite'
+import type BetterSQLite3 from 'better-sqlite3'
+
+vi.mock('electron', () => ({
+  app: { isPackaged: false, getAppPath: () => process.cwd() },
+}))
+
+vi.mock('../../db', () => ({ getDb: vi.fn() }))
+
+import { getDb } from '../../db'
+import { runMigrations } from '../../db/migrate'
+import { resolveProjectId } from '../../copilot/resolve-project'
+import { getAppSession, upsertObservedSession, insertAppSession } from './store'
+import {
+  reconcileRecent,
+  reconcileOne,
+  type ReconcileDeps,
+  type ReconcileFs,
+} from './reconcile'
+
+let db: BunDb
+
+beforeEach(() => {
+  db = new BunDb(':memory:')
+  db.exec('PRAGMA foreign_keys = ON')
+  const betterDb = db as unknown as BetterSQLite3.Database
+  runMigrations(betterDb)
+  vi.mocked(getDb).mockReturnValue(betterDb)
+})
+
+function makeProject(name: string): number {
+  return (db.prepare('INSERT INTO projects (name) VALUES (?) RETURNING id').get(name) as { id: number }).id
+}
+function mapRepo(owner: string, name: string, projectId: number): void {
+  db.prepare('INSERT INTO repo_rules (repo_owner, repo_name, project_id) VALUES (?, ?, ?)').run(owner, name, projectId)
+}
+
+/** A fake session-state fs backed by an in-memory map of id → workspace.yaml text. */
+function fakeFs(files: Record<string, { mtimeMs: number; yaml: string | null }>): ReconcileFs {
+  return {
+    listSessions: () => Object.entries(files).map(([id, f]) => ({ id, mtimeMs: f.mtimeMs })),
+    readWorkspaceYaml: (id) => files[id]?.yaml ?? null,
+  }
+}
+
+function deps(fs: ReconcileFs, now = 1_000_000): ReconcileDeps {
+  return {
+    fs,
+    now: () => now,
+    resolveProject: (owner, repo) => resolveProjectId(owner, repo),
+    getExisting: (id) => getAppSession(id),
+    upsertObserved: (input) => upsertObservedSession(input),
+  }
+}
+
+function yamlFor(id: string, cwd: string, repository: string, name?: string): string {
+  const lines = [`id: ${id}`, `cwd: ${cwd}`, `repository: ${repository}`]
+  if (name !== undefined) lines.push(`name: '${name}'`)
+  return lines.join('\n')
+}
+
+describe('reconcile — cwd→repo→project→observed ingest', () => {
+  it('ingests a directly-opened session in a known repo as an observed row', () => {
+    const pid = makeProject('Notifier')
+    mapRepo('robert-crandall', 'gh-notifier', pid)
+    const fs = fakeFs({
+      's1': { mtimeMs: 999_999, yaml: yamlFor('s1', '/repos/gh-notifier', 'robert-crandall/gh-notifier', 'Fix the bug') },
+    })
+
+    const summary = reconcileRecent(deps(fs))
+    expect(summary.upserted).toBe(1)
+    expect(summary.changed).toBe(1)
+
+    const s = getAppSession('s1')
+    expect(s).not.toBeNull()
+    expect(s?.origin).toBe('observed')
+    expect(s?.projectId).toBe(pid)
+    expect(s?.repoOwner).toBe('robert-crandall')
+    expect(s?.repoName).toBe('gh-notifier')
+    expect(s?.cwd).toBe('/repos/gh-notifier')
+    expect(s?.title).toBe('Fix the bug')
+  })
+
+  it('skips a session whose repo maps to no project (out of scope for #119)', () => {
+    const fs = fakeFs({ 's1': { mtimeMs: 999_999, yaml: yamlFor('s1', '/repos/unknown', 'someone/unknown') } })
+    const summary = reconcileRecent(deps(fs))
+    expect(summary.skippedUnresolved).toBe(1)
+    expect(summary.upserted).toBe(0)
+    expect(getAppSession('s1')).toBeNull()
+  })
+
+  it('skips a session with no well-formed repository', () => {
+    const fs = fakeFs({ 's1': { mtimeMs: 999_999, yaml: 'id: s1\ncwd: /repos/x' } })
+    const summary = reconcileRecent(deps(fs))
+    expect(summary.skippedNoRepo).toBe(1)
+    expect(getAppSession('s1')).toBeNull()
+  })
+
+  it('skips a malformed file with no cwd', () => {
+    const fs = fakeFs({ 's1': { mtimeMs: 999_999, yaml: 'repository: a/b' } })
+    const summary = reconcileRecent(deps(fs))
+    expect(summary.skippedMalformed).toBe(1)
+    expect(getAppSession('s1')).toBeNull()
+  })
+
+  it('skips (id_mismatch) when workspace.yaml.id disagrees with the dir name', () => {
+    const pid = makeProject('P')
+    mapRepo('a', 'b', pid)
+    const fs = fakeFs({ 'dir-id': { mtimeMs: 999_999, yaml: yamlFor('OTHER-id', '/x', 'a/b') } })
+    const summary = reconcileRecent(deps(fs))
+    expect(summary.skippedMalformed).toBe(1)
+    expect(getAppSession('dir-id')).toBeNull()
+  })
+
+  it('NEVER downgrades a Projects-launched session to observed', () => {
+    const pid = makeProject('P')
+    mapRepo('a', 'b', pid)
+    insertAppSession({ id: 's1', projectId: pid, cwd: '/x', title: 'launched', repoOwner: 'a', repoName: 'b' })
+    const fs = fakeFs({ 's1': { mtimeMs: 999_999, yaml: yamlFor('s1', '/x', 'a/b') } })
+
+    const summary = reconcileRecent(deps(fs))
+    expect(summary.skippedLaunched).toBe(1)
+    expect(getAppSession('s1')?.origin).toBe('launched')
+    expect(getAppSession('s1')?.title).toBe('launched') // untouched
+  })
+
+  it('full scan is recency-bounded, but reconcileOne ingests an old-but-active session', () => {
+    const pid = makeProject('P')
+    mapRepo('a', 'b', pid)
+    const old = 1_000_000 - 100 * 24 * 60 * 60 * 1000 // 100 days old
+    const fs = fakeFs({ 'old': { mtimeMs: old, yaml: yamlFor('old', '/x', 'a/b') } })
+
+    // The periodic full scan skips it (too old to be in the window).
+    expect(reconcileRecent(deps(fs)).scanned).toBe(0)
+    expect(getAppSession('old')).toBeNull()
+
+    // But a targeted reconcile (triggered by a live WS event) ingests it regardless of age.
+    const outcome = reconcileOne('old', deps(fs))
+    expect(outcome.kind).toBe('upserted')
+    expect(getAppSession('old')?.projectId).toBe(pid)
+  })
+
+  it('reconcileOne reports missing when workspace.yaml is not yet flushed', () => {
+    const fs = fakeFs({ 's1': { mtimeMs: 999_999, yaml: null } })
+    expect(reconcileOne('s1', deps(fs)).kind).toBe('missing')
+  })
+
+  it('re-reconcile keeps a sticky manual pin instead of drifting', () => {
+    const projA = makeProject('A')
+    const projB = makeProject('B')
+    mapRepo('a', 'b', projA) // repo resolves to A
+    const fs = fakeFs({ 's1': { mtimeMs: 999_999, yaml: yamlFor('s1', '/x', 'a/b') } })
+    reconcileRecent(deps(fs))
+    expect(getAppSession('s1')?.projectId).toBe(projA)
+
+    // User manually pins it to B (sticky).
+    db.prepare('UPDATE copilot_app_sessions SET project_id = ?, pinned_project_id = ? WHERE id = ?').run(projB, projB, 's1')
+
+    // Next reconcile still resolves the repo to A, but the sticky pin to B wins.
+    reconcileRecent(deps(fs))
+    expect(getAppSession('s1')?.projectId).toBe(projB)
+  })
+
+  it('reports no change on a re-reconcile that changes nothing', () => {
+    const pid = makeProject('P')
+    mapRepo('a', 'b', pid)
+    const fs = fakeFs({ 's1': { mtimeMs: 999_999, yaml: yamlFor('s1', '/x', 'a/b', 'title') } })
+    expect(reconcileRecent(deps(fs)).changed).toBe(1)
+    expect(reconcileRecent(deps(fs)).changed).toBe(0)
+  })
+})

--- a/src/main/agent/copilot-app/reconcile.ts
+++ b/src/main/agent/copilot-app/reconcile.ts
@@ -1,0 +1,240 @@
+/**
+ * Read-only reconciler for sessions the user opened DIRECTLY in the Copilot
+ * desktop app (#119). It is the SOURCE OF TRUTH for a session's repo, because the
+ * live WS `session_event` frame carries no cwd (confirmed in the spike) — only a
+ * session id. We map each observed session to a project by reading the app's own
+ * on-disk session store and upsert it tagged `observed`.
+ *
+ * Layout (UNOFFICIAL — treated as best-effort, contained entirely in this adapter):
+ *   ~/.copilot/session-state/<session-id>/workspace.yaml  → { id, cwd, repository, name }
+ * The DIRECTORY BASENAME is the canonical session id; when `workspace.yaml.id` is
+ * present it must match, else the session is skipped (fail closed).
+ *
+ * Guarantees: never writes to any ~/.copilot file; never runs a subprocess in the
+ * loop; the asserted `repository` is used ONLY for project mapping/display, never
+ * for command execution or filesystem access. Bounds the full scan by recency +
+ * cap so the thousands of historical session dirs don't churn each poll; the WS
+ * observer catches old-but-active sessions via targeted `reconcileOne`.
+ */
+
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import type { CopilotAppSession } from '../../../shared/ipc-channels'
+import { resolveProjectId } from '../../copilot/resolve-project'
+import { getAppSession, upsertObservedSession, type UpsertObservedSessionInput } from './store'
+import { parseWorkspaceYaml, parseAssertedRepo, isValidSessionId } from './workspace-yaml'
+
+/** Directory holding the desktop app's per-session state. */
+export function sessionStateDir(): string {
+  return join(homedir(), '.copilot', 'session-state')
+}
+
+/** Injectable filesystem probes (real impls by default; faked with fixtures in tests). */
+export interface ReconcileFs {
+  /** session-state child directories as { id: basename, mtimeMs }. */
+  listSessions: () => { id: string; mtimeMs: number }[]
+  /** A session's workspace.yaml text, or null when missing/unreadable. */
+  readWorkspaceYaml: (id: string) => string | null
+}
+
+export interface ReconcileDeps {
+  fs: ReconcileFs
+  now: () => number
+  resolveProject: (owner: string, repo: string) => number | null
+  getExisting: (id: string) => CopilotAppSession | null
+  upsertObserved: (input: UpsertObservedSessionInput) => CopilotAppSession
+}
+
+/** Why a session wasn't upserted as observed. */
+export type ReconcileSkipReason =
+  | 'invalid_id'   // dir name isn't a valid session id
+  | 'id_mismatch'  // workspace.yaml.id disagrees with the dir name
+  | 'no_cwd'       // no cwd in workspace.yaml (malformed / not a workspace session)
+  | 'no_repo'      // no well-formed owner/repo asserted
+  | 'unresolved'   // repo doesn't map to any live project — out of scope for #119
+  | 'launched'     // already tracked as a Projects-launched session (never downgrade)
+
+export type ReconcileOutcome =
+  | { kind: 'missing' } // workspace.yaml not readable yet (may be a flush race — caller can retry)
+  | { kind: 'skipped'; reason: ReconcileSkipReason }
+  | { kind: 'upserted'; changed: boolean; session: CopilotAppSession }
+
+export interface ReconcileSummary {
+  scanned: number
+  parsed: number
+  skippedMalformed: number
+  skippedNoRepo: number
+  skippedUnresolved: number
+  skippedLaunched: number
+  upserted: number
+  /** How many upserts actually changed a row (new, or project/title/cwd/repo moved). */
+  changed: number
+}
+
+function emptySummary(): ReconcileSummary {
+  return {
+    scanned: 0,
+    parsed: 0,
+    skippedMalformed: 0,
+    skippedNoRepo: 0,
+    skippedUnresolved: 0,
+    skippedLaunched: 0,
+    upserted: 0,
+    changed: 0,
+  }
+}
+
+/** Pure-ish core: reconcile one session given its already-read workspace.yaml text. */
+export function reconcileSession(id: string, yamlText: string | null, deps: ReconcileDeps): ReconcileOutcome {
+  if (!isValidSessionId(id)) return { kind: 'skipped', reason: 'invalid_id' }
+  if (yamlText === null) return { kind: 'missing' }
+
+  const parsed = parseWorkspaceYaml(yamlText)
+  // The dir basename is canonical; a present-but-different id is a red flag → skip.
+  if (parsed.id !== null && parsed.id !== id) return { kind: 'skipped', reason: 'id_mismatch' }
+
+  const cwd = parsed.cwd
+  if (cwd === null) return { kind: 'skipped', reason: 'no_cwd' }
+
+  // Never downgrade a Projects-launched session; it's already tracked with better provenance.
+  const existing = deps.getExisting(id)
+  if (existing !== null && existing.origin === 'launched') return { kind: 'skipped', reason: 'launched' }
+
+  const repo = parseAssertedRepo(parsed.repository)
+  if (repo === null) return { kind: 'skipped', reason: 'no_repo' }
+
+  const projectId = deps.resolveProject(repo.owner, repo.repo)
+  // Scope for #119: only observe sessions in a repo Projects already knows about.
+  if (projectId === null) return { kind: 'skipped', reason: 'unresolved' }
+
+  const title = parsed.name ?? `${repo.owner}/${repo.repo}`
+  const session = deps.upsertObserved({
+    id,
+    projectId,
+    cwd,
+    title,
+    repoOwner: repo.owner,
+    repoName: repo.repo,
+  })
+
+  const changed =
+    existing === null ||
+    existing.projectId !== session.projectId ||
+    existing.title !== session.title ||
+    existing.cwd !== session.cwd ||
+    existing.repoOwner !== session.repoOwner ||
+    existing.repoName !== session.repoName
+  return { kind: 'upserted', changed, session }
+}
+
+/** Fold a single outcome into a running summary. */
+function tally(summary: ReconcileSummary, outcome: ReconcileOutcome): void {
+  summary.scanned++
+  switch (outcome.kind) {
+    case 'missing':
+      summary.skippedMalformed++
+      return
+    case 'skipped':
+      if (outcome.reason === 'no_repo') summary.skippedNoRepo++
+      else if (outcome.reason === 'unresolved') summary.skippedUnresolved++
+      else if (outcome.reason === 'launched') summary.skippedLaunched++
+      else summary.skippedMalformed++
+      return
+    case 'upserted':
+      summary.parsed++
+      summary.upserted++
+      if (outcome.changed) summary.changed++
+      return
+  }
+}
+
+/** Reconcile a single session by id (targeted; NOT recency-bounded). */
+export function reconcileOne(id: string, deps: ReconcileDeps): ReconcileOutcome {
+  const yamlText = isValidSessionId(id) ? deps.fs.readWorkspaceYaml(id) : null
+  return reconcileSession(id, yamlText, deps)
+}
+
+export interface ReconcileRecentOptions {
+  /** Only scan sessions whose dir mtime is within this window. Default 45 days. */
+  maxAgeMs?: number
+  /** Hard cap on sessions scanned per pass (most-recent first). Default 500. */
+  cap?: number
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000
+const DEFAULTS: Required<ReconcileRecentOptions> = { maxAgeMs: 45 * DAY_MS, cap: 500 }
+
+/**
+ * Full reconcile of RECENT session dirs — the startup + periodic backstop. Bounds
+ * work by recency + cap (most-recent first) so historical dirs don't churn.
+ * Returns a token-safe summary (no ids/paths) for fail-closed diagnostics.
+ */
+export function reconcileRecent(deps: ReconcileDeps, options: ReconcileRecentOptions = {}): ReconcileSummary {
+  const maxAgeMs = options.maxAgeMs ?? DEFAULTS.maxAgeMs
+  const cap = options.cap ?? DEFAULTS.cap
+  const summary = emptySummary()
+
+  const cutoff = deps.now() - maxAgeMs
+  const recent = deps.fs
+    .listSessions()
+    .filter((s) => s.mtimeMs >= cutoff)
+    .sort((a, b) => b.mtimeMs - a.mtimeMs)
+    .slice(0, cap)
+
+  for (const { id } of recent) {
+    tally(summary, reconcileOne(id, deps))
+  }
+  return summary
+}
+
+/** Real filesystem probes over ~/.copilot/session-state (read-only). */
+export function createReconcileFs(dir: string = sessionStateDir()): ReconcileFs {
+  return {
+    listSessions: () => {
+      let entries: import('node:fs').Dirent[]
+      try {
+        entries = readdirSync(dir, { withFileTypes: true })
+      } catch {
+        return [] // session-state missing → app never ran / different layout
+      }
+      const out: { id: string; mtimeMs: number }[] = []
+      for (const entry of entries) {
+        if (!entry.isDirectory()) continue
+        try {
+          out.push({ id: entry.name, mtimeMs: statSync(join(dir, entry.name)).mtimeMs })
+        } catch {
+          /* vanished between readdir and stat — skip */
+        }
+      }
+      return out
+    },
+    readWorkspaceYaml: (id) => {
+      try {
+        return readFileSync(join(dir, id, 'workspace.yaml'), 'utf8')
+      } catch {
+        return null // not yet flushed / missing / unreadable
+      }
+    },
+  }
+}
+
+/** Production wiring for the reconciler. */
+export function createReconcileDeps(): ReconcileDeps {
+  return {
+    fs: createReconcileFs(),
+    now: () => Date.now(),
+    resolveProject: (owner, repo) => resolveProjectId(owner, repo),
+    getExisting: (id) => getAppSession(id),
+    upsertObserved: (input) => upsertObservedSession(input),
+  }
+}
+
+/** Token-safe one-line summary for logs (no ids, paths, or repo names). */
+export function formatReconcileSummary(s: ReconcileSummary): string {
+  return (
+    `scanned=${s.scanned} upserted=${s.upserted} changed=${s.changed} ` +
+    `skipped(malformed=${s.skippedMalformed} no_repo=${s.skippedNoRepo} ` +
+    `unresolved=${s.skippedUnresolved} launched=${s.skippedLaunched})`
+  )
+}

--- a/src/main/agent/copilot-app/settings.ts
+++ b/src/main/agent/copilot-app/settings.ts
@@ -11,6 +11,7 @@ import { getDb } from '../../db'
 import { DEFAULT_REPOS_ROOT } from './cwd'
 
 const APP_DELEGATE_ENABLED_KEY = 'copilot_app_delegate_enabled'
+const APP_OBSERVE_ENABLED_KEY = 'copilot_app_observe_enabled'
 const REPOS_ROOT_KEY = 'copilot_repos_root'
 
 function readMeta(key: string): string | null {
@@ -31,6 +32,20 @@ export function getAppDelegateEnabled(): boolean {
 
 export function setAppDelegateEnabled(enabled: boolean): void {
   writeMeta(APP_DELEGATE_ENABLED_KEY, enabled ? 'true' : 'false')
+}
+
+/**
+ * Whether directly-opened desktop-app sessions are observed (#119). Default TRUE:
+ * this is the feature's whole point, it's read-only w.r.t. the app's files, and it
+ * degrades quietly when the app is closed. A visible Settings toggle is the kill
+ * switch. Stored as the literal 'false' to disable, so an absent key reads as on.
+ */
+export function getAppObserveEnabled(): boolean {
+  return readMeta(APP_OBSERVE_ENABLED_KEY) !== 'false'
+}
+
+export function setAppObserveEnabled(enabled: boolean): void {
+  writeMeta(APP_OBSERVE_ENABLED_KEY, enabled ? 'true' : 'false')
 }
 
 /** The configured repos root (raw string; `~` is expanded by the cwd resolver). */

--- a/src/main/agent/copilot-app/status.ts
+++ b/src/main/agent/copilot-app/status.ts
@@ -21,8 +21,8 @@
 
 import { homedir } from 'node:os'
 import { join } from 'node:path'
-import type { CopilotAppSessionStatus, TodoAppSession } from '../../../shared/ipc-channels'
-import { getTodoAppSessionsForProject, updateAppSessionStatus } from './store'
+import type { CopilotAppSessionStatus, TodoAppSession, CopilotAppSession } from '../../../shared/ipc-channels'
+import { getTodoAppSessionsForProject, updateAppSessionStatus, getAppSessionsForProject } from './store'
 
 /** Path to the desktop app's own sqlite database. */
 export function copilotDataDbPath(): string {
@@ -123,4 +123,34 @@ export async function refreshTodoAppSessionsForProject(
     }
   }
   return changed ? getTodoAppSessionsForProject(projectId) : links
+}
+
+/**
+ * Return ALL app sessions for a project (both Projects-'launched' and directly-
+ * 'observed', #119), newest first, after refreshing their live status from the
+ * app's local store (read-only). Mirrors `refreshTodoAppSessionsForProject` but
+ * keyed on project assignment rather than a todo link, so observed sessions —
+ * which have no todo — surface too. On a transient read failure the stored
+ * (last-known) status is kept. `reader` is injectable for tests.
+ */
+export async function refreshProjectAppSessions(
+  projectId: number,
+  reader: AppStatusReader = readAppSessionStatuses
+): Promise<CopilotAppSession[]> {
+  const sessions = getAppSessionsForProject(projectId)
+  const ids = [...new Set(sessions.map((s) => s.id))]
+  const read = await reader(ids)
+  if (!read.ok) return sessions // transient failure → last-known
+
+  // Only write when the status actually changed, so polling doesn't bump
+  // updated_at (and reorder sessions) on every refresh.
+  const current = new Map(sessions.map((s) => [s.id, s.status]))
+  let changed = false
+  for (const [id, status] of read.statuses) {
+    if (current.get(id) !== status) {
+      updateAppSessionStatus(id, status)
+      changed = true
+    }
+  }
+  return changed ? getAppSessionsForProject(projectId) : sessions
 }

--- a/src/main/agent/copilot-app/store.integration.test.ts
+++ b/src/main/agent/copilot-app/store.integration.test.ts
@@ -92,6 +92,25 @@ describe('observed app sessions (#119)', () => {
     expect(s.origin).toBe('launched')
   })
 
+  it('UPGRADES an observed row to launched when Projects later delegates it', () => {
+    const pid = makeProject('P')
+    upsertObservedSession({ id: 's1', projectId: pid, cwd: '/x', title: 't', repoOwner: 'me', repoName: 'foo' })
+    const s = insertAppSession({ id: 's1', projectId: pid, cwd: '/x', title: 't', repoOwner: 'me', repoName: 'foo' })
+    expect(s.origin).toBe('launched')
+  })
+
+  it('skips the write (no updated_at churn) on an unchanged re-reconcile', () => {
+    const pid = makeProject('P')
+    upsertObservedSession({ id: 's1', projectId: pid, cwd: '/x', title: 't', repoOwner: 'me', repoName: 'foo' })
+    db.prepare("UPDATE copilot_app_sessions SET updated_at = '2000-01-01 00:00:00' WHERE id = 's1'").run()
+    // Identical input → no write, so updated_at stays the sentinel.
+    upsertObservedSession({ id: 's1', projectId: pid, cwd: '/x', title: 't', repoOwner: 'me', repoName: 'foo' })
+    expect(getAppSession('s1')?.updatedAt).toBe('2000-01-01 00:00:00')
+    // A real change DOES write (updated_at moves off the sentinel).
+    upsertObservedSession({ id: 's1', projectId: pid, cwd: '/y', title: 't', repoOwner: 'me', repoName: 'foo' })
+    expect(getAppSession('s1')?.updatedAt).not.toBe('2000-01-01 00:00:00')
+  })
+
   it('keeps a sticky pin over the freshly-resolved project on re-upsert', () => {
     const a = makeProject('A')
     const b = makeProject('B')

--- a/src/main/agent/copilot-app/store.integration.test.ts
+++ b/src/main/agent/copilot-app/store.integration.test.ts
@@ -17,7 +17,7 @@ import {
   getUnassignedActiveCount,
   getAllStatuses,
 } from '../../copilot/db'
-import { listProjects, getProject } from '../../db/projects'
+import { listProjects, getProject, deleteProject } from '../../db/projects'
 
 let db: BunDb
 
@@ -127,6 +127,19 @@ describe('observed app sessions (#119)', () => {
     upsertObservedSession({ id: 's1', projectId: pid, cwd: '/x', title: 't', repoOwner: 'me', repoName: 'foo' })
     expect(() => assignAppSession('s1', 9999)).toThrow('PROJECT_NOT_FOUND')
     expect(() => assignAppSession('nope', pid)).toThrow('SESSION_NOT_FOUND')
+  })
+
+  it('deleteProject detaches app sessions (project + pin cleared)', () => {
+    const pid = makeProject('P')
+    insertAppSession({ id: 'launched-1', projectId: pid, cwd: '/x', title: 't', repoOwner: 'me', repoName: 'foo' })
+    const obs = upsertObservedSession({ id: 'observed-1', projectId: pid, cwd: '/x', title: 't', repoOwner: 'me', repoName: 'foo' })
+    assignAppSession(obs.id, pid) // pin it too
+    deleteProject(pid)
+    for (const id of ['launched-1', 'observed-1']) {
+      const s = getAppSession(id)
+      expect(s?.projectId).toBeNull()
+      expect(s?.pinnedProjectId).toBeNull()
+    }
   })
 })
 

--- a/src/main/agent/copilot-app/store.integration.test.ts
+++ b/src/main/agent/copilot-app/store.integration.test.ts
@@ -10,7 +10,7 @@ vi.mock('../../db', () => ({ getDb: vi.fn() }))
 
 import { getDb } from '../../db'
 import { runMigrations } from '../../db/migrate'
-import { insertAppSession, getAppSession, getAppSessionsForProject, updateAppSessionStatus, linkTodoSession, getTodoAppSessionsForProject } from './store'
+import { insertAppSession, getAppSession, getAppSessionsForProject, updateAppSessionStatus, linkTodoSession, getTodoAppSessionsForProject, upsertObservedSession, assignAppSession } from './store'
 import {
   getSessionsForProject,
   getUnassignedSessions,
@@ -66,6 +66,67 @@ describe('copilot_app_sessions store', () => {
     db.prepare("UPDATE projects SET deleted_at = datetime('now') WHERE id = ?").run(pid)
     const s = insertAppSession({ id: 'app-1', projectId: pid, cwd: '/x', title: 't', repoOwner: null, repoName: null })
     expect(s.projectId).toBeNull()
+  })
+
+  it('tags launched sessions origin=launched', () => {
+    const pid = makeProject('P')
+    const s = insertAppSession({ id: 'app-1', projectId: pid, cwd: '/x', title: 't', repoOwner: null, repoName: null })
+    expect(s.origin).toBe('launched')
+    expect(s.pinnedProjectId).toBeNull()
+  })
+})
+
+describe('observed app sessions (#119)', () => {
+  it('upserts an observed session tagged origin=observed', () => {
+    const pid = makeProject('P')
+    const s = upsertObservedSession({ id: 'obs-1', projectId: pid, cwd: '/x', title: 't', repoOwner: 'me', repoName: 'foo' })
+    expect(s.origin).toBe('observed')
+    expect(s.projectId).toBe(pid)
+    expect(getAppSessionsForProject(pid).map((r) => r.id)).toEqual(['obs-1'])
+  })
+
+  it('never downgrades a launched row to observed', () => {
+    const pid = makeProject('P')
+    insertAppSession({ id: 's1', projectId: pid, cwd: '/x', title: 'launched', repoOwner: 'me', repoName: 'foo' })
+    const s = upsertObservedSession({ id: 's1', projectId: pid, cwd: '/x', title: 'observed', repoOwner: 'me', repoName: 'foo' })
+    expect(s.origin).toBe('launched')
+  })
+
+  it('keeps a sticky pin over the freshly-resolved project on re-upsert', () => {
+    const a = makeProject('A')
+    const b = makeProject('B')
+    upsertObservedSession({ id: 's1', projectId: a, cwd: '/x', title: 't', repoOwner: 'me', repoName: 'foo' })
+    assignAppSession('s1', b) // sticky pin to B
+    // A later reconcile still resolves to A, but the pin to B wins.
+    const s = upsertObservedSession({ id: 's1', projectId: a, cwd: '/x', title: 't', repoOwner: 'me', repoName: 'foo' })
+    expect(s.projectId).toBe(b)
+    expect(s.pinnedProjectId).toBe(b)
+  })
+
+  it('clears a sticky pin whose project was soft-deleted, falling back to resolution', () => {
+    const a = makeProject('A')
+    const b = makeProject('B')
+    upsertObservedSession({ id: 's1', projectId: a, cwd: '/x', title: 't', repoOwner: 'me', repoName: 'foo' })
+    assignAppSession('s1', b)
+    db.prepare("UPDATE projects SET deleted_at = datetime('now') WHERE id = ?").run(b)
+    const s = upsertObservedSession({ id: 's1', projectId: a, cwd: '/x', title: 't', repoOwner: 'me', repoName: 'foo' })
+    expect(s.pinnedProjectId).toBeNull()
+    expect(s.projectId).toBe(a)
+  })
+
+  it('getAppSessionsForProject returns both launched and observed, newest first', () => {
+    const pid = makeProject('P')
+    insertAppSession({ id: 'launched-1', projectId: pid, cwd: '/x', title: 't', repoOwner: 'me', repoName: 'foo' })
+    upsertObservedSession({ id: 'observed-1', projectId: pid, cwd: '/x', title: 't', repoOwner: 'me', repoName: 'foo' })
+    const ids = getAppSessionsForProject(pid).map((r) => r.id)
+    expect(ids.sort()).toEqual(['launched-1', 'observed-1'])
+  })
+
+  it('assignAppSession rejects a missing project or session', () => {
+    const pid = makeProject('P')
+    upsertObservedSession({ id: 's1', projectId: pid, cwd: '/x', title: 't', repoOwner: 'me', repoName: 'foo' })
+    expect(() => assignAppSession('s1', 9999)).toThrow('PROJECT_NOT_FOUND')
+    expect(() => assignAppSession('nope', pid)).toThrow('SESSION_NOT_FOUND')
   })
 })
 

--- a/src/main/agent/copilot-app/store.ts
+++ b/src/main/agent/copilot-app/store.ts
@@ -69,6 +69,9 @@ export function insertAppSession(input: InsertAppSessionInput): CopilotAppSessio
     VALUES
       (?, ?, ?, ?, 'in_progress', ?, ?, 'launched')
     ON CONFLICT(id) DO UPDATE SET
+      -- A launched session is authoritative provenance (Projects created it), so
+      -- upgrade an existing observed row rather than leaving it mis-tagged.
+      origin     = 'launched',
       cwd        = excluded.cwd,
       title      = excluded.title,
       repo_owner = excluded.repo_owner,
@@ -100,10 +103,38 @@ export interface UpsertObservedSessionInput {
  * `pinned_project_id` points at a live project it wins over the freshly-resolved
  * `project_id` (a manual assignment doesn't drift on the next reconcile); a pin
  * whose project is gone is cleared. New rows keep `pinned_project_id` NULL.
- * Volatile fields (cwd/title/repo) always track the on-disk truth. Returns the row.
+ * Volatile fields (cwd/title/repo) always track the on-disk truth.
+ *
+ * No-op guard: when an existing row would come out identical (same repo/cwd/title
+ * and the same effective project + pin), the write is skipped entirely so a
+ * periodic reconcile doesn't bump `updated_at` and reorder the project's session
+ * list. Returns the row either way.
  */
 export function upsertObservedSession(input: UpsertObservedSessionInput): CopilotAppSession {
   const db = getDb()
+
+  // Skip the write when nothing would actually change, mirroring the SQL's
+  // sticky-pin resolution so `updated_at` (and list order) stays put on a no-op.
+  const existing = db.prepare('SELECT * FROM copilot_app_sessions WHERE id = ?').get(input.id) as
+    | AppSessionRow
+    | undefined
+    | null
+  if (existing !== undefined && existing !== null) {
+    const pinLive =
+      existing.pinned_project_id !== null &&
+      db.prepare('SELECT 1 FROM projects WHERE id = ? AND deleted_at IS NULL').get(existing.pinned_project_id) != null
+    const effectivePin = pinLive ? existing.pinned_project_id : null
+    const effectiveProject = pinLive ? existing.pinned_project_id : input.projectId
+    const unchanged =
+      existing.cwd === input.cwd &&
+      existing.title === input.title &&
+      existing.repo_owner === input.repoOwner &&
+      existing.repo_name === input.repoName &&
+      existing.project_id === effectiveProject &&
+      existing.pinned_project_id === effectivePin
+    if (unchanged) return toSession(existing)
+  }
+
   db.prepare(`
     INSERT INTO copilot_app_sessions
       (id, project_id, cwd, title, status, repo_owner, repo_name, origin)

--- a/src/main/agent/copilot-app/store.ts
+++ b/src/main/agent/copilot-app/store.ts
@@ -9,7 +9,7 @@
  */
 
 import { getDb } from '../../db'
-import type { CopilotAppSession, CopilotAppSessionStatus } from '../../../shared/ipc-channels'
+import type { CopilotAppSession, CopilotAppSessionStatus, CopilotAppSessionOrigin } from '../../../shared/ipc-channels'
 
 interface AppSessionRow {
   id: string
@@ -19,6 +19,8 @@ interface AppSessionRow {
   status: CopilotAppSessionStatus
   repo_owner: string | null
   repo_name: string | null
+  origin: CopilotAppSessionOrigin
+  pinned_project_id: number | null
   created_at: string
   updated_at: string
 }
@@ -32,6 +34,8 @@ function toSession(row: AppSessionRow): CopilotAppSession {
     status: row.status,
     repoOwner: row.repo_owner,
     repoName: row.repo_name,
+    origin: row.origin,
+    pinnedProjectId: row.pinned_project_id,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   }
@@ -47,10 +51,10 @@ export interface InsertAppSessionInput {
 }
 
 /**
- * Insert a just-delegated app session (status starts `in_progress`). Only pins a
- * live project: if the originating project vanished mid-delegate (or is
- * soft-deleted), the session is tracked unassigned instead, so a successful
- * delegate is never lost to an FK failure.
+ * Insert a just-delegated app session (status starts `in_progress`, origin
+ * `launched`). Only pins a live project: if the originating project vanished
+ * mid-delegate (or is soft-deleted), the session is tracked unassigned instead,
+ * so a successful delegate is never lost to an FK failure.
  */
 export function insertAppSession(input: InsertAppSessionInput): CopilotAppSession {
   const db = getDb()
@@ -61,9 +65,9 @@ export function insertAppSession(input: InsertAppSessionInput): CopilotAppSessio
 
   db.prepare(`
     INSERT INTO copilot_app_sessions
-      (id, project_id, cwd, title, status, repo_owner, repo_name)
+      (id, project_id, cwd, title, status, repo_owner, repo_name, origin)
     VALUES
-      (?, ?, ?, ?, 'in_progress', ?, ?)
+      (?, ?, ?, ?, 'in_progress', ?, ?, 'launched')
     ON CONFLICT(id) DO UPDATE SET
       cwd        = excluded.cwd,
       title      = excluded.title,
@@ -76,10 +80,86 @@ export function insertAppSession(input: InsertAppSessionInput): CopilotAppSessio
   return toSession(row)
 }
 
+export interface UpsertObservedSessionInput {
+  id: string
+  /** Freshly auto-resolved project for the session's repo (may be null). */
+  projectId: number | null
+  cwd: string
+  title: string
+  repoOwner: string | null
+  repoName: string | null
+}
+
+/**
+ * Upsert a session observed directly in the desktop app (#119). New rows are
+ * tagged origin `observed`; an EXISTING row is never downgraded from `launched`
+ * to `observed` (so a session Projects created keeps its provenance even though
+ * the reconciler also sees it on disk).
+ *
+ * Sticky assignment mirrors `copilot_sessions.upsertSessions`: while a row's
+ * `pinned_project_id` points at a live project it wins over the freshly-resolved
+ * `project_id` (a manual assignment doesn't drift on the next reconcile); a pin
+ * whose project is gone is cleared. New rows keep `pinned_project_id` NULL.
+ * Volatile fields (cwd/title/repo) always track the on-disk truth. Returns the row.
+ */
+export function upsertObservedSession(input: UpsertObservedSessionInput): CopilotAppSession {
+  const db = getDb()
+  db.prepare(`
+    INSERT INTO copilot_app_sessions
+      (id, project_id, cwd, title, status, repo_owner, repo_name, origin)
+    VALUES
+      (?, ?, ?, ?, 'unknown', ?, ?, 'observed')
+    ON CONFLICT(id) DO UPDATE SET
+      pinned_project_id = CASE
+        WHEN copilot_app_sessions.pinned_project_id IS NOT NULL
+         AND EXISTS (
+           SELECT 1 FROM projects p
+           WHERE p.id = copilot_app_sessions.pinned_project_id AND p.deleted_at IS NULL
+         )
+        THEN copilot_app_sessions.pinned_project_id
+        ELSE NULL
+      END,
+      project_id = CASE
+        WHEN copilot_app_sessions.pinned_project_id IS NOT NULL
+         AND EXISTS (
+           SELECT 1 FROM projects p
+           WHERE p.id = copilot_app_sessions.pinned_project_id AND p.deleted_at IS NULL
+         )
+        THEN copilot_app_sessions.pinned_project_id
+        ELSE excluded.project_id
+      END,
+      cwd        = excluded.cwd,
+      title      = excluded.title,
+      repo_owner = excluded.repo_owner,
+      repo_name  = excluded.repo_name,
+      updated_at = datetime('now')
+  `).run(input.id, input.projectId, input.cwd, input.title, input.repoOwner, input.repoName)
+
+  const row = db.prepare('SELECT * FROM copilot_app_sessions WHERE id = ?').get(input.id) as AppSessionRow
+  return toSession(row)
+}
+
+/**
+ * Pin an app session to a live project (sticky across reconciles), mirroring
+ * `assignSession` for cloud tasks. Throws when the project is missing/soft-deleted
+ * or the session doesn't exist. Used by the per-project assignment UI (#117/#118).
+ */
+export function assignAppSession(sessionId: string, projectId: number): void {
+  const db = getDb()
+  const project = db.prepare('SELECT 1 FROM projects WHERE id = ? AND deleted_at IS NULL').get(projectId)
+  if (project === undefined || project === null) throw new Error('PROJECT_NOT_FOUND')
+  const result = db
+    .prepare('UPDATE copilot_app_sessions SET project_id = ?, pinned_project_id = ? WHERE id = ?')
+    .run(projectId, projectId, sessionId)
+  if (result.changes === 0) throw new Error('SESSION_NOT_FOUND')
+}
+
 /** Returns a single app session by id, or null. */
 export function getAppSession(id: string): CopilotAppSession | null {
-  const row = getDb().prepare('SELECT * FROM copilot_app_sessions WHERE id = ?').get(id) as AppSessionRow | undefined
-  return row === undefined ? null : toSession(row)
+  // better-sqlite3 returns `undefined` for no row; bun:sqlite (tests) returns
+  // `null`. Guard against both so a lookup for an as-yet-unseen id can't crash.
+  const row = getDb().prepare('SELECT * FROM copilot_app_sessions WHERE id = ?').get(id) as AppSessionRow | undefined | null
+  return row === undefined || row === null ? null : toSession(row)
 }
 
 /** Updates the status of an app session (used by the status reader in PR3). */

--- a/src/main/agent/copilot-app/workspace-yaml.test.ts
+++ b/src/main/agent/copilot-app/workspace-yaml.test.ts
@@ -29,6 +29,11 @@ describe('parseWorkspaceYaml', () => {
     expect(parseWorkspaceYaml('repository: "owner/repo"').repository).toBe('owner/repo')
   })
 
+  it('honors escaped quotes/backslashes inside a double-quoted scalar', () => {
+    expect(parseWorkspaceYaml('name: "a \\"quoted\\" b"').name).toBe('a "quoted" b')
+    expect(parseWorkspaceYaml('name: "back\\\\slash"').name).toBe('back\\slash')
+  })
+
   it('IGNORES indented (nested) keys — only column-0 keys count', () => {
     const yaml = ['meta:', '  repository: sneaky/nested', '  cwd: /nested/path'].join('\n')
     const parsed = parseWorkspaceYaml(yaml)

--- a/src/main/agent/copilot-app/workspace-yaml.test.ts
+++ b/src/main/agent/copilot-app/workspace-yaml.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest'
+import { parseWorkspaceYaml, parseAssertedRepo, isValidSessionId } from './workspace-yaml'
+
+describe('parseWorkspaceYaml', () => {
+  it('reads the top-level scalars from a realistic file', () => {
+    const yaml = [
+      'id: 684bcab0-cd45-497e-ba90-dd94f306be7e',
+      'cwd: /Users/me/repos/gh-notifier',
+      'git_root: /Users/me/repos/gh-notifier',
+      'repository: robert-crandall/gh-notifier',
+      'branch: main',
+      "name: 'Implement issue #105'",
+      'user_named: false',
+    ].join('\n')
+    expect(parseWorkspaceYaml(yaml)).toEqual({
+      id: '684bcab0-cd45-497e-ba90-dd94f306be7e',
+      cwd: '/Users/me/repos/gh-notifier',
+      repository: 'robert-crandall/gh-notifier',
+      name: 'Implement issue #105',
+    })
+  })
+
+  it('unescapes doubled single quotes in a quoted name', () => {
+    const yaml = "name: 'it''s a title'"
+    expect(parseWorkspaceYaml(yaml).name).toBe("it's a title")
+  })
+
+  it('handles a double-quoted scalar', () => {
+    expect(parseWorkspaceYaml('repository: "owner/repo"').repository).toBe('owner/repo')
+  })
+
+  it('IGNORES indented (nested) keys — only column-0 keys count', () => {
+    const yaml = ['meta:', '  repository: sneaky/nested', '  cwd: /nested/path'].join('\n')
+    const parsed = parseWorkspaceYaml(yaml)
+    expect(parsed.repository).toBeNull()
+    expect(parsed.cwd).toBeNull()
+  })
+
+  it('skips full-line comments and blank lines', () => {
+    const yaml = ['# a comment', '', 'cwd: /x', '# repository: commented/out'].join('\n')
+    const parsed = parseWorkspaceYaml(yaml)
+    expect(parsed.cwd).toBe('/x')
+    expect(parsed.repository).toBeNull()
+  })
+
+  it('first occurrence of a key wins (a later stray line cannot clobber it)', () => {
+    expect(parseWorkspaceYaml('cwd: /good\ncwd: /evil').cwd).toBe('/good')
+  })
+
+  it('returns nulls for a malformed / unrelated file', () => {
+    expect(parseWorkspaceYaml('just some text\nno colons here')).toEqual({
+      id: null,
+      cwd: null,
+      repository: null,
+      name: null,
+    })
+  })
+
+  it('treats an unterminated single-quote as malformed (null)', () => {
+    expect(parseWorkspaceYaml("name: 'unterminated").name).toBeNull()
+  })
+
+  it('strips a clearly-separated inline comment on an unquoted scalar', () => {
+    expect(parseWorkspaceYaml('repository: owner/repo # inline').repository).toBe('owner/repo')
+  })
+
+  it('folds a block-scalar name into a single trimmed title', () => {
+    const yaml = ['cwd: /x', 'name: |-', '  Implement the thing', '  across two lines', 'user_named: false'].join('\n')
+    const parsed = parseWorkspaceYaml(yaml)
+    expect(parsed.name).toBe('Implement the thing across two lines')
+    expect(parsed.cwd).toBe('/x') // parsing resumed correctly after the block
+  })
+
+  it('reads the key AFTER a block scalar (continuation consumption is bounded)', () => {
+    const yaml = ['name: |-', '  A multiline', '  title here', 'repository: owner/repo'].join('\n')
+    const parsed = parseWorkspaceYaml(yaml)
+    expect(parsed.name).toBe('A multiline title here')
+    expect(parsed.repository).toBe('owner/repo')
+  })
+
+  it('caps an over-long name', () => {
+    const long = 'x'.repeat(900)
+    expect((parseWorkspaceYaml(`name: '${long}'`).name ?? '').length).toBe(500)
+  })
+})
+
+describe('parseAssertedRepo', () => {
+  it('accepts a clean owner/repo, case-preserved', () => {
+    expect(parseAssertedRepo('Robert-Crandall/GH-Notifier')).toEqual({
+      owner: 'Robert-Crandall',
+      repo: 'GH-Notifier',
+    })
+  })
+
+  it('rejects null, blanks, extra slashes, whitespace, and control-ish input', () => {
+    expect(parseAssertedRepo(null)).toBeNull()
+    expect(parseAssertedRepo('')).toBeNull()
+    expect(parseAssertedRepo('owner')).toBeNull()
+    expect(parseAssertedRepo('owner/repo/extra')).toBeNull()
+    expect(parseAssertedRepo('own er/repo')).toBeNull()
+    expect(parseAssertedRepo('/repo')).toBeNull()
+    expect(parseAssertedRepo('owner/')).toBeNull()
+    expect(parseAssertedRepo('../repo')).toBeNull()
+    expect(parseAssertedRepo('owner/..')).toBeNull()
+  })
+})
+
+describe('isValidSessionId', () => {
+  it('accepts uuid-shaped ids and rejects unsafe ones', () => {
+    expect(isValidSessionId('684bcab0-cd45-497e-ba90-dd94f306be7e')).toBe(true)
+    expect(isValidSessionId('abc123')).toBe(true)
+    expect(isValidSessionId('')).toBe(false)
+    expect(isValidSessionId('../etc/passwd')).toBe(false)
+    expect(isValidSessionId('has space')).toBe(false)
+    expect(isValidSessionId('a'.repeat(65))).toBe(false)
+  })
+})

--- a/src/main/agent/copilot-app/workspace-yaml.ts
+++ b/src/main/agent/copilot-app/workspace-yaml.ts
@@ -1,0 +1,166 @@
+/**
+ * Minimal, defensive parser for the desktop app's per-session `workspace.yaml`.
+ *
+ * This file is part of the app's UNOFFICIAL on-disk layout, so we don't pull in a
+ * YAML dependency and we never trust its shape. We extract only the handful of
+ * TOP-LEVEL scalar keys we need — `id`, `cwd`, `repository`, `name` — and fail
+ * closed (null) on anything unexpected. Nested/indented keys are deliberately
+ * ignored (only column-0 keys count), so a `repository:` buried inside some nested
+ * mapping can't be mistaken for the session's repo.
+ *
+ * Verified against real files (see the #119 spike): keys appear unindented as
+ * `key: value`, with `name` typically a single-quoted single line.
+ */
+
+/** The scalar fields we read out of a workspace.yaml. Each is null when absent/blank. */
+export interface WorkspaceYaml {
+  id: string | null
+  cwd: string | null
+  repository: string | null
+  name: string | null
+}
+
+const WANTED = new Set(['id', 'cwd', 'repository', 'name'])
+/** Defensive cap on the cosmetic `name`/title so a giant block scalar can't bloat storage. */
+const MAX_NAME = 500
+
+/**
+ * If a scalar value is a YAML block-scalar indicator (`|`, `>`, with optional
+ * chomping/indent like `|-`), fold the following indented lines into a single
+ * trimmed string. Returns the folded text plus the index of the last consumed
+ * line, or undefined when `rawValue` isn't a block indicator.
+ */
+function tryBlockScalar(
+  rawValue: string,
+  lines: string[],
+  keyIndex: number
+): { text: string | null; lastIndex: number } | undefined {
+  if (!/^[|>][+-]?\d*$/.test(rawValue.trim())) return undefined
+  const collected: string[] = []
+  let j = keyIndex + 1
+  for (; j < lines.length; j++) {
+    const l = lines[j] ?? ''
+    if (l.trim().length === 0) {
+      collected.push('') // blank line — still inside the block
+      continue
+    }
+    if (/^\s/.test(l)) {
+      collected.push(l) // indented — inside the block
+      continue
+    }
+    break // a non-indented, non-blank line ends the block
+  }
+  const nonBlank = collected.filter((l) => l.length > 0)
+  if (nonBlank.length === 0) return { text: null, lastIndex: j - 1 }
+  const minIndent = Math.min(...nonBlank.map((l) => (/^\s*/.exec(l)?.[0].length ?? 0)))
+  const folded = nonBlank
+    .map((l) => l.slice(minIndent))
+    .join(' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+  return { text: folded.length > 0 ? folded : null, lastIndex: j - 1 }
+}
+
+/**
+ * Unquote a YAML scalar value. Handles single-quoted (with `''` → `'` escaping)
+ * and double-quoted (with basic `\"`/`\\` escaping) forms; otherwise returns the
+ * trimmed raw text. Returns null for an empty result.
+ */
+function unquoteScalar(raw: string): string | null {
+  const s = raw.trim()
+  if (s.length === 0) return null
+
+  if (s.startsWith("'")) {
+    // Single-quoted: scan to the closing quote; a doubled `''` is a literal quote.
+    let out = ''
+    let i = 1
+    let closed = false
+    while (i < s.length) {
+      const ch = s[i]
+      if (ch === "'") {
+        if (s[i + 1] === "'") {
+          out += "'"
+          i += 2
+          continue
+        }
+        closed = true
+        break
+      }
+      out += ch
+      i += 1
+    }
+    if (!closed) return null // no closing quote → malformed
+    return out.length > 0 ? out : null
+  }
+
+  if (s.startsWith('"')) {
+    const end = s.indexOf('"', 1)
+    if (end === -1) return null
+    const body = s.slice(1, end).replace(/\\"/g, '"').replace(/\\\\/g, '\\')
+    return body.length > 0 ? body : null
+  }
+
+  // Unquoted scalar: strip a trailing inline comment only when clearly separated
+  // (" #"), which never appears in a cwd/owner-repo but keeps a commented YAML tidy.
+  const hashIdx = s.search(/\s#/)
+  const body = (hashIdx === -1 ? s : s.slice(0, hashIdx)).trim()
+  return body.length > 0 ? body : null
+}
+
+/**
+ * Parse a workspace.yaml's text into the scalar fields we care about. Only
+ * column-0 `key: value` lines with a wanted key are considered; everything else
+ * (indented keys, comments, block scalars, other keys) is ignored. Never throws.
+ */
+export function parseWorkspaceYaml(text: string): WorkspaceYaml {
+  const out: WorkspaceYaml = { id: null, cwd: null, repository: null, name: null }
+  const lines = text.split(/\r?\n/)
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i] ?? ''
+    // Top-level only: no leading whitespace, not a comment.
+    if (line.length === 0 || /^\s/.test(line) || line.startsWith('#')) continue
+    const colon = line.indexOf(':')
+    if (colon <= 0) continue
+    const key = line.slice(0, colon).trim()
+    if (!WANTED.has(key)) continue
+    const k = key as keyof WorkspaceYaml
+    // First occurrence wins; don't let a later stray line clobber a good value.
+    if (out[k] !== null) continue
+    const rawValue = line.slice(colon + 1)
+    const block = tryBlockScalar(rawValue, lines, i)
+    if (block !== undefined) {
+      out[k] = block.text
+      i = block.lastIndex // skip the consumed continuation lines
+    } else {
+      out[k] = unquoteScalar(rawValue)
+    }
+  }
+  if (out.name !== null && out.name.length > MAX_NAME) out.name = out.name.slice(0, MAX_NAME)
+  return out
+}
+
+/**
+ * Validate + normalize an asserted `owner/repo` slug from workspace.yaml.
+ * Case-PRESERVED (so `repo_rules`' exact match still works). Returns null unless
+ * it's exactly two non-empty segments of safe characters — no extra slashes, no
+ * whitespace, no control/structural characters. This value is used ONLY for
+ * project mapping/display; it is never fed into command execution or file access.
+ */
+export function parseAssertedRepo(repository: string | null): { owner: string; repo: string } | null {
+  if (repository === null) return null
+  const s = repository.trim()
+  // owner and repo: GitHub-safe characters only.
+  const m = /^([A-Za-z0-9._-]+)\/([A-Za-z0-9._-]+)$/.exec(s)
+  if (m === null) return null
+  const owner = m[1]
+  const repo = m[2]
+  if (owner === undefined || repo === undefined) return null
+  // Reject "." / ".." path-ish segments defensively.
+  if (owner === '.' || owner === '..' || repo === '.' || repo === '..') return null
+  return { owner, repo }
+}
+
+/** A desktop-app session id is a bounded uuid-shaped / alphanumeric-dash token. */
+export function isValidSessionId(id: string): boolean {
+  return /^[A-Za-z0-9-]{1,64}$/.test(id)
+}

--- a/src/main/agent/copilot-app/workspace-yaml.ts
+++ b/src/main/agent/copilot-app/workspace-yaml.ts
@@ -94,10 +94,28 @@ function unquoteScalar(raw: string): string | null {
   }
 
   if (s.startsWith('"')) {
-    const end = s.indexOf('"', 1)
-    if (end === -1) return null
-    const body = s.slice(1, end).replace(/\\"/g, '"').replace(/\\\\/g, '\\')
-    return body.length > 0 ? body : null
+    // Double-quoted: scan to the closing quote, honoring `\"` and `\\` escapes so
+    // an escaped quote inside the value doesn't terminate it early.
+    let out = ''
+    let i = 1
+    let closed = false
+    while (i < s.length) {
+      const ch = s[i]
+      if (ch === '\\' && i + 1 < s.length) {
+        const next = s[i + 1]
+        out += next === '"' || next === '\\' ? next : `\\${next}`
+        i += 2
+        continue
+      }
+      if (ch === '"') {
+        closed = true
+        break
+      }
+      out += ch
+      i += 1
+    }
+    if (!closed) return null // no closing quote → malformed
+    return out.length > 0 ? out : null
   }
 
   // Unquoted scalar: strip a trailing inline comment only when clearly separated

--- a/src/main/db/projects.ts
+++ b/src/main/db/projects.ts
@@ -350,6 +350,9 @@ export function deleteProject(id: number): void {
     ).run(new Date().toISOString(), id)
     db.prepare('UPDATE notification_threads SET project_id = NULL WHERE project_id = ?').run(id)
     db.prepare('UPDATE copilot_sessions SET project_id = NULL, pinned_project_id = NULL WHERE project_id = ? OR pinned_project_id = ?').run(id, id)
+    // Desktop-app sessions (launched + observed, #119) detach the same way, so a
+    // deleted project doesn't keep hiding live external work behind a dead pin.
+    db.prepare('UPDATE copilot_app_sessions SET project_id = NULL, pinned_project_id = NULL WHERE project_id = ? OR pinned_project_id = ?').run(id, id)
   })
   run()
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -42,8 +42,9 @@ import { resolveModelProvisioning } from './context/model-path'
 import { runEmbeddingSmoke, EMBEDDING_SMOKE_FLAG } from './context/embedding-smoke'
 import { delegateTask, appDelegateAvailability, buildAppSessionDeepLink, createDefaultDelegateDeps } from './agent/copilot-app/delegate'
 import { linkTodoSession } from './agent/copilot-app/store'
-import { refreshTodoAppSessionsForProject } from './agent/copilot-app/status'
-import { getAppDelegateEnabled, setAppDelegateEnabled, getReposRoot, setReposRoot } from './agent/copilot-app/settings'
+import { refreshTodoAppSessionsForProject, refreshProjectAppSessions } from './agent/copilot-app/status'
+import { getAppDelegateEnabled, setAppDelegateEnabled, getReposRoot, setReposRoot, getAppObserveEnabled } from './agent/copilot-app/settings'
+import { initObserving, setObserveEnabled, shutdownObserving } from './agent/copilot-app/observe'
 import { enableMcpServer, disableMcpServer, shutdownMcpServer } from './mcp-server/lifecycle'
 import { getMcpServerEnabled, setMcpServerEnabled } from './mcp-server/settings'
 import { listRunbooksForProject } from './knowledge/project-runbooks'
@@ -370,11 +371,20 @@ app.whenReady().then(async () => {
   ipcMain.handle('copilot:app-sessions-for-project', (_event, projectId: number) =>
     refreshTodoAppSessionsForProject(projectId)
   )
+  ipcMain.handle('copilot:project-app-sessions', (_event, projectId: number) =>
+    refreshProjectAppSessions(projectId)
+  )
 
   // Desktop-app delegate settings.
   ipcMain.handle('settings:get-app-delegate-enabled', () => getAppDelegateEnabled())
   ipcMain.handle('settings:set-app-delegate-enabled', (_event, enabled: boolean) => {
     setAppDelegateEnabled(enabled)
+  })
+  // Observe directly-opened desktop-app sessions (#119). Toggling stops/starts the
+  // whole observer pipeline (WS + on-disk reconcile).
+  ipcMain.handle('settings:get-app-observe-enabled', () => getAppObserveEnabled())
+  ipcMain.handle('settings:set-app-observe-enabled', (_event, enabled: boolean) => {
+    setObserveEnabled(enabled)
   })
   ipcMain.handle('settings:get-repos-root', () => getReposRoot())
   ipcMain.handle('settings:set-repos-root', (_event, root: string) => {
@@ -472,6 +482,15 @@ app.whenReady().then(async () => {
     })
   }
 
+  // Observe directly-opened desktop-app sessions (#119). Read-only, degrades
+  // quietly when the app is closed; a reconcile that changes something refreshes
+  // the renderer. Guarded so a failure can't block the window.
+  try {
+    initObserving(() => broadcast('copilot:updated'))
+  } catch (err) {
+    console.error('[copilot/observe] Failed to start observer:', err instanceof Error ? err.message : 'error')
+  }
+
   createWindow()
 
   app.on('activate', () => {
@@ -489,6 +508,7 @@ app.on('window-all-closed', () => {
 // ~/.mcp.json entry in place (quit != disable); the shim degrades gracefully to
 // "app not running" when the run files are gone.
 app.on('will-quit', () => {
+  shutdownObserving()
   void shutdownMcpServer().catch((err: unknown) => {
     console.error('[mcp] Shutdown failed:', err instanceof Error ? err.message : 'error')
   })

--- a/src/renderer/src/components/TodoSessionChip.test.tsx
+++ b/src/renderer/src/components/TodoSessionChip.test.tsx
@@ -17,7 +17,8 @@ beforeEach(() => {
 function session(overrides: Partial<CopilotAppSession> = {}): CopilotAppSession {
   return {
     id: 'app-1', projectId: 1, cwd: '/x', title: 't', status: 'in_progress',
-    repoOwner: null, repoName: null, createdAt: '', updatedAt: '', ...overrides,
+    repoOwner: null, repoName: null, origin: 'launched', pinnedProjectId: null,
+    createdAt: '', updatedAt: '', ...overrides,
   }
 }
 

--- a/src/renderer/src/pages/SettingsView.tsx
+++ b/src/renderer/src/pages/SettingsView.tsx
@@ -60,22 +60,25 @@ export function SettingsView({ theme, onClose, onOpenRules }: SettingsViewProps)
   const [syncInterval, setSyncInterval] = useState<SyncIntervalMinutes | null>(null)
   const [maxDays, setMaxDays] = useState<MaxSyncDays | null>(null)
   const [appDelegate, setAppDelegate] = useState<boolean | null>(null)
+  const [appObserve, setAppObserve] = useState<boolean | null>(null)
   const [reposRoot, setReposRoot] = useState<string | null>(null)
 
   useEffect(() => {
     let active = true
     void (async () => {
       try {
-        const [interval, days, delegate, root] = await Promise.all([
+        const [interval, days, delegate, observe, root] = await Promise.all([
           window.electron.ipc.invoke('settings:get-sync-interval'),
           window.electron.ipc.invoke('settings:get-max-sync-days'),
           window.electron.ipc.invoke('settings:get-app-delegate-enabled'),
+          window.electron.ipc.invoke('settings:get-app-observe-enabled'),
           window.electron.ipc.invoke('settings:get-repos-root'),
         ])
         if (!active) return
         setSyncInterval(interval)
         setMaxDays(days)
         setAppDelegate(delegate)
+        setAppObserve(observe)
         setReposRoot(root)
       } catch (err) {
         console.error('[Settings] load failed:', err)
@@ -97,6 +100,10 @@ export function SettingsView({ theme, onClose, onOpenRules }: SettingsViewProps)
   const changeAppDelegate = (value: boolean): void => {
     setAppDelegate(value)
     fire(window.electron.ipc.invoke('settings:set-app-delegate-enabled', value), 'settings:set-app-delegate-enabled')
+  }
+  const changeAppObserve = (value: boolean): void => {
+    setAppObserve(value)
+    fire(window.electron.ipc.invoke('settings:set-app-observe-enabled', value), 'settings:set-app-observe-enabled')
   }
   const saveReposRoot = (): void => {
     if (reposRoot === null) return
@@ -255,6 +262,19 @@ export function SettingsView({ theme, onClose, onOpenRules }: SettingsViewProps)
               checked={appDelegate ?? false}
               disabled={appDelegate === null}
               onChange={(e) => changeAppDelegate(e.target.checked)}
+            />
+          </label>
+          <label className={styles.field}>
+            <span className={styles.label}>
+              Observe desktop-app sessions
+              <span className={styles.hint}> — tracks sessions you open directly in the Copilot app (read-only) and shows them under the matching project. Turn off to stop watching.</span>
+            </span>
+            <input
+              type="checkbox"
+              className={styles.checkbox}
+              checked={appObserve ?? false}
+              disabled={appObserve === null}
+              onChange={(e) => changeAppObserve(e.target.checked)}
             />
           </label>
           <div className={styles.field}>

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -93,9 +93,18 @@ export type CopilotAppSessionStatus =
   | 'unknown'     // app closed / status unreadable
 
 /**
- * A task delegated to the INSTALLED GitHub Copilot desktop app over its local
- * WebSocket. Kept in a dedicated table (`copilot_app_sessions`), never mixed
- * with cloud `gh agent-task` sessions.
+ * How a `copilot_app_sessions` row came to exist:
+ *   - 'launched'  — GH Projects created the session over the WS delegate path.
+ *   - 'observed'  — the user opened the session directly in the desktop app and
+ *                   we reconciled it read-only from the app's on-disk store (#119).
+ */
+export type CopilotAppSessionOrigin = 'launched' | 'observed'
+
+/**
+ * A GitHub Copilot desktop-app session. Kept in a dedicated table
+ * (`copilot_app_sessions`), never mixed with cloud `gh agent-task` sessions.
+ * Either delegated by Projects ('launched') or observed after the user opened it
+ * directly in the app ('observed', #119).
  */
 export interface CopilotAppSession {
   id: string                     // WS session_id (uuid)
@@ -105,6 +114,14 @@ export interface CopilotAppSession {
   status: CopilotAppSessionStatus
   repoOwner: string | null
   repoName: string | null
+  origin: CopilotAppSessionOrigin
+  /**
+   * Sticky project assignment for an app session, mirroring
+   * `CopilotSession.pinnedProjectId`. Set by manual assignment; when it points at
+   * a live project it wins over the reconciler's auto-resolution so an observed
+   * session doesn't drift on the next reconcile. Null = follow auto-resolution.
+   */
+  pinnedProjectId: number | null
   createdAt: string              // SQLite datetime, UTC ("YYYY-MM-DD HH:MM:SS")
   updatedAt: string              // SQLite datetime, UTC ("YYYY-MM-DD HH:MM:SS")
 }
@@ -920,6 +937,19 @@ export type IpcChannels = {
     result: TodoAppSession[]
   }
 
+  /**
+   * Returns ALL desktop-app sessions for a project (both Projects-'launched' and
+   * directly-'observed', #119), newest first. Unlike
+   * `copilot:app-sessions-for-project` (which only surfaces sessions linked to a
+   * todo), this is keyed purely on the session's project assignment, so observed
+   * sessions — which have no todo link — show up too. The clean per-project reader
+   * #117's Copilot tab builds on.
+   */
+  'copilot:project-app-sessions': {
+    args: [projectId: number]
+    result: CopilotAppSession[]
+  }
+
   /** Reads the app-delegate feature flag (default false). */
   'settings:get-app-delegate-enabled': {
     args: []
@@ -928,6 +958,18 @@ export type IpcChannels = {
 
   /** Sets the app-delegate feature flag. */
   'settings:set-app-delegate-enabled': {
+    args: [enabled: boolean]
+    result: void
+  }
+
+  /** Reads whether directly-opened desktop-app sessions are observed (default true, #119). */
+  'settings:get-app-observe-enabled': {
+    args: []
+    result: boolean
+  }
+
+  /** Enables/disables observing directly-opened desktop-app sessions (#119). */
+  'settings:set-app-observe-enabled': {
     args: [enabled: boolean]
     result: void
   }


### PR DESCRIPTION
Closes #119. Part of #101 (epic #98).

This tracks Copilot sessions the user opens **directly in the desktop app** (not delegated from Projects) - the real pain from #101. It maps them to a project by repo, stores them as `observed` (distinct from Projects-`launched`), and lets us link back via the existing `github-app://sessions/<id>` deep link. It's spike-flavored: it rides the desktop app's unofficial local protocol, so it's built to degrade quietly and fail closed, all contained behind the one adapter dir `src/main/agent/copilot-app/`.

## The key open question, answered with live evidence

**Does the WS `session_event` (for externally-created sessions) carry the `cwd`? No.** I ran a read-only observer probe against the running app (token redacted, only listened, never sent a session-mutating frame). `session_event` is:

```
{ session_id, type, event: { type, data, id, parentId, timestamp, ephemeral } }
```

`event.type` values seen: `assistant.turn_start` / `turn_end`, `tool.execution_partial_result` / `_complete`, `session.usage_info`, `session.canvas.opened`, `session.background_tasks_changed`. A recursive key scan found **no `cwd` / `repository` / `git_root` anywhere**. So the WS tells us a session exists and is *live*, but not *where*. That's exactly why the on-disk reconciler is required, and it's the design here.

The repo/cwd comes from the app's own on-disk store: `~/.copilot/session-state/<id>/workspace.yaml` carries `cwd`, `repository` (owner/repo), and `name`. The directory basename equals the session id equals the WS `session_id`.

## Two mechanisms (both behind `src/main/agent/copilot-app/`)

1. **Persistent WS observer** (`observer.ts`) - a single long-lived listener, distinct from the one-shot delegate client. It treats `session_event` as a *liveness trigger*: an event for a session id triggers a targeted on-disk reconcile of that id. It re-reads the rotating token on every reconnect (never logs/throws it), resets backoff only on `server_hello` (a stable connection), uses capped exponential reconnect backoff, and a generation token so `stop()` turns every scheduled callback into a no-op. A short miss-retry schedule handles the `workspace.yaml` flush race, and a periodic scan is the backstop.
2. **On-disk reconciler** (`reconcile.ts`) - read-only. Parses `workspace.yaml` (defensively, no YAML dep) as the source of truth for repo, maps repo -> project via `resolveProjectId`, and upserts. Bounded by recency + a cap so the ~3,300 historical session dirs don't churn; `reconcileOne` is *not* recency-bounded so an old-but-active session flagged by the WS is still ingested. The dir basename is canonical identity; a `workspace.yaml.id` that disagrees is skipped. The asserted `repository` is validated to strict `owner/repo` and used **only** for project mapping - never for command execution or file access.

**Scope decision (honest):** I only store observed sessions whose repo resolves to a live project (i.e. "a repo Projects knows about"). Sessions in unmapped repos are skipped rather than piling thousands of unrelated app sessions into the store. They become observable if a mapping is added later while they're still in the recency window. A bounded unresolved-session cache for #118-style adoption is intentionally out of scope here.

## Storage / IPC (clean seam for #117/#118)

- Migration `021` adds `origin` (`launched` | `observed`, CHECK) and `pinned_project_id` (FK, `ON DELETE SET NULL`) to `copilot_app_sessions`.
- `upsertObservedSession` never downgrades a `launched` row to `observed`, and keeps a sticky `pinned_project_id` (pin wins while its project is live, else the freshly-resolved project) - mirroring the cloud `copilot_sessions` upsert.
- `assignAppSession` for manual sticky assignment; `deleteProject` now detaches app sessions the same way it detaches cloud sessions.
- New `copilot:project-app-sessions` IPC returns all of a project's app sessions (both origins), status-refreshed read-only. Deep link reuses the existing `copilot:open-app-session`.
- A visible **Settings toggle** ("Observe desktop-app sessions", default on) is a real kill switch that tears the whole pipeline down.

## Guardrails
- Read-only w.r.t. all `~/.copilot/` files; never writes them; never logs the WS token.
- Unofficial layout/protocol behind one adapter; fails closed on shape drift; token-safe diagnostic counters so a silent break is still debuggable.
- Only works while the app is running; degrades quietly otherwise. TS strict, no `any`, named exports, all I/O off the render thread, typed IPC.

## How I verified

- **`bun run test` green: 723 tests, typecheck + eslint clean.**
- **Unit/integration:**
  - `workspace-yaml.test.ts` - parser edge cases: quoted/doubled-quote scalars, block-scalar folding (`name: |-`), indented/nested keys ignored, comments, first-occurrence-wins, unterminated quote, strict `owner/repo` validation, session-id shape.
  - `reconcile.integration.test.ts` (real store + in-memory DB + fixture fs) - cwd->repo->project->observed upsert; skips no-repo / unresolved / already-launched (no downgrade) / id-mismatch; full scan is recency-bounded but `reconcileOne` still ingests an old session; sticky pin doesn't drift; no-op re-reconcile reports no change.
  - `observer.integration.test.ts` (real fake WS server) - `server_hello`-driven full reconcile; a `session_event` for a session not in the on-disk listing still ingests via targeted reconcile; reconnect + endpoint re-read after the app drops the socket; the `workspace.yaml` flush-race retry; a full reconcile doesn't drop a queued targeted id; `stop()` halts ingestion and reconnection.
  - store tests - observed upsert, no origin downgrade, sticky pin (incl. cleared when the pinned project is soft-deleted), `assignAppSession`, `deleteProject` detaches app sessions, still invisible to the github-session readers.
- **Live characterization on the running app** (this machine):
  - The `session_event`-has-no-cwd finding above.
  - The real reconciler parser run against the actual `~/.copilot/session-state`: 1,676 recent dirs scanned, 1,649 with a `cwd`, 1,464 with a valid `repository`, 0 id-mismatches, 43 correctly mapped to `robert-crandall/gh-notifier` (with correct cwds + titles).
  - The full WS->disk handoff against the live app: a real `session_event` for a session resolved through its on-disk `workspace.yaml` to `robert-crandall-org/librarian` with its real title.

## Honest gaps
- A fully automated end-to-end against the real desktop app opening a *brand-new* session is not automated (the WS + on-disk halves are each characterized live above, and the wiring is unit-tested against a fake server).
- The `workspace.yaml` layout is unofficial; if the app changes it, this one adapter fails closed (empty diagnostics counters) rather than misbehaving.
- The MCP-skill `register_session(repo)` self-registration idea from #119 is **not** needed here (session_event lacks cwd, but the on-disk `workspace.yaml` reliably supplies cwd+repo) - it stays a documented future option.