### PR TITLE
One-tap "assign + remember repo" for unassigned cloud sessions

### DIFF
--- a/src/main/copilot/copilot-db.integration.test.ts
+++ b/src/main/copilot/copilot-db.integration.test.ts
@@ -18,8 +18,11 @@ import {
   getUnassignedSessions,
   getUnassignedActiveCount,
   assignSession,
+  getRepoRuleSuggestionForSession,
 } from './db'
 import { getLaunchTargets } from './launch-targets'
+import { resolveProjectId } from './resolve-project'
+import { createRepoRule, listRepoRules } from '../db/notifications'
 import { deleteProject } from '../db/projects'
 import { getDigest } from '../digest'
 
@@ -139,6 +142,128 @@ describe('assignSession', () => {
     expect(() => assignSession('nope', p)).toThrow(/SESSION_NOT_FOUND/)
     deleteProject(p)
     expect(() => assignSession('s1', p)).toThrow(/PROJECT_NOT_FOUND/)
+  })
+})
+
+describe('getRepoRuleSuggestionForSession', () => {
+  it('suggests opt-in when the repo has no rule yet', () => {
+    const p = makeProject('P')
+    upsertSessions([syncedSession({ id: 's1', projectId: null, repoOwner: 'o', repoName: 'r' })])
+    assignSession('s1', p)
+
+    expect(getRepoRuleSuggestionForSession('s1', p)).toEqual({
+      type: 'opt-in',
+      repoOwner: 'o',
+      repoName: 'r',
+      projectId: p,
+      projectName: 'P',
+    })
+  })
+
+  it('returns null when a live repo rule already exists', () => {
+    const p = makeProject('P')
+    upsertSessions([syncedSession({ id: 's1', projectId: null, repoOwner: 'o', repoName: 'r' })])
+    assignSession('s1', p)
+    createRepoRule('o', 'r', p)
+
+    expect(getRepoRuleSuggestionForSession('s1', p)).toBeNull()
+  })
+
+  it('still suggests (to repair) when the only rule points at a soft-deleted project', () => {
+    const dead = makeProject('Dead')
+    const live = makeProject('Live')
+    createRepoRule('o', 'r', dead)
+    deleteProject(dead)
+    upsertSessions([syncedSession({ id: 's1', projectId: null, repoOwner: 'o', repoName: 'r' })])
+    assignSession('s1', live)
+
+    expect(getRepoRuleSuggestionForSession('s1', live)).toEqual({
+      type: 'opt-in',
+      repoOwner: 'o',
+      repoName: 'r',
+      projectId: live,
+      projectName: 'Live',
+    })
+  })
+
+  it('returns null when the session carries no repo', () => {
+    const p = makeProject('P')
+    upsertSessions([syncedSession({ id: 's1', projectId: null, repoOwner: null, repoName: null })])
+    assignSession('s1', p)
+    expect(getRepoRuleSuggestionForSession('s1', p)).toBeNull()
+  })
+
+  it('returns null for a missing session', () => {
+    const p = makeProject('P')
+    expect(getRepoRuleSuggestionForSession('nope', p)).toBeNull()
+  })
+})
+
+describe('assign-and-remember (issue #118)', () => {
+  it('assigns the session and remembers the repo so future sessions auto-assign', () => {
+    const p = makeProject('P')
+    upsertSessions([syncedSession({ id: 's1', projectId: null, repoOwner: 'o', repoName: 'r' })])
+
+    // One-tap: assign the session, then remember the repo mapping.
+    assignSession('s1', p)
+    const suggestion = getRepoRuleSuggestionForSession('s1', p)
+    expect(suggestion).not.toBeNull()
+    createRepoRule(suggestion!.repoOwner, suggestion!.repoName, suggestion!.projectId)
+
+    // The session is homed and the repo rule now exists.
+    expect(getSessionsForProject(p).map((s) => s.id)).toContain('s1')
+    expect(listRepoRules().map((r) => `${r.repoOwner}/${r.repoName}→${r.projectId}`)).toContain('o/r→' + p)
+
+    // A subsequent NEW session synced from the same repo auto-resolves — no manual assign.
+    const resolved = resolveProjectId('o', 'r', null)
+    expect(resolved).toBe(p)
+    upsertSessions([syncedSession({ id: 's2', projectId: resolved, repoOwner: 'o', repoName: 'r' })])
+    expect(getSessionsForProject(p).map((s) => s.id)).toContain('s2')
+    expect(getUnassignedSessions().map((s) => s.id)).not.toContain('s2')
+  })
+
+  it('the just-assigned session survives a resync that resolves to null (sticky)', () => {
+    const p = makeProject('P')
+    upsertSessions([syncedSession({ id: 's1', projectId: null, repoOwner: 'o', repoName: 'r' })])
+    assignSession('s1', p)
+    createRepoRule('o', 'r', p)
+
+    // Force a sync whose incoming projectId is null to prove the PIN (not the rule) holds it.
+    upsertSessions([syncedSession({ id: 's1', projectId: null, repoOwner: 'o', repoName: 'r' })])
+
+    const row = db
+      .prepare('SELECT project_id, pinned_project_id FROM copilot_sessions WHERE id = ?')
+      .get('s1') as { project_id: number | null; pinned_project_id: number | null }
+    expect(row.project_id).toBe(p)
+    expect(row.pinned_project_id).toBe(p)
+    expect(getUnassignedSessions().map((s) => s.id)).not.toContain('s1')
+    expect(getUnassignedActiveCount()).toBe(0)
+  })
+
+  it('repairs a stale dead-project rule so new sessions resolve to the live project', () => {
+    const dead = makeProject('Old')
+    const live = makeProject('New')
+    createRepoRule('o', 'r', dead)
+    deleteProject(dead)
+
+    // resolveProjectId skips the dead-project rule, so a synced session lands unassigned.
+    expect(resolveProjectId('o', 'r', null)).toBeNull()
+    upsertSessions([syncedSession({ id: 's1', projectId: resolveProjectId('o', 'r', null), repoOwner: 'o', repoName: 'r' })])
+    expect(getUnassignedSessions().map((s) => s.id)).toContain('s1')
+
+    // Assign + remember: the suggestion fires (dead rule = no live mapping) and the
+    // UPSERT overwrites the stale rule to point at the live project.
+    assignSession('s1', live)
+    const suggestion = getRepoRuleSuggestionForSession('s1', live)
+    expect(suggestion).not.toBeNull()
+    createRepoRule(suggestion!.repoOwner, suggestion!.repoName, suggestion!.projectId)
+
+    expect(listRepoRules().map((r) => `${r.repoOwner}/${r.repoName}→${r.projectId}`)).toEqual(['o/r→' + live])
+
+    // A new synced session now resolves to the live project.
+    expect(resolveProjectId('o', 'r', null)).toBe(live)
+    upsertSessions([syncedSession({ id: 's2', projectId: resolveProjectId('o', 'r', null), repoOwner: 'o', repoName: 'r' })])
+    expect(getSessionsForProject(live).map((s) => s.id)).toContain('s2')
   })
 })
 

