### PR TITLE
Add a per-project Copilot sessions tab to WorkingColumn (#117)

### DIFF
--- a/src/renderer/src/components/CopilotSessionsPanel.module.css
+++ b/src/renderer/src/components/CopilotSessionsPanel.module.css
@@ -1,0 +1,83 @@
+.list {
+  display: flex;
+  flex-direction: column;
+}
+
+.row {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  padding: 9px 6px;
+  border-bottom: 1px solid var(--border-muted);
+}
+
+.row:hover {
+  background: var(--bg-subtle);
+}
+
+.status {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: none;
+}
+
+.toneAgent {
+  color: var(--accent-text);
+}
+
+.toneAttention {
+  color: var(--attention);
+}
+
+.toneQuiet {
+  color: var(--text-3);
+}
+
+.body {
+  flex: 1;
+  min-width: 0;
+}
+
+.title {
+  font-size: 13px;
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.meta {
+  font-size: 11.5px;
+  color: var(--text-3);
+  margin-top: 2px;
+}
+
+.hint {
+  color: var(--text-2);
+}
+
+.rowAction {
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  color: var(--text-3);
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  flex: none;
+}
+
+.rowAction:hover {
+  background: var(--bg-elevated);
+  color: var(--text);
+}
+
+.empty {
+  color: var(--text-3);
+  font-size: 13px;
+  padding: 4px 0;
+}

--- a/src/renderer/src/components/CopilotSessionsPanel.test.tsx
+++ b/src/renderer/src/components/CopilotSessionsPanel.test.tsx
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import type { CopilotSessionRow } from '../hooks/useCopilotSessions'
+import { CopilotSessionsPanel } from './CopilotSessionsPanel'
+
+beforeEach(() => {
+  ;(globalThis as unknown as { window: Window }).window.electron = {
+    ipc: { invoke: vi.fn(() => Promise.resolve()) },
+    openExternal: vi.fn(() => Promise.resolve()),
+  } as unknown as Window['electron']
+})
+
+function row(overrides: Partial<CopilotSessionRow>): CopilotSessionRow {
+  return {
+    key: 'cloud:c',
+    kind: 'cloud',
+    title: 'A session',
+    status: 'in_progress',
+    startedAt: '2026-07-01T00:00:00Z',
+    updatedAtMs: Date.parse('2026-07-01T00:00:00Z'),
+    githubUrl: null,
+    appSessionId: null,
+    origin: null,
+    ...overrides,
+  }
+}
+
+describe('CopilotSessionsPanel empty states', () => {
+  it('shows the definitive "no sessions" copy only on an authoritative empty', () => {
+    render(<CopilotSessionsPanel rows={[]} emptyIsAuthoritative={true} />)
+    expect(screen.getByText(/No Copilot sessions/i)).toBeTruthy()
+  })
+
+  it('stays indeterminate (never "no sessions") on a non-authoritative empty', () => {
+    // Covers both the initial load and a transient/failed load while the tab is pinned:
+    // a failure must never present as a confirmed empty.
+    render(<CopilotSessionsPanel rows={[]} emptyIsAuthoritative={false} />)
+    expect(screen.queryByText(/No Copilot sessions/i)).toBeNull()
+    expect(screen.getByText('Loading…')).toBeTruthy()
+  })
+
+  it('renders the session list when rows are present', () => {
+    render(<CopilotSessionsPanel rows={[row({ title: 'My session' })]} emptyIsAuthoritative={false} />)
+    expect(screen.getByText('My session')).toBeTruthy()
+    expect(screen.queryByText(/No Copilot sessions/i)).toBeNull()
+  })
+})

--- a/src/renderer/src/components/CopilotSessionsPanel.tsx
+++ b/src/renderer/src/components/CopilotSessionsPanel.tsx
@@ -1,0 +1,115 @@
+import { formatDistanceToNow } from 'date-fns'
+import { Sparkles, GitPullRequest, PauseCircle, CheckCircle2, HelpCircle, ExternalLink, ArrowUpRight } from 'lucide-react'
+import type { LucideIcon } from 'lucide-react'
+import { parseDbTimestampMs } from '@shared/time'
+import type { CopilotRowKind, CopilotRowStatus, CopilotSessionRow } from '../hooks/useCopilotSessions'
+import { Icon } from './Icon'
+import { fire, openExternal } from '../ipc'
+import styles from './CopilotSessionsPanel.module.css'
+
+interface StatusMeta {
+  label: string
+  icon: LucideIcon
+  tone: string
+}
+
+/**
+ * Source-aware status metadata. `waiting` deliberately reads differently per source:
+ * a cloud task waiting means the agent needs you, but an app session `waiting` is an
+ * idle/not-running session (matching how `TodoSessionChip` already labels it), so we
+ * don't falsely tell the user a desktop session needs their attention.
+ */
+function statusMeta(kind: CopilotRowKind, status: CopilotRowStatus): StatusMeta {
+  switch (status) {
+    case 'in_progress':
+      return { label: 'Working', icon: Sparkles, tone: styles.toneAgent }
+    case 'pr_ready':
+      return { label: 'PR ready', icon: GitPullRequest, tone: styles.toneAttention }
+    case 'waiting':
+      return kind === 'app'
+        ? { label: 'Idle', icon: PauseCircle, tone: styles.toneQuiet }
+        : { label: 'Needs you', icon: PauseCircle, tone: styles.toneAttention }
+    case 'completed':
+      return { label: 'Done', icon: CheckCircle2, tone: styles.toneQuiet }
+    case 'unknown':
+      return { label: 'Unknown', icon: HelpCircle, tone: styles.toneQuiet }
+    default:
+      return { label: String(status), icon: HelpCircle, tone: styles.toneQuiet }
+  }
+}
+
+function sourceHint(row: CopilotSessionRow): string {
+  if (row.kind === 'cloud') return 'Cloud'
+  return row.origin === 'observed' ? 'Observed' : 'Launched'
+}
+
+function relativeTime(ts: string): string {
+  const ms = parseDbTimestampMs(ts)
+  return Number.isNaN(ms) ? '' : formatDistanceToNow(ms, { addSuffix: true })
+}
+
+function SessionRow({ row }: { row: CopilotSessionRow }): JSX.Element {
+  const meta = statusMeta(row.kind, row.status)
+  const started = relativeTime(row.startedAt)
+  const { githubUrl, appSessionId } = row
+
+  return (
+    <div className={styles.row}>
+      <span className={`${styles.status} ${meta.tone}`} title={meta.label}>
+        <Icon icon={meta.icon} size={15} />
+      </span>
+      <div className={styles.body}>
+        <div className={styles.title}>{row.title || 'Untitled session'}</div>
+        <div className={styles.meta}>
+          <span className={styles.hint}>{sourceHint(row)}</span>
+          {' · '}
+          {meta.label}
+          {started ? ` · started ${started}` : ''}
+        </div>
+      </div>
+      {githubUrl && (
+        <button
+          type="button"
+          className={styles.rowAction}
+          onClick={() => openExternal(githubUrl)}
+          aria-label="Open on GitHub"
+          title="Open on GitHub"
+        >
+          <Icon icon={ExternalLink} size={14} />
+        </button>
+      )}
+      {appSessionId && (
+        <button
+          type="button"
+          className={styles.rowAction}
+          onClick={() =>
+            fire(window.electron.ipc.invoke('copilot:open-app-session', appSessionId), 'copilot:open-app-session')
+          }
+          aria-label="Open in Copilot app"
+          title="Open in Copilot app"
+        >
+          <Icon icon={ArrowUpRight} size={14} />
+        </button>
+      )}
+    </div>
+  )
+}
+
+export function CopilotSessionsPanel({
+  rows,
+  isLoading,
+}: {
+  rows: CopilotSessionRow[]
+  isLoading: boolean
+}): JSX.Element {
+  if (rows.length === 0) {
+    return <div className={styles.empty}>{isLoading ? 'Loading…' : 'No Copilot sessions for this project yet.'}</div>
+  }
+  return (
+    <div className={styles.list}>
+      {rows.map((row) => (
+        <SessionRow key={row.key} row={row} />
+      ))}
+    </div>
+  )
+}

--- a/src/renderer/src/components/CopilotSessionsPanel.tsx
+++ b/src/renderer/src/components/CopilotSessionsPanel.tsx
@@ -97,13 +97,20 @@ function SessionRow({ row }: { row: CopilotSessionRow }): JSX.Element {
 
 export function CopilotSessionsPanel({
   rows,
-  isLoading,
+  emptyIsAuthoritative,
 }: {
   rows: CopilotSessionRow[]
-  isLoading: boolean
+  emptyIsAuthoritative: boolean
 }): JSX.Element {
   if (rows.length === 0) {
-    return <div className={styles.empty}>{isLoading ? 'Loading…' : 'No Copilot sessions for this project yet.'}</div>
+    // Only a clean, both-sources-succeeded empty is a real "no sessions". A still-
+    // loading or failed (non-authoritative) empty stays indeterminate so a transient
+    // IPC failure never presents as "no sessions".
+    return (
+      <div className={styles.empty}>
+        {emptyIsAuthoritative ? 'No Copilot sessions for this project yet.' : 'Loading…'}
+      </div>
+    )
   }
   return (
     <div className={styles.list}>

--- a/src/renderer/src/components/WorkingColumn.test.tsx
+++ b/src/renderer/src/components/WorkingColumn.test.tsx
@@ -1,0 +1,145 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
+import type { CopilotSession, CopilotAppSession, ProjectDetail } from '@shared/ipc-channels'
+import { WorkingColumn } from './WorkingColumn'
+
+const invoke = vi.fn()
+const openExternal = vi.fn(() => Promise.resolve())
+let copilotCallback: (() => void) | null = null
+const onCopilotUpdated = vi.fn((cb: () => void) => {
+  copilotCallback = cb
+  return () => {}
+})
+const onNotificationsUpdated = vi.fn(() => () => {})
+
+let cloudSessions: CopilotSession[] = []
+let appSessions: CopilotAppSession[] = []
+
+function setSessions(cloud: CopilotSession[], app: CopilotAppSession[]): void {
+  cloudSessions = cloud
+  appSessions = app
+}
+
+beforeEach(() => {
+  invoke.mockReset()
+  openExternal.mockClear()
+  onCopilotUpdated.mockClear()
+  onNotificationsUpdated.mockClear()
+  copilotCallback = null
+  cloudSessions = []
+  appSessions = []
+  invoke.mockImplementation((channel: string) => {
+    if (channel === 'copilot:sessions-for-project') return Promise.resolve(cloudSessions)
+    if (channel === 'copilot:project-app-sessions') return Promise.resolve(appSessions)
+    return Promise.resolve(undefined)
+  })
+  ;(globalThis as unknown as { window: Window }).window.electron = {
+    ipc: { invoke },
+    openExternal,
+    onCopilotUpdated,
+    onNotificationsUpdated,
+  } as unknown as Window['electron']
+})
+
+function cloud(overrides: Partial<CopilotSession>): CopilotSession {
+  return {
+    id: 'c', projectId: 1, source: 'github', status: 'in_progress', title: 'Cloud task',
+    htmlUrl: null, startedAt: '2026-07-01T00:00:00Z', updatedAt: '2026-07-01T00:00:00Z',
+    repoOwner: 'o', repoName: 'r', branch: null, linkedPrUrl: null, pinnedProjectId: null,
+    ...overrides,
+  }
+}
+
+function app(overrides: Partial<CopilotAppSession>): CopilotAppSession {
+  return {
+    id: 'a', projectId: 1, cwd: '/tmp/repo', title: 'App session', status: 'in_progress',
+    repoOwner: 'o', repoName: 'r', origin: 'launched', pinnedProjectId: null,
+    createdAt: '2026-07-01 00:00:00', updatedAt: '2026-07-01 00:00:00',
+    ...overrides,
+  }
+}
+
+function makeDetail(): ProjectDetail {
+  return {
+    id: 1, name: 'Alpha', notes: '', nextAction: '', status: 'active', sortOrder: 0,
+    createdAt: '', updatedAt: '', unreadCount: 0, activeTodoCount: 0, snoozeMode: null,
+    snoozeUntil: null, copilotStatus: null, lastFocusedAt: null, driftState: 'active',
+    todos: [], links: [],
+  }
+}
+
+function renderColumn(): void {
+  render(
+    <WorkingColumn
+      detail={makeDetail()}
+      onCreateTodo={vi.fn()}
+      onToggleTodo={vi.fn()}
+      onDeleteTodo={vi.fn()}
+      onSaveNotes={vi.fn()}
+      onDelegate={vi.fn()}
+      appSessionsByTodo={new Map()}
+      showUndo={vi.fn()}
+    />
+  )
+}
+
+describe('WorkingColumn — Copilot tab', () => {
+  it('hides the Copilot tab when the project has no sessions', async () => {
+    setSessions([], [])
+    renderColumn()
+    await waitFor(() => expect(invoke).toHaveBeenCalledWith('copilot:project-app-sessions', 1))
+    expect(screen.queryByRole('button', { name: 'Copilot' })).toBeNull()
+  })
+
+  it('shows the tab and lists merged cloud + app sessions with source-aware status labels', async () => {
+    setSessions(
+      [cloud({ id: 'c1', title: 'Cloud task', status: 'in_progress', updatedAt: '2026-07-02T12:00:00Z' })],
+      [app({ id: 'a1', title: 'App session', status: 'waiting', origin: 'observed', updatedAt: '2026-07-02 09:00:00' })]
+    )
+    renderColumn()
+
+    const tab = await screen.findByRole('button', { name: 'Copilot' })
+    fireEvent.click(tab)
+
+    expect(await screen.findByText('Cloud task')).toBeTruthy()
+    expect(screen.getByText('App session')).toBeTruthy()
+    // Cloud in_progress reads "Working"; app `waiting` reads "Idle" (not "Needs you").
+    // The status icon carries the label as its title, so query that (the meta line
+    // concatenates the label with the source hint + "started …").
+    expect(screen.getByTitle('Working')).toBeTruthy()
+    expect(screen.getByTitle('Idle')).toBeTruthy()
+    expect(screen.getByText('Observed')).toBeTruthy()
+  })
+
+  it('cloud open control opens the GitHub URL; app open control fires the deep-link IPC', async () => {
+    setSessions(
+      [cloud({ id: 'c1', title: 'Cloud task', htmlUrl: 'https://github.com/o/r/pull/1', updatedAt: '2026-07-02T12:00:00Z' })],
+      [app({ id: 'a1', title: 'App session', updatedAt: '2026-07-02 09:00:00' })]
+    )
+    renderColumn()
+    fireEvent.click(await screen.findByRole('button', { name: 'Copilot' }))
+    await screen.findByText('Cloud task')
+
+    fireEvent.click(screen.getByLabelText('Open on GitHub'))
+    expect(openExternal).toHaveBeenCalledWith('https://github.com/o/r/pull/1')
+
+    fireEvent.click(screen.getByLabelText('Open in Copilot app'))
+    await waitFor(() => expect(invoke).toHaveBeenCalledWith('copilot:open-app-session', 'a1'))
+  })
+
+  it('reveals the tab live when a copilot:updated push adds the first session', async () => {
+    setSessions([], [])
+    renderColumn()
+    await waitFor(() => expect(invoke).toHaveBeenCalledWith('copilot:project-app-sessions', 1))
+    expect(screen.queryByRole('button', { name: 'Copilot' })).toBeNull()
+
+    // A session appears, then the push fires — the tab should surface without a remount.
+    setSessions([cloud({ id: 'c1', title: 'Fresh task' })], [])
+    await act(async () => {
+      copilotCallback?.()
+    })
+
+    expect(await screen.findByRole('button', { name: 'Copilot' })).toBeTruthy()
+  })
+})

--- a/src/renderer/src/components/WorkingColumn.tsx
+++ b/src/renderer/src/components/WorkingColumn.tsx
@@ -23,13 +23,15 @@ import type { LucideIcon } from 'lucide-react'
 import { Icon } from './Icon'
 import { ResourcePanel } from './ResourcePanel'
 import { RunbooksPanel } from './RunbooksPanel'
+import { CopilotSessionsPanel } from './CopilotSessionsPanel'
 import { TodoSessionChip } from './TodoSessionChip'
 import { LinkifiedText } from './LinkifiedText'
+import { useCopilotSessions } from '../hooks/useCopilotSessions'
 import { fire, openExternal } from '../ipc'
 import { isSafeExternalUrl } from '@shared/safe-url'
 import styles from './WorkingColumn.module.css'
 
-type TabId = 'todos' | 'notes' | 'resources' | 'runbooks' | 'notifications'
+type TabId = 'todos' | 'notes' | 'resources' | 'runbooks' | 'notifications' | 'copilot'
 
 interface WorkingColumnProps {
   detail: ProjectDetail
@@ -295,15 +297,30 @@ const TABS: { id: TabId; label: string; icon: LucideIcon }[] = [
   { id: 'notifications', label: 'Notifications', icon: Bell },
 ]
 
+const COPILOT_TAB: { id: TabId; label: string; icon: LucideIcon } = { id: 'copilot', label: 'Copilot', icon: Sparkles }
+
 export function WorkingColumn(props: WorkingColumnProps): JSX.Element {
   const [tab, setTab] = useState<TabId>('todos')
   const notifCountRef = useRef(props.detail.unreadCount)
   notifCountRef.current = props.detail.unreadCount
 
+  const { rows: copilotRows, isLoading: copilotLoading, emptyIsAuthoritative } = useCopilotSessions(props.detail.id)
+
+  // Show the Copilot tab when the project has sessions (current or historical). Keep
+  // it while it's the active tab so a project-switch reload never leaves the panel
+  // showing with no matching tab button; snap back only once we're certain the
+  // project has no sessions (a clean, both-sources-succeeded empty).
+  const showCopilotTab = copilotRows.length > 0 || tab === 'copilot'
+  const tabs = showCopilotTab ? [...TABS, COPILOT_TAB] : TABS
+
+  useEffect(() => {
+    if (tab === 'copilot' && emptyIsAuthoritative) setTab('todos')
+  }, [tab, emptyIsAuthoritative])
+
   return (
     <div className={styles.column}>
       <div className={styles.tabs}>
-        {TABS.map((t) => (
+        {tabs.map((t) => (
           <button type="button"
             key={t.id}
             className={styles.tab}
@@ -333,6 +350,7 @@ export function WorkingColumn(props: WorkingColumnProps): JSX.Element {
         {tab === 'resources' && <ResourcePanel key={props.detail.id} projectId={props.detail.id} showUndo={props.showUndo} />}
         {tab === 'runbooks' && <RunbooksPanel key={props.detail.id} projectId={props.detail.id} />}
         {tab === 'notifications' && <NotificationsPanel projectId={props.detail.id} onDelegate={props.onDelegate} />}
+        {tab === 'copilot' && <CopilotSessionsPanel rows={copilotRows} isLoading={copilotLoading} />}
       </div>
     </div>
   )

--- a/src/renderer/src/components/WorkingColumn.tsx
+++ b/src/renderer/src/components/WorkingColumn.tsx
@@ -304,7 +304,7 @@ export function WorkingColumn(props: WorkingColumnProps): JSX.Element {
   const notifCountRef = useRef(props.detail.unreadCount)
   notifCountRef.current = props.detail.unreadCount
 
-  const { rows: copilotRows, isLoading: copilotLoading, emptyIsAuthoritative } = useCopilotSessions(props.detail.id)
+  const { rows: copilotRows, emptyIsAuthoritative } = useCopilotSessions(props.detail.id)
 
   // Show the Copilot tab when the project has sessions (current or historical). Keep
   // it while it's the active tab so a project-switch reload never leaves the panel
@@ -350,7 +350,7 @@ export function WorkingColumn(props: WorkingColumnProps): JSX.Element {
         {tab === 'resources' && <ResourcePanel key={props.detail.id} projectId={props.detail.id} showUndo={props.showUndo} />}
         {tab === 'runbooks' && <RunbooksPanel key={props.detail.id} projectId={props.detail.id} />}
         {tab === 'notifications' && <NotificationsPanel projectId={props.detail.id} onDelegate={props.onDelegate} />}
-        {tab === 'copilot' && <CopilotSessionsPanel rows={copilotRows} isLoading={copilotLoading} />}
+        {tab === 'copilot' && <CopilotSessionsPanel rows={copilotRows} emptyIsAuthoritative={emptyIsAuthoritative} />}
       </div>
     </div>
   )

--- a/src/renderer/src/hooks/useCopilotSessions.test.ts
+++ b/src/renderer/src/hooks/useCopilotSessions.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest'
+import type { CopilotSession, CopilotAppSession } from '@shared/ipc-channels'
+import { mergeCopilotSessions } from './useCopilotSessions'
+
+function cloud(overrides: Partial<CopilotSession>): CopilotSession {
+  return {
+    id: 'c',
+    projectId: 1,
+    source: 'github',
+    status: 'in_progress',
+    title: 'Cloud task',
+    htmlUrl: null,
+    startedAt: '2026-07-01T00:00:00Z',
+    updatedAt: '2026-07-01T00:00:00Z',
+    repoOwner: 'o',
+    repoName: 'r',
+    branch: null,
+    linkedPrUrl: null,
+    pinnedProjectId: null,
+    ...overrides,
+  }
+}
+
+function app(overrides: Partial<CopilotAppSession>): CopilotAppSession {
+  return {
+    id: 'a',
+    projectId: 1,
+    cwd: '/tmp/repo',
+    title: 'App session',
+    status: 'in_progress',
+    repoOwner: 'o',
+    repoName: 'r',
+    origin: 'launched',
+    pinnedProjectId: null,
+    createdAt: '2026-07-01 00:00:00',
+    updatedAt: '2026-07-01 00:00:00',
+    ...overrides,
+  }
+}
+
+describe('mergeCopilotSessions', () => {
+  it('merges both sources and sorts by updatedAt desc across the ISO and SQLite formats', () => {
+    // Cloud uses ISO 8601; app uses SQLite space format. Both are UTC, so the app
+    // row at 12:00 must sort ahead of the cloud row at 10:00 despite the format gap.
+    const rows = mergeCopilotSessions(
+      [cloud({ id: 'c1', title: 'cloud older', updatedAt: '2026-07-02T10:00:00Z' })],
+      [app({ id: 'a1', title: 'app newer', updatedAt: '2026-07-02 12:00:00' })]
+    )
+    expect(rows.map((r) => r.title)).toEqual(['app newer', 'cloud older'])
+    expect(rows.map((r) => r.key)).toEqual(['app:a1', 'cloud:c1'])
+  })
+
+  it('prefixes keys so a cloud and an app session sharing a UUID cannot collide', () => {
+    const rows = mergeCopilotSessions([cloud({ id: 'same' })], [app({ id: 'same' })])
+    expect(new Set(rows.map((r) => r.key)).size).toBe(2)
+  })
+
+  it('picks the first safe GitHub URL, preferring the PR link', () => {
+    const [row] = mergeCopilotSessions(
+      [cloud({ linkedPrUrl: 'https://github.com/o/r/pull/9', htmlUrl: 'https://github.com/o/r/issues/1' })],
+      []
+    )
+    expect(row.githubUrl).toBe('https://github.com/o/r/pull/9')
+  })
+
+  it('falls back to htmlUrl when the PR link is missing or unsafe', () => {
+    const [missing] = mergeCopilotSessions([cloud({ linkedPrUrl: null, htmlUrl: 'https://github.com/o/r' })], [])
+    expect(missing.githubUrl).toBe('https://github.com/o/r')
+
+    const [unsafe] = mergeCopilotSessions(
+      [cloud({ linkedPrUrl: 'javascript:alert(1)', htmlUrl: 'https://github.com/o/r' })],
+      []
+    )
+    expect(unsafe.githubUrl).toBe('https://github.com/o/r')
+  })
+
+  it('carries no GitHub URL and the deep-link id for app rows; cloud rows carry no app id', () => {
+    const rows = mergeCopilotSessions([cloud({ id: 'c1' })], [app({ id: 'a1' })])
+    const cloudRow = rows.find((r) => r.kind === 'cloud')
+    const appRow = rows.find((r) => r.kind === 'app')
+    expect(appRow?.appSessionId).toBe('a1')
+    expect(appRow?.githubUrl).toBeNull()
+    expect(appRow?.origin).toBe('launched')
+    expect(cloudRow?.appSessionId).toBeNull()
+  })
+
+  it('uses startedAt for cloud and createdAt for app as the displayed start', () => {
+    const [cloudRow] = mergeCopilotSessions([cloud({ startedAt: '2026-01-01T00:00:00Z' })], [])
+    expect(cloudRow.startedAt).toBe('2026-01-01T00:00:00Z')
+    const [appRow] = mergeCopilotSessions([], [app({ createdAt: '2026-02-02 00:00:00' })])
+    expect(appRow.startedAt).toBe('2026-02-02 00:00:00')
+  })
+})

--- a/src/renderer/src/hooks/useCopilotSessions.ts
+++ b/src/renderer/src/hooks/useCopilotSessions.ts
@@ -1,0 +1,186 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import type {
+  CopilotSession,
+  CopilotAppSession,
+  CopilotSessionStatus,
+  CopilotAppSessionStatus,
+  CopilotAppSessionOrigin,
+} from '@shared/ipc-channels'
+import { parseDbTimestampMs } from '@shared/time'
+import { parseSafeExternalUrl } from '@shared/safe-url'
+
+/**
+ * Per-project Copilot sessions for the project working view (#117). Merges the two
+ * already-exposed per-project readers - cloud `gh agent-task` sessions
+ * (`copilot:sessions-for-project`) and desktop-app sessions
+ * (`copilot:project-app-sessions`, both launched + observed) - into one unified,
+ * newest-activity-first list, and keeps it live on the `copilot:updated` push event.
+ */
+
+export type CopilotRowKind = 'cloud' | 'app'
+
+/** The union of both source status vocabularies (cloud adds `pr_ready`, app adds `unknown`). */
+export type CopilotRowStatus = CopilotSessionStatus | CopilotAppSessionStatus
+
+export interface CopilotSessionRow {
+  /** Stable, source-prefixed key; the two UUID namespaces could otherwise collide. */
+  key: string
+  kind: CopilotRowKind
+  title: string
+  status: CopilotRowStatus
+  /** Raw "started" timestamp for display (cloud `startedAt` / app `createdAt`). */
+  startedAt: string
+  /** Epoch ms of last activity, for sorting. NaN when unparseable (sorts last). */
+  updatedAtMs: number
+  /** Cloud open target: the first of `linkedPrUrl`/`htmlUrl` that is a safe http(s) URL. */
+  githubUrl: string | null
+  /** App open target: the desktop session id, opened via `copilot:open-app-session`. */
+  appSessionId: string | null
+  /** App-only provenance hint (`launched` vs `observed`). */
+  origin: CopilotAppSessionOrigin | null
+}
+
+function cloudRow(session: CopilotSession): CopilotSessionRow {
+  return {
+    key: `cloud:${session.id}`,
+    kind: 'cloud',
+    title: session.title,
+    status: session.status,
+    startedAt: session.startedAt,
+    updatedAtMs: parseDbTimestampMs(session.updatedAt),
+    // Prefer the PR link, but only take the first URL that is actually safe to open.
+    githubUrl: parseSafeExternalUrl(session.linkedPrUrl) ?? parseSafeExternalUrl(session.htmlUrl),
+    appSessionId: null,
+    origin: null,
+  }
+}
+
+function appRow(session: CopilotAppSession): CopilotSessionRow {
+  return {
+    key: `app:${session.id}`,
+    kind: 'app',
+    title: session.title,
+    status: session.status,
+    startedAt: session.createdAt,
+    updatedAtMs: parseDbTimestampMs(session.updatedAt),
+    githubUrl: null,
+    appSessionId: session.id,
+    origin: session.origin,
+  }
+}
+
+// Unparseable timestamps sort as epoch 0 (oldest) rather than poisoning the comparator.
+function sortKey(ms: number): number {
+  return Number.isNaN(ms) ? 0 : ms
+}
+
+/** Merge the two per-project session sources into one list, newest activity first. */
+export function mergeCopilotSessions(
+  cloud: CopilotSession[],
+  app: CopilotAppSession[]
+): CopilotSessionRow[] {
+  const rows = [...cloud.map(cloudRow), ...app.map(appRow)]
+  rows.sort((a, b) => sortKey(b.updatedAtMs) - sortKey(a.updatedAtMs))
+  return rows
+}
+
+interface CopilotSessionsState {
+  projectId: number
+  rows: CopilotSessionRow[]
+  isLoading: boolean
+  /** The last settled load had BOTH sources fulfilled (its emptiness is trustworthy). */
+  authoritative: boolean
+}
+
+export interface UseCopilotSessionsResult {
+  rows: CopilotSessionRow[]
+  isLoading: boolean
+  /**
+   * True only after a load where BOTH sources succeeded AND the merged list is
+   * empty. The one signal allowed to hide the tab / snap the user off it - a
+   * transient or partial read failure must never read as "no sessions".
+   */
+  emptyIsAuthoritative: boolean
+}
+
+export function useCopilotSessions(projectId: number): UseCopilotSessionsResult {
+  const [state, setState] = useState<CopilotSessionsState>({
+    projectId,
+    rows: [],
+    isLoading: true,
+    authoritative: false,
+  })
+  const mountedRef = useRef(true)
+  const reqIdRef = useRef(0)
+
+  const load = useCallback(async (): Promise<void> => {
+    const reqId = ++reqIdRef.current
+    const [cloudRes, appRes] = await Promise.allSettled([
+      window.electron.ipc.invoke('copilot:sessions-for-project', projectId),
+      window.electron.ipc.invoke('copilot:project-app-sessions', projectId),
+    ])
+    // Drop a superseded load or a post-unmount settle.
+    if (!mountedRef.current || reqId !== reqIdRef.current) return
+
+    if (cloudRes.status === 'fulfilled' && appRes.status === 'fulfilled') {
+      // All-or-nothing: only a fully successful read may replace rows / be authoritative,
+      // even when empty (that is a real "no sessions").
+      setState({
+        projectId,
+        rows: mergeCopilotSessions(cloudRes.value, appRes.value),
+        isLoading: false,
+        authoritative: true,
+      })
+      return
+    }
+
+    if (cloudRes.status === 'rejected') {
+      console.error('[Copilot] cloud sessions load failed:', cloudRes.reason)
+    }
+    if (appRes.status === 'rejected') {
+      console.error('[Copilot] app sessions load failed:', appRes.reason)
+    }
+    // Preserve the prior snapshot for this project; a partial/total failure must
+    // never blank the tab or read as an authoritative empty.
+    setState((prev) =>
+      prev.projectId === projectId
+        ? { ...prev, isLoading: false, authoritative: false }
+        : { projectId, rows: [], isLoading: false, authoritative: false }
+    )
+  }, [projectId])
+
+  useEffect(() => {
+    // Re-arm on setup so React.StrictMode's setup→cleanup→setup dev cycle doesn't
+    // leave the ref permanently false and bail every subsequent load.
+    mountedRef.current = true
+    setState({ projectId, rows: [], isLoading: true, authoritative: false })
+    void load()
+    const unsub = window.electron.onCopilotUpdated(() => {
+      void load()
+    })
+    const onFocus = (): void => {
+      void load()
+    }
+    const onVisible = (): void => {
+      if (document.visibilityState === 'visible') void load()
+    }
+    window.addEventListener('focus', onFocus)
+    document.addEventListener('visibilitychange', onVisible)
+    return () => {
+      mountedRef.current = false
+      unsub()
+      window.removeEventListener('focus', onFocus)
+      document.removeEventListener('visibilitychange', onVisible)
+    }
+  }, [projectId, load])
+
+  // Render-time projectId guard: never surface another project's snapshot, and
+  // ignore any setState written by a stale-projectId in-flight load. This closes
+  // the one-paint window between a projectId change and the effect re-running.
+  const matches = state.projectId === projectId
+  const rows = matches ? state.rows : []
+  const isLoading = matches ? state.isLoading : true
+  const authoritative = matches ? state.authoritative : false
+
+  return { rows, isLoading, emptyIsAuthoritative: authoritative && rows.length === 0 }
+}


### PR DESCRIPTION
Closes #117.

## What I did

Added a `copilot` tab to the project working view (`WorkingColumn.tsx`) that lists that project's Copilot sessions, so you can see them inside the project instead of only in the flat Agent Tasks list.

The tab merges the two already-exposed per-project IPC readers into one list:
- Cloud `gh agent-task` sessions - `copilot:sessions-for-project` (`CopilotSession[]`).
- Desktop-app sessions (both `launched` and `observed`, from #119/#121) - `copilot:project-app-sessions` (`CopilotAppSession[]`).

Per row: a source-aware status, the title, "started X ago", and one open control - the GitHub URL for cloud tasks, or the existing `copilot:open-app-session` deep-link IPC for desktop-app sessions (reused, not rebuilt). A small hint disambiguates the two origins (`Cloud` / `Launched` / `Observed`).

Behavior:
- The tab is hidden when the project has no sessions (current or historical), per `requirements/copilot.md`.
- It live-refreshes on the existing `copilot:updated` push event (plus window focus, for desktop-app status freshness - that status only updates when the reader runs and `copilot:updated` may not fire for a pure app-status change).
- The existing tabs (todos / notes / resources / runbooks / notifications) and #116's Runbooks/`card.services` work are untouched.

## How it's built (right-layer reuse)

- New hook `useCopilotSessions(projectId)` loads both readers with `Promise.allSettled` and merges them via a pure, unit-tested `mergeCopilotSessions`.
- Timestamps differ per source (cloud is ISO 8601; app is SQLite `YYYY-MM-DD HH:MM:SS` UTC), so I reuse the shared `parseDbTimestampMs` uniformly for both cross-source sort and the "started X ago" display, rather than the per-file `parseISO` helpers (which mis-parse the space format).
- Open targets reuse existing paths: `openExternal` + `parseSafeExternalUrl` for cloud, and the `copilot:open-app-session` IPC for app (same as `TodoSessionChip`).
- `waiting` is labeled per source: cloud = "Needs you" (matches `AgentTasksView`), app = "Idle" (matches `TodoSessionChip`), so a desktop session isn't falsely flagged as needing you.

A few correctness details worth calling out (all reviewed):
- Merge keys are source-prefixed (`cloud:` / `app:`) so the two UUID namespaces can't collide.
- A render-time `projectId` guard means a project switch never shows/opens the previous project's rows for even one paint.
- All-or-nothing snapshots + an `emptyIsAuthoritative` gate mean a transient/partial IPC failure never blanks the tab or ejects you from it - only a clean both-sources-succeeded empty hides it.
- `mountedRef` is re-armed in the effect setup so React.StrictMode's dev setup→cleanup→setup cycle doesn't wedge it.

## How I verified

- `bun run test` (strict typecheck + eslint + Vitest) - **green, 750 tests, no warnings.**
- New `mergeCopilotSessions` unit tests: merges both sources and sorts by `updatedAt` desc across the ISO/SQLite format gap; source-prefixed keys can't collide; picks the first safe GitHub URL (prefers the PR link, falls back on a missing/unsafe one); `startedAt` uses cloud `startedAt` / app `createdAt`.
- New `WorkingColumn` RTL tests: hides the Copilot tab when both sources are empty; lists merged cloud + app sessions with source-aware status labels; the cloud open control calls `openExternal` with the GitHub URL; the app open control invokes `copilot:open-app-session` with the session id; the tab surfaces live after a `copilot:updated` push adds the first session.

## Honest gap

A packaged-app click-through of the real `github-app://sessions/<id>` deep link isn't automated - the RTL test asserts the correct IPC fires with the right id, but not that macOS actually opens the Copilot app. The main-process handler that turns that id into the deep link already exists and is covered separately.