--- a/src/main/copilot/db.ts
+++ b/src/main/copilot/db.ts
@@ -5,7 +5,7 @@
  */
 
 import { getDb } from '../db'
-import type { CopilotSession, CopilotSessionStatus } from '../../shared/ipc-channels'
+import type { CopilotSession, CopilotSessionStatus, RepoRuleSuggestion } from '../../shared/ipc-channels'
 
 interface CopilotSessionRow {
   id: string
@@ -229,6 +229,59 @@ export function assignSession(sessionId: string, projectId: number): void {
     .prepare('UPDATE copilot_sessions SET project_id = ?, pinned_project_id = ? WHERE id = ?')
     .run(projectId, projectId, sessionId)
   if (result.changes === 0) throw new Error('SESSION_NOT_FOUND')
+}
+
+/**
+ * After an unassigned session is assigned to a project, offer to remember the
+ * repo → project mapping so future sessions in that repo auto-assign at sync time
+ * (the "Assign to project + remember this repo" affordance). Mirrors the Inbox's
+ * repo-rule suggestion: always an `opt-in` for cloud sessions (there is no
+ * other-threads signal to compute opt-out from).
+ *
+ * Returns null when:
+ *   - the session is missing or carries no repo (nothing to remember), or
+ *   - a repo rule already exists whose project is LIVE. A rule pointing at a
+ *     soft-deleted project is treated as no effective mapping (resolveProjectId
+ *     skips dead-project rules, which is why the session was unassigned), so the
+ *     suggestion still fires and `createRepoRule`'s UPSERT can repair the stale row.
+ *
+ * Uses exact-case repo matching, consistent with resolveProjectId step 2 and
+ * createRepoRule.
+ */
+export function getRepoRuleSuggestionForSession(
+  sessionId: string,
+  projectId: number
+): RepoRuleSuggestion | null {
+  const db = getDb()
+
+  const session = db
+    .prepare('SELECT repo_owner, repo_name FROM copilot_sessions WHERE id = ?')
+    .get(sessionId) as { repo_owner: string | null; repo_name: string | null } | undefined
+  if (!session || !session.repo_owner || !session.repo_name) return null
+
+  // A live repo rule already routes future sessions here — nothing to suggest.
+  const liveRule = db
+    .prepare(`
+      SELECT 1 FROM repo_rules rr
+      JOIN projects p ON p.id = rr.project_id
+      WHERE rr.repo_owner = ? AND rr.repo_name = ? AND p.deleted_at IS NULL
+      LIMIT 1
+    `)
+    .get(session.repo_owner, session.repo_name)
+  if (liveRule) return null
+
+  const project = db
+    .prepare('SELECT name FROM projects WHERE id = ? AND deleted_at IS NULL')
+    .get(projectId) as { name: string } | undefined
+  if (!project) return null
+
+  return {
+    type: 'opt-in',
+    repoOwner: session.repo_owner,
+    repoName: session.repo_name,
+    projectId,
+    projectName: project.name,
+  }
 }
 
 /**

--- a/src/main/copilot/db.ts
+++ b/src/main/copilot/db.ts
@@ -256,7 +256,7 @@ export function getRepoRuleSuggestionForSession(
 
   const session = db
     .prepare('SELECT repo_owner, repo_name FROM copilot_sessions WHERE id = ?')
-    .get(sessionId) as { repo_owner: string | null; repo_name: string | null } | undefined
+    .get(sessionId) as { repo_owner: string | null; repo_name: string | null } | undefined | null
   if (!session || !session.repo_owner || !session.repo_name) return null
 
   // A live repo rule already routes future sessions here — nothing to suggest.
@@ -272,7 +272,7 @@ export function getRepoRuleSuggestionForSession(
 
   const project = db
     .prepare('SELECT name FROM projects WHERE id = ? AND deleted_at IS NULL')
-    .get(projectId) as { name: string } | undefined
+    .get(projectId) as { name: string } | undefined | null
   if (!project) return null
 
   return {

--- a/src/main/copilot/resolve-project.ts
+++ b/src/main/copilot/resolve-project.ts
@@ -26,7 +26,7 @@ export function resolveProjectId(
   // A chosen project only counts if it's live (not soft-deleted), so a deleted
   // project can't keep absorbing Copilot sessions on the next sync.
   const isLive = (projectId: number): boolean =>
-    db.prepare('SELECT 1 FROM projects WHERE id = ? AND deleted_at IS NULL').get(projectId) !== undefined
+    db.prepare('SELECT 1 FROM projects WHERE id = ? AND deleted_at IS NULL').get(projectId) != null
 
   // 1. Follow the notification thread — wherever the PR notification is routed, the
   //    Copilot session goes too. This keeps Copilot sessions co-located with their work

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -25,7 +25,7 @@ import { listRoutingRules, createRoutingRule, deleteRoutingRule, applyRoutingRul
 import { startNotificationSync, syncOnce, prefetchThreadContent, getSyncIntervalMinutes, setSyncIntervalMinutes, rescheduleSync, getMaxSyncDays, setMaxSyncDays } from './notifications/sync'
 import { startSnoozeWatcher } from './snooze'
 import { syncCopilotSessions } from './copilot/sync'
-import { getSessionsForProject, getAllStatuses, insertLaunchedSession, getUnassignedSessions, getUnassignedActiveCount, assignSession } from './copilot/db'
+import { getSessionsForProject, getAllStatuses, insertLaunchedSession, getUnassignedSessions, getUnassignedActiveCount, assignSession, getRepoRuleSuggestionForSession } from './copilot/db'
 import { launchAgentTask } from './copilot/launch'
 import { getLaunchTargets } from './copilot/launch-targets'
 import { getDigest, markProjectFocused, markDigestSeen, dismissResurface } from './digest'
@@ -335,8 +335,10 @@ app.whenReady().then(async () => {
   ipcMain.handle('copilot:unassigned-count', () => getUnassignedActiveCount())
   ipcMain.handle('copilot:assign', (_event, sessionId: string, projectId: number) => {
     assignSession(sessionId, projectId)
+    const suggestion = getRepoRuleSuggestionForSession(sessionId, projectId)
     broadcast('copilot:updated')
     broadcast('projects:updated')
+    return suggestion
   })
   ipcMain.handle('copilot:launch-targets', (_event, projectId: number) => getLaunchTargets(projectId))
 

--- a/src/renderer/src/pages/AgentTasksView.module.css
+++ b/src/renderer/src/pages/AgentTasksView.module.css
@@ -27,6 +27,47 @@
   color: var(--text-3);
 }
 
+.suggestion {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin: 12px 24px 0;
+  padding: 10px 14px;
+  background: var(--accent-subtle);
+  border: 1px solid var(--accent-border);
+  border-radius: var(--radius);
+  font-size: 13px;
+  color: var(--text);
+}
+
+.suggestionActions {
+  display: flex;
+  gap: 8px;
+  flex: none;
+}
+
+.accept,
+.dismiss {
+  height: 26px;
+  padding: 0 10px;
+  font-size: 12px;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+
+.accept {
+  color: var(--accent-fg);
+  background: var(--accent);
+  border: 1px solid transparent;
+}
+
+.dismiss {
+  color: var(--text-2);
+  background: var(--bg-window);
+  border: 1px solid var(--border);
+}
+
 .content {
   flex: 1;
   overflow-y: auto;

--- a/src/renderer/src/pages/AgentTasksView.test.tsx
+++ b/src/renderer/src/pages/AgentTasksView.test.tsx
@@ -97,6 +97,29 @@ describe('AgentTasksView', () => {
     await waitFor(() => expect(screen.queryByText(/Always route o\/r to/)).toBeNull())
   })
 
+  it('keeps the banner up when remembering the repo fails', async () => {
+    invoke.mockImplementation((channel: string) => {
+      if (channel === 'copilot:unassigned') {
+        return Promise.resolve([session({ id: 'a', title: 'Active one', repoOwner: 'o', repoName: 'r' })])
+      }
+      if (channel === 'projects:list') return Promise.resolve([project])
+      if (channel === 'copilot:assign') return Promise.resolve(optInSuggestion)
+      if (channel === 'repo-rules:create') return Promise.reject(new Error('boom'))
+      return Promise.resolve(undefined)
+    })
+    render(<AgentTasksView />)
+    await screen.findByText('Active one')
+
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: '1' } })
+    await screen.findByText(/Always route o\/r to/)
+
+    fireEvent.click(screen.getByText('Remember repo'))
+
+    // The create failed, so the banner stays so the user can retry.
+    await waitFor(() => expect(invoke).toHaveBeenCalledWith('repo-rules:create', 'o', 'r', 1))
+    expect(screen.getByText(/Always route o\/r to/)).toBeTruthy()
+  })
+
   it('dismisses the suggestion without creating a rule', async () => {
     mockInvoke([session({ id: 'a', title: 'Active one', repoOwner: 'o', repoName: 'r' })], optInSuggestion)
     render(<AgentTasksView />)

--- a/src/renderer/src/pages/AgentTasksView.test.tsx
+++ b/src/renderer/src/pages/AgentTasksView.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
-import type { CopilotSession, Project } from '@shared/ipc-channels'
+import type { CopilotSession, Project, RepoRuleSuggestion } from '@shared/ipc-channels'
 import { AgentTasksView } from './AgentTasksView'
 
 const invoke = vi.fn()
@@ -32,13 +32,18 @@ const project: Project = {
   snoozeUntil: null, copilotStatus: null, lastFocusedAt: null, driftState: 'active',
 }
 
-function mockInvoke(sessions: CopilotSession[]): void {
+function mockInvoke(sessions: CopilotSession[], assignResult: RepoRuleSuggestion | null = null): void {
   invoke.mockImplementation((channel: string) => {
     if (channel === 'copilot:unassigned') return Promise.resolve(sessions)
     if (channel === 'projects:list') return Promise.resolve([project])
-    if (channel === 'copilot:assign') return Promise.resolve(undefined)
+    if (channel === 'copilot:assign') return Promise.resolve(assignResult)
+    if (channel === 'repo-rules:create') return Promise.resolve(undefined)
     return Promise.resolve(undefined)
   })
+}
+
+const optInSuggestion: RepoRuleSuggestion = {
+  type: 'opt-in', repoOwner: 'o', repoName: 'r', projectId: 1, projectName: 'Alpha',
 }
 
 describe('AgentTasksView', () => {
@@ -69,5 +74,75 @@ describe('AgentTasksView', () => {
     fireEvent.change(select, { target: { value: '1' } })
 
     await waitFor(() => expect(invoke).toHaveBeenCalledWith('copilot:assign', 'a', 1))
+  })
+
+  it('offers to remember the repo and creates the rule on accept', async () => {
+    mockInvoke([session({ id: 'a', title: 'Active one', repoOwner: 'o', repoName: 'r' })], optInSuggestion)
+    render(<AgentTasksView />)
+    await screen.findByText('Active one')
+
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: '1' } })
+
+    // Banner surfaces after assign returns a suggestion.
+    await screen.findByText(/Always route o\/r to/)
+    fireEvent.click(screen.getByText('Remember repo'))
+
+    await waitFor(() => expect(invoke).toHaveBeenCalledWith('repo-rules:create', 'o', 'r', 1))
+    // Banner clears after accepting.
+    await waitFor(() => expect(screen.queryByText(/Always route o\/r to/)).toBeNull())
+  })
+
+  it('dismisses the suggestion without creating a rule', async () => {
+    mockInvoke([session({ id: 'a', title: 'Active one', repoOwner: 'o', repoName: 'r' })], optInSuggestion)
+    render(<AgentTasksView />)
+    await screen.findByText('Active one')
+
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: '1' } })
+    await screen.findByText(/Always route o\/r to/)
+
+    fireEvent.click(screen.getByText('No thanks'))
+
+    await waitFor(() => expect(screen.queryByText(/Always route o\/r to/)).toBeNull())
+    expect(invoke).not.toHaveBeenCalledWith('repo-rules:create', 'o', 'r', 1)
+  })
+
+  it('shows no banner when assign returns no suggestion', async () => {
+    mockInvoke([session({ id: 'a', title: 'Active one' })], null)
+    render(<AgentTasksView />)
+    await screen.findByText('Active one')
+
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: '1' } })
+
+    await waitFor(() => expect(invoke).toHaveBeenCalledWith('copilot:assign', 'a', 1))
+    expect(screen.queryByText(/Always route/)).toBeNull()
+  })
+
+  it('clears a stale banner when a later assignment returns no suggestion', async () => {
+    // First assign surfaces a banner; a second assign of a different session in an
+    // already-mapped repo returns null and must clear the older banner.
+    invoke.mockImplementation((channel: string, _id?: string) => {
+      if (channel === 'copilot:unassigned') {
+        return Promise.resolve([
+          session({ id: 'a', title: 'First', repoOwner: 'o', repoName: 'r' }),
+          session({ id: 'b', title: 'Second', repoOwner: 'o', repoName: 'r' }),
+        ])
+      }
+      if (channel === 'projects:list') return Promise.resolve([project])
+      if (channel === 'copilot:assign') return Promise.resolve(_id === 'a' ? optInSuggestion : null)
+      if (channel === 'repo-rules:create') return Promise.resolve(undefined)
+      return Promise.resolve(undefined)
+    })
+    render(<AgentTasksView />)
+    await screen.findByText('First')
+
+    const selects = screen.getAllByRole('combobox')
+    fireEvent.change(selects[0], { target: { value: '1' } })
+    await screen.findByText(/Always route o\/r to/)
+
+    // Row 'a' is optimistically removed; assign the remaining session 'b', whose
+    // assign returns null → the older banner must clear.
+    const remaining = screen.getAllByRole('combobox')
+    fireEvent.change(remaining[remaining.length - 1], { target: { value: '1' } })
+    await waitFor(() => expect(screen.queryByText(/Always route o\/r to/)).toBeNull())
   })
 })

--- a/src/renderer/src/pages/AgentTasksView.test.tsx
+++ b/src/renderer/src/pages/AgentTasksView.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
-import type { CopilotSession, Project, RepoRuleSuggestion } from '@shared/ipc-channels'
+import type { CopilotSession, Project, RepoRule, RepoRuleSuggestion } from '@shared/ipc-channels'
 import { AgentTasksView } from './AgentTasksView'
 
 const invoke = vi.fn()
@@ -32,12 +32,17 @@ const project: Project = {
   snoozeUntil: null, copilotStatus: null, lastFocusedAt: null, driftState: 'active',
 }
 
+// repo-rules:create resolves to the created RepoRule per the typed IPC contract.
+const createdRule: RepoRule = {
+  id: 7, repoOwner: 'o', repoName: 'r', projectId: 1, createdAt: '2026-07-10T00:00:00Z',
+}
+
 function mockInvoke(sessions: CopilotSession[], assignResult: RepoRuleSuggestion | null = null): void {
   invoke.mockImplementation((channel: string) => {
     if (channel === 'copilot:unassigned') return Promise.resolve(sessions)
     if (channel === 'projects:list') return Promise.resolve([project])
     if (channel === 'copilot:assign') return Promise.resolve(assignResult)
-    if (channel === 'repo-rules:create') return Promise.resolve(undefined)
+    if (channel === 'repo-rules:create') return Promise.resolve(createdRule)
     return Promise.resolve(undefined)
   })
 }
@@ -129,7 +134,7 @@ describe('AgentTasksView', () => {
       }
       if (channel === 'projects:list') return Promise.resolve([project])
       if (channel === 'copilot:assign') return Promise.resolve(_id === 'a' ? optInSuggestion : null)
-      if (channel === 'repo-rules:create') return Promise.resolve(undefined)
+      if (channel === 'repo-rules:create') return Promise.resolve(createdRule)
       return Promise.resolve(undefined)
     })
     render(<AgentTasksView />)

--- a/src/renderer/src/pages/AgentTasksView.tsx
+++ b/src/renderer/src/pages/AgentTasksView.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { formatDistanceToNow, parseISO } from 'date-fns'
 import { Sparkles, GitPullRequest, PauseCircle, CheckCircle2, ExternalLink } from 'lucide-react'
-import type { CopilotSession, CopilotSessionStatus, Project } from '@shared/ipc-channels'
+import type { CopilotSession, CopilotSessionStatus, Project, RepoRuleSuggestion } from '@shared/ipc-channels'
 import type { LucideIcon } from 'lucide-react'
 import { Icon } from '../components/Icon'
 import { openExternal } from '../ipc'
@@ -74,6 +74,7 @@ export function AgentTasksView(): JSX.Element {
   const [sessions, setSessions] = useState<CopilotSession[]>([])
   const [projects, setProjects] = useState<Project[]>([])
   const [isLoading, setIsLoading] = useState(true)
+  const [suggestion, setSuggestion] = useState<RepoRuleSuggestion | null>(null)
   const mountedRef = useRef(true)
 
   useEffect(() => {
@@ -105,13 +106,28 @@ export function AgentTasksView(): JSX.Element {
 
   const handleAssign = useCallback(async (sessionId: string, projectId: number) => {
     try {
-      await window.electron.ipc.invoke('copilot:assign', sessionId, projectId)
+      const result = await window.electron.ipc.invoke('copilot:assign', sessionId, projectId)
+      if (!mountedRef.current) return
+      // Offer to remember the repo → project mapping so future sessions in this
+      // repo auto-assign. A null result (repo already has a live mapping) also
+      // clears any stale banner from a previous assignment.
+      setSuggestion(result)
       // Optimistically drop it from the list; the push event reconciles the rest.
       setSessions((prev) => prev.filter((s) => s.id !== sessionId))
     } catch (err) {
       console.error('[AgentTasks] Assign failed:', err)
     }
   }, [])
+
+  const acceptRule = useCallback(async () => {
+    if (!suggestion) return
+    try {
+      await window.electron.ipc.invoke('repo-rules:create', suggestion.repoOwner, suggestion.repoName, suggestion.projectId)
+    } catch (err) {
+      console.error('[AgentTasks] Repo rule creation failed:', err)
+    }
+    if (mountedRef.current) setSuggestion(null)
+  }, [suggestion])
 
   const active = sessions.filter((s) => s.status !== 'completed')
   const completed = sessions.filter((s) => s.status === 'completed')
@@ -122,6 +138,18 @@ export function AgentTasksView(): JSX.Element {
         <span className={styles.heading}>Agent tasks</span>
         <span className={styles.sub}>Copilot sessions not tied to a project</span>
       </header>
+
+      {suggestion && (
+        <div className={styles.suggestion}>
+          <span>
+            Always route {suggestion.repoOwner}/{suggestion.repoName} to &ldquo;{suggestion.projectName}&rdquo;?
+          </span>
+          <div className={styles.suggestionActions}>
+            <button type="button" className={styles.accept} onClick={() => void acceptRule()}>Remember repo</button>
+            <button type="button" className={styles.dismiss} onClick={() => setSuggestion(null)}>No thanks</button>
+          </div>
+        </div>
+      )}
 
       <div className={styles.content}>
         {isLoading && <div className={styles.empty}>Loading…</div>}

--- a/src/renderer/src/pages/AgentTasksView.tsx
+++ b/src/renderer/src/pages/AgentTasksView.tsx
@@ -123,10 +123,11 @@ export function AgentTasksView(): JSX.Element {
     if (!suggestion) return
     try {
       await window.electron.ipc.invoke('repo-rules:create', suggestion.repoOwner, suggestion.repoName, suggestion.projectId)
+      // Only dismiss on success so a transient IPC/DB error leaves the banner up to retry.
+      if (mountedRef.current) setSuggestion(null)
     } catch (err) {
       console.error('[AgentTasks] Repo rule creation failed:', err)
     }
-    if (mountedRef.current) setSuggestion(null)
   }, [suggestion])
 
   const active = sessions.filter((s) => s.status !== 'completed')

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -866,11 +866,13 @@ export type IpcChannels = {
 
   /**
    * Pins an unassigned session to a live project (sticky across syncs).
+   * Returns a repo-rule suggestion when the repo has no live mapping yet
+   * (offer to remember it so future sessions auto-assign), otherwise null.
    * Throws if the project is missing or soft-deleted.
    */
   'copilot:assign': {
     args: [sessionId: string, projectId: number]
-    result: void
+    result: RepoRuleSuggestion | null
   }
 
   /**


### PR DESCRIPTION
Closes #118. Part of #101.

## What and why

Cloud `gh agent-task` sessions in a mapped repo already auto-assign at sync time (`resolveProjectId`: notification thread -> `repo_rules` -> `routing_rules`), and a manual assign is sticky via `pinned_project_id`. The gap was the *first* unassigned session in a repo with no mapping yet: assigning it left no `repo_rules` row, so the next session in that repo landed unassigned again.

Now, assigning an unassigned session in `AgentTasksView` surfaces an Inbox-style banner offering to remember the repo -> project mapping. Accept creates the `repo_rules` row so future sessions auto-assign; dismiss is a no-op. This reuses the Inbox's existing suggestion pattern and the existing `repo-rules:create` IPC.

## Changes

- **`getRepoRuleSuggestionForSession` (main, `copilot/db.ts`)**: returns an `opt-in` `RepoRuleSuggestion` unless a **live** repo rule already exists for the session's repo. A rule pointing at a soft-deleted project counts as no effective mapping (`resolveProjectId` skips dead-project rules), so the suggestion still fires and `createRepoRule`'s UPSERT repairs the stale row. Exact-case repo match, consistent with `resolveProjectId` step 2 and `createRepoRule`.
- **`copilot:assign` IPC**: now returns `RepoRuleSuggestion | null` (was `void`). The handler assigns first (sticky), then computes the suggestion. The only caller is `AgentTasksView`.
- **`AgentTasksView`**: `handleAssign` stores the returned suggestion and renders a banner ("Always route owner/repo to \"Project\"?") with **Remember repo** -> `repo-rules:create` and **No thanks** -> dismiss. Setting the suggestion unconditionally means a later assign that returns null also clears a stale banner. Reuses the Inbox banner CSS.
- **`resolve-project.ts` liveness check**: `!= null` instead of `!== undefined` so it's correct under both better-sqlite3 (returns `undefined` for no-row) and the bun:sqlite test harness (returns `null`). No production behavior change; this makes the dead-rule path genuinely testable.

No new tables and no new IPC channels (only the `copilot:assign` return type widened).

## How I verified

`bun run test` (typecheck + eslint + 752 vitest tests) is green. New tests:

- **`getRepoRuleSuggestionForSession`** (`copilot-db.integration.test.ts`): opt-in when no rule; null when a live rule exists; opt-in (repair) when the only rule points at a soft-deleted project; null when the session has no repo; null for a missing session.
- **assign-and-remember**: `assignSession` + `createRepoRule` homes the session and writes the `repo_rules` row, and a subsequent synced *new* session in that repo auto-resolves (`resolveProjectId` -> project, `upsertSessions` homes it) with no manual assign.
- **sticky across resync**: after assign-and-remember, a sync whose incoming `projectId` is null leaves both `project_id` and `pinned_project_id` set and the session absent from the unassigned list/count - it does not bounce back.
- **dead-rule repair end-to-end**: a dead-project rule makes `resolveProjectId` return null (session unassigned); assign + accept overwrites the rule to the live project; a new synced session then resolves to the live project.
- **renderer** (`AgentTasksView.test.tsx`): assigning surfaces the banner; Remember calls `repo-rules:create` with the right args and clears the banner; No thanks dismisses without creating a rule; a null return shows no banner; a later null-returning assign clears a stale banner.

### Not verified

A packaged-app click-through isn't automated - I exercised the renderer via React Testing Library and the main-process paths via the Bun sqlite integration suite, not a running Electron build.

## Review process

Plan and implementation were both reviewed by an independent model (GPT 5.5) to convergence. The plan review caught the soft-deleted-rule suppression edge (fixed before implementing); the impl review confirmed ready for merge after two nit fixes (stale-banner clear + the `resolveProjectId` liveness tidy-up), both included here